### PR TITLE
FileUpload - fix :destroy handler

### DIFF
--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -14,7 +14,7 @@ jQuery ->
     dropZone: $('#drop-zone')
     destroy: (e, data) ->
       if confirm('Are you sure?')
-        $.blueimpUI.fileupload.prototype.options.destroy.call(this, e, data);
+        $.blueimp.fileupload.prototype.options.destroy.call(this, e, data);
 
     paste: (e, data)->
       $.each data.files, (index, file) ->


### PR DESCRIPTION
This commit closes securityroots/dradispro-tracker#325

See:
  https://github.com/securityroots/dradispro-tracker/issues/325