### PR TITLE
Smart(er) Issues#index table

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -32,7 +32,7 @@ class IssueTable
     @$column_menu.find('a').each ->
       $link = $(this)
       if that.selectedColumns.indexOf($link.data('column')) > -1
-        $($link.find('input')).prop('checked', true)
+        $link.find('input').prop('checked', true)
 
 
   onColumnPickerClick: (event) =>

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -3,8 +3,14 @@ class IssueTable
   selectedColumns: []
 
   constructor: ->
-    @$table = $('#issue-table table')
+    @$table       = $('#issue-table table')
+    @$column_menu = $('.dropdown-menu.js-table-columns')
 
+    # -------------------------------------------------------- Load table state
+    @loadColumnState()
+    @showHideColumns()
+
+    # -------------------------------------------------- Install event handlers
     $('#issue-table').on('click', '.js-taglink', @tagSelected)
 
     # We're hooking into Rails UJS data-confirm behavior to only fire the Ajax
@@ -12,7 +18,7 @@ class IssueTable
     $('#issue-table').on('confirm:complete', '#delete-selected', @deleteSelected)
 
     # Handle the showing / hiding of table columns
-    $('.dropdown-menu.js-table-columns a').on 'click', @onColumnPickerClick
+    @$column_menu.find('a').on 'click', @onColumnPickerClick
 
   deleteSelected: (element, answer) ->
     if answer
@@ -40,6 +46,16 @@ class IssueTable
 
     # prevent Rails UJS from doing anything else.
     false
+
+  loadColumnState: =>
+    # TODO: persist this in browser local storage or a cookie
+    @selectedColumns = ['title', 'tags', 'affected']
+    that = this
+
+    @$column_menu.find('a').each ->
+      $link = $(this)
+      if that.selectedColumns.indexOf($link.data('column')) > -1
+        $($link.find('input')).prop('checked', true)
 
   tagSelected: (event) ->
     $target = $(event.target)
@@ -75,7 +91,7 @@ class IssueTable
 
   onColumnPickerClick: (event) =>
     $target = $(event.currentTarget)
-    val     = $target.attr('data-value')
+    val     = $target.data('column')
     $input  = $target.find('input')
 
     if ((idx = @selectedColumns.indexOf(val)) > -1)

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -7,7 +7,7 @@ class IssueTable
 
   deleteSelected: (element, answer) ->
     if answer
-      $('#tbl-issues').find('input[type=checkbox]:checked.js-multicheck').each ->
+      $('.js-tbl-issues').find('input[type=checkbox]:checked.js-multicheck').each ->
         $row = $(this).parent().parent()
         $($row.find('td')[2]).replaceWith("<td class=\"loading\">Deleting...</td>")
         $that = $(this)
@@ -22,6 +22,9 @@ class IssueTable
             # Delete link from the sidebar
             $("#issue_#{data.id}").remove()
 
+            if $('input[type=checkbox]:checked').length == 0
+              $('.js-issue-actions').css('visibility', 'hidden')
+
           error: (foo,bar,foobar) ->
             $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
         }
@@ -33,7 +36,7 @@ class IssueTable
     $target = $(event.target)
     event.preventDefault()
 
-    $('#tbl-issues').find('input[type=checkbox]:checked.js-multicheck').each ->
+    $('.js-tbl-issues').find('input[type=checkbox]:checked.js-multicheck').each ->
       $this = $(this)
 
       $this.prop('checked', false)
@@ -53,6 +56,8 @@ class IssueTable
 
           $($row.find('td')[2]).replaceWith(data.tag_cell)
           $("#issues #issue_#{issue_id}").replaceWith(data.issue_link)
+          if $('input[type=checkbox]:checked').length == 0
+            $('.js-issue-actions').css('visibility', 'hidden')
 
         error: (foo,bar,foobar) ->
           $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
@@ -78,8 +83,8 @@ jQuery ->
 
     $('input[type=checkbox]').click ->
       if $('input[type=checkbox]:checked').length
-        $('.btn-group').css('visibility', 'visible')
+        $('.js-issue-actions').css('visibility', 'visible')
       else
-        $('.btn-group').css('visibility', 'hidden')
+        $('.js-issue-actions').css('visibility', 'hidden')
 
     new IssueTable

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -87,4 +87,11 @@ jQuery ->
       else
         $('.js-issue-actions').css('visibility', 'hidden')
 
+    $('#js-table-filter').on 'keyup', ->
+        rex = new RegExp($(this).val(), 'i')
+        $('tbody tr').hide();
+        $('tbody tr').filter( ->
+          rex.test($(this).text());
+        ).show();
+
     new IssueTable

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -13,6 +13,10 @@ class IssueTable
     # -------------------------------------------------- Install event handlers
     $('#issue-table').on('click', '.js-taglink', @onTagSelected)
 
+    # Then Select all button is clicked, click the inner checkbox
+    $('.js-select-all-issues').on 'click', ->
+      $(this).find('input').click()
+
     # We're hooking into Rails UJS data-confirm behavior to only fire the Ajax
     # if the user confirmed the deletion
     $('#issue-table').on('confirm:complete', '#delete-selected', @onDeleteSelected)

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -120,8 +120,8 @@ jQuery ->
 
       $('#select-all').prop('checked', _select_all)
 
-    $('input[type=checkbox].js-multicheck').click ->
-      if $('input[type=checkbox]:checked').length
+    $('input[type=checkbox]').click ->
+      if $('input[type=checkbox]:checked.js-multicheck').length
         $('.js-issue-actions').css('display', 'inline-block')
       else
         $('.js-issue-actions').css('display', 'none')

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -1,9 +1,18 @@
 class IssueTable
+  $table: null
+  selectedColumns: []
+
   constructor: ->
+    @$table = $('#issue-table table')
+
     $('#issue-table').on('click', '.js-taglink', @tagSelected)
+
     # We're hooking into Rails UJS data-confirm behavior to only fire the Ajax
     # if the user confirmed the deletion
     $('#issue-table').on('confirm:complete', '#delete-selected', @deleteSelected)
+
+    # Handle the showing / hiding of table columns
+    $('.dropdown-menu.js-table-columns a').on 'click', @onColumnPickerClick
 
   deleteSelected: (element, answer) ->
     if answer
@@ -23,7 +32,7 @@ class IssueTable
             $("#issue_#{data.id}").remove()
 
             if $('input[type=checkbox]:checked').length == 0
-              $('.js-issue-actions').css('visibility', 'hidden')
+              $('.js-issue-actions').css('display', 'none')
 
           error: (foo,bar,foobar) ->
             $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
@@ -57,11 +66,41 @@ class IssueTable
           $($row.find('td')[2]).replaceWith(data.tag_cell)
           $("#issues #issue_#{issue_id}").replaceWith(data.issue_link)
           if $('input[type=checkbox]:checked').length == 0
-            $('.js-issue-actions').css('visibility', 'hidden')
+            $('.js-issue-actions').css('display', 'none')
 
         error: (foo,bar,foobar) ->
           $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
       }
+
+
+  onColumnPickerClick: (event) =>
+    $target = $(event.currentTarget)
+    val     = $target.attr('data-value')
+    $input  = $target.find('input')
+
+    if ((idx = @selectedColumns.indexOf(val)) > -1)
+      @selectedColumns.splice(idx, 1)
+      setTimeout ->
+        $input.prop('checked', false)
+      , 0
+    else
+      @selectedColumns.push(val)
+      setTimeout ->
+        $input.prop('checked', true)
+      , 0
+
+    $(event.target).blur()
+    @showHideColumns()
+    false
+
+  showHideColumns: =>
+    that = this
+    $.each @$table.find('thead th'), (index, th)->
+      if (column = $(th).data('column'))
+        if that.selectedColumns.indexOf(column) > -1
+          console.log("show #{column}")
+        else
+          console.log("hide #{column}")
 
 jQuery ->
   if $('body.issues.index').length
@@ -81,11 +120,12 @@ jQuery ->
 
       $('#select-all').prop('checked', _select_all)
 
-    $('input[type=checkbox]').click ->
+    $('input[type=checkbox].js-multicheck').click ->
       if $('input[type=checkbox]:checked').length
-        $('.js-issue-actions').css('visibility', 'visible')
+        $('.js-issue-actions').css('display', 'inline-block')
       else
-        $('.js-issue-actions').css('visibility', 'hidden')
+        $('.js-issue-actions').css('display', 'none')
+
 
     $('#js-table-filter').on 'keyup', ->
         rex = new RegExp($(this).val(), 'i')

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -128,7 +128,7 @@ jQuery ->
 
     # Checkbox behavior: select all, show 'btn-group', etc.
     $('#select-all').click ->
-      $('input[type=checkbox]').not(this).prop('checked', $(this).prop('checked'))
+      $('input[type=checkbox].js-multicheck').not(this).prop('checked', $(this).prop('checked'))
 
 
     $('input[type=checkbox].js-multicheck').click ->

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -111,12 +111,17 @@ class IssueTable
 
   showHideColumns: =>
     that = this
+
     $.each @$table.find('thead th'), (index, th)->
+      $th = $(th)
+
       if (column = $(th).data('column'))
         if that.selectedColumns.indexOf(column) > -1
-          console.log("show #{column}")
+          that.$table.find("td:nth-child(#{index + 1})").css('display', 'table-cell')
+          $th.css('display', 'table-cell')
         else
-          console.log("hide #{column}")
+          that.$table.find("td:nth-child(#{index + 1})").css('display', 'none')
+          $th.css('display', 'none')
 
 jQuery ->
   if $('body.issues.index').length

--- a/app/assets/stylesheets/snowcrash/modules/issues.scss
+++ b/app/assets/stylesheets/snowcrash/modules/issues.scss
@@ -77,19 +77,13 @@ body.issues.index {
 
   //-------------------------------------------------------------- Issues table
   .btn-toolbar {
-
     input[type='checkbox'] {
       margin: 0;
     }
 
     .issue-actions {
-      visibility: hidden;
-      .btn {
-        background-color: #e6e6e6;
-        &:active, &:hover {
-          background-color: darken(#e6e6e6, 10%);
-        }
-      }
+      display: none;
+
       .dropdown-menu {
         text-align: left;
       }

--- a/app/assets/stylesheets/snowcrash/modules/issues.scss
+++ b/app/assets/stylesheets/snowcrash/modules/issues.scss
@@ -25,28 +25,6 @@ body.issues {
           }
         }
 
-        .issue-actions {
-          text-align: center;
-
-          .btn-group {
-            visibility: hidden;
-            .btn {
-              background-color: #e6e6e6;
-              &:active, &:hover {
-                background-color: darken(#e6e6e6, 10%);
-              }
-            }
-            .dropdown-menu {
-              text-align: left;
-            }
-          }
-        }
-
-        td.loading {
-          background: image-url('loading.gif') no-repeat left center;
-          padding-left: 20px;
-        }
-
         .popover {
           .popover-title {
             font-size: 14px;
@@ -86,13 +64,52 @@ body.issues.show {
 }
 
 body.issues.index {
+  //-------------------------------------------------------- Empty-state styles
   p.lead {
     margin: 1ex 0;
     text-align: center;
   }
+
   .add-issues {
     margin-top: 4em;
   }
+  //------------------------------------------------------- /Empty-state styles
+
+  //-------------------------------------------------------------- Issues table
+  .btn-toolbar {
+
+    input[type='checkbox'] {
+      margin: 0;
+    }
+
+    .issue-actions {
+      visibility: hidden;
+      .btn {
+        background-color: #e6e6e6;
+        &:active, &:hover {
+          background-color: darken(#e6e6e6, 10%);
+        }
+      }
+      .dropdown-menu {
+        text-align: left;
+      }
+    }
+  }
+
+  .tbl-issues {
+    td.loading {
+      background: image-url('loading.gif') no-repeat left center;
+      padding-left: 20px;
+    }
+
+    .column-checkbox {
+      padding: 0;
+      text-align: center;
+      vertical-align: middle;
+      width: 36px;
+    }
+  }
+  //------------------------------------------------------------- /Issues table
 }
 
 body.issues.new, body.issues.edit {

--- a/app/views/issues/_empty.html.erb
+++ b/app/views/issues/_empty.html.erb
@@ -1,0 +1,21 @@
+<h1>This project doesn't have any issues yet</h1>
+<p>Here are some ways to add new issues:</p>
+
+<div class="row-fluid add-issues">
+  <div class="span3">
+    <h3>1. Manually add a finding</h3>
+    <p>Just click on the <i class="fa fa-plus"></i> sign next to the <strong>Issues</strong> heading in the sidebar.</p>
+  </div>
+  <div class="offset1 span3">
+    <h3>2. Import from a library</h3>
+    <p>Before you can import findings from an external library, you may have to do some configuring.</p>
+    <p>For MediaWiki and VulnDB, click on the <%= link_to main_app.configurations_path, target: '_blank' do %><i class="fa fa-cog fa-lg"></i> Configuration<% end %> link at the top-right of the page.</p>
+    <p>Then click on the <i class="fa fa-chevron-down"></i> next to <strong>Import issues</strong> in the sidebar.</p>
+  </div>
+  <div class="offset1 span3">
+    <h3>3. Upload the output of a tool</h3>
+    <p>Use the <%= link_to main_app.upload_manager_path do %><i class="fa fa-cloud-upload fa-lg"></i> Upload output from tool<% end %> link at the top of the page.</p>
+  </div>
+</div>
+<!-- <p>Use the <strong><i class="fa fa-plus"></i></strong> icon next to <em>Project issues</em> on the side bar to add a new issue manually.</p>
+<p>Or use the <em>Import issues</em> <strong><i class="fa fa-chevron-down"></i></strong> menu to import an issue from an external source.</p> -->

--- a/app/views/issues/_empty.html.erb
+++ b/app/views/issues/_empty.html.erb
@@ -17,5 +17,3 @@
     <p>Use the <%= link_to main_app.upload_manager_path do %><i class="fa fa-cloud-upload fa-lg"></i> Upload output from tool<% end %> link at the top of the page.</p>
   </div>
 </div>
-<!-- <p>Use the <strong><i class="fa fa-plus"></i></strong> icon next to <em>Project issues</em> on the side bar to add a new issue manually.</p>
-<p>Or use the <em>Import issues</em> <strong><i class="fa fa-chevron-down"></i></strong> menu to import an issue from an external source.</p> -->

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -1,7 +1,7 @@
-<table id="tbl-issues" class="table table-striped">
+<table class="table table-striped tbl-issues js-tbl-issues">
   <thead>
     <tr>
-      <th><input type="checkbox" id="select-all" /></th>
+      <th></th>
       <th>Title</th>
       <th>Tags</th>
       <th>Affects</th>
@@ -10,7 +10,7 @@
   <tbody>
     <% issues.each do |issue| %>
     <tr>
-      <td><%= check_box_tag dom_id(issue), issue.id, false, class: 'js-multicheck', data: {url: issue_path(issue, format: :json)} %></td>
+      <td class="column-checkbox"><%= check_box_tag dom_id(issue), issue.id, false, class: 'js-multicheck', data: { url: issue_path(issue, format: :json) } %></td>
       <td><%= link_to issue.title, issue %></td>
       <td><%= tag_and_name_for(issue) %></td>
       <%# this count is coming from the SQL finder in the controller %>

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -2,9 +2,9 @@
   <thead>
     <tr>
       <th></th>
-      <th>Title</th>
-      <th>Tags</th>
-      <th>Affects</th>
+      <th data-column="title">Title</th>
+      <th data-column="tags">Tags</th>
+      <th data-column="affected">Affects</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -1,0 +1,32 @@
+<%#
+  Inspired in the Gmail toolbar. Some of the controls are hidden while nothing
+  is selected and they become visible once the user selects at least one row.
+%>
+<div class="btn-toolbar">
+  <div class="btn-group">
+     <button class="btn">
+       <input type="checkbox" id="select-all" />
+     </button>
+  </div>
+
+  <div class="btn-group issue-actions js-issue-actions">
+    <a id="delete-selected" class="btn" data-confirm="Are you sure?" data-method="delete"><i class="fa fa-trash text-error"></i></a>
+    <a class="btn dropdown-toggle" data-toggle="dropdown">
+      <i class="fa fa-tags"> </i>
+      <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu">
+      <% @tags.each do |tag| %>
+      <li>
+        <%= link_to 'javascript:void(0)', class: 'js-taglink', style: "color: #{tag.color}", data: { tag: h(tag.name) } do %>
+          <i class="fa fa-tag"></i> <%= h(tag.display_name) %>
+        <% end %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="filter pull-right">
+    <input type="text" id="js-table-filter" class="form-control input-xlarge" placeholder="Type here to filter table..."/>
+  </div>
+</div>

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -1,5 +1,5 @@
 <%#
-  Inspired in the Gmail toolbar. Some of the controls are hidden while nothing
+  Inspired by the Gmail toolbar. Some of the controls are hidden while nothing
   is selected and they become visible once the user selects at least one row.
 %>
 <div class="btn-toolbar">

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -29,9 +29,9 @@
   <div class="btn-group">
     <button class="btn" data-toggle="dropdown"><i class="fa fa-columns"></i> <span class="caret"></span></button>
     <ul class="dropdown-menu js-table-columns">
-      <li><a href="javascript:void(0)" data-value="title"><input type="checkbox" /> Title</a></li>
-      <li><a href="javascript:void(0)" data-value="tags"><input type="checkbox"/> Tags</a></li>
-      <li><a href="javascript:void(0)" data-value="affected"><input type="checkbox"/> Affected</a></li>
+      <li><a href="javascript:void(0)" data-column="title"><input type="checkbox" /> Title</a></li>
+      <li><a href="javascript:void(0)" data-column="tags"><input type="checkbox"/> Tags</a></li>
+      <li><a href="javascript:void(0)" data-column="affected"><input type="checkbox"/> Affected</a></li>
     </ul>
   </div>
 

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -26,6 +26,15 @@
     </ul>
   </div>
 
+  <div class="btn-group">
+    <button class="btn" data-toggle="dropdown"><i class="fa fa-columns"></i> <span class="caret"></span></button>
+    <ul class="dropdown-menu js-table-columns">
+      <li><a href="javascript:void(0)" data-value="title"><input type="checkbox" /> Title</a></li>
+      <li><a href="javascript:void(0)" data-value="tags"><input type="checkbox"/> Tags</a></li>
+      <li><a href="javascript:void(0)" data-value="affected"><input type="checkbox"/> Affected</a></li>
+    </ul>
+  </div>
+
   <div class="filter pull-right">
     <input type="text" id="js-table-filter" class="form-control input-xlarge" placeholder="Type here to filter table..."/>
   </div>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -16,7 +16,6 @@
       </div>
     <% else %>
       <%= render 'empty' %>
-      <%= render :partial => 'empty' %>
     <% end %>
   </div>
 </div>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -11,48 +11,12 @@
 
     <% if @issues.any? %>
       <div id="issue-table">
-        <div class="issue-actions">
-          <div class="btn-group">
-            <button class="btn dropdown-toggle" data-toggle="dropdown">
-              <i class="fa fa-tags"> </i>
-              <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu">
-              <% @tags.each do |tag| %>
-              <li>
-                <%= link_to 'javascript:void(0)', class: 'js-taglink', style: "color: #{tag.color}", data: { tag: h(tag.name) } do %>
-                  <i class="fa fa-tag"></i> <%= h(tag.display_name) %>
-                <% end %>
-              </li>
-              <% end %>
-            </ul>
-            <a id="delete-selected" class="btn" data-confirm="Are you sure?" data-method="delete"><i class="fa fa-trash"></i></a>
-          </div>
-        </div>
+        <%= render 'toolbar', issues: @issues %>
         <%= render 'table', issues: @issues %>
       </div>
     <% else %>
-      <h1>This project doesn't have any issues yet</h1>
-      <p>Here are some ways to add new issues:</p>
-
-      <div class="row-fluid add-issues">
-        <div class="span3">
-          <h3>1. Manually add a finding</h3>
-          <p>Just click on the <i class="fa fa-plus"></i> sign next to the <strong>Issues</strong> heading in the sidebar.</p>
-        </div>
-        <div class="offset1 span3">
-          <h3>2. Import from a library</h3>
-          <p>Before you can import findings from an external library, you may have to do some configuring.</p>
-          <p>For MediaWiki and VulnDB, click on the <%= link_to main_app.configurations_path, target: '_blank' do %><i class="fa fa-cog fa-lg"></i> Configuration<% end %> link at the top-right of the page.</p>
-          <p>Then click on the <i class="fa fa-chevron-down"></i> next to <strong>Import issues</strong> in the sidebar.</p>
-        </div>
-        <div class="offset1 span3">
-          <h3>3. Upload the output of a tool</h3>
-          <p>Use the <%= link_to main_app.upload_manager_path do %><i class="fa fa-cloud-upload fa-lg"></i> Upload output from tool<% end %> link at the top of the page.</p>
-        </div>
-      </div>
-      <!-- <p>Use the <strong><i class="fa fa-plus"></i></strong> icon next to <em>Project issues</em> on the side bar to add a new issue manually.</p>
-      <p>Or use the <em>Import issues</em> <strong><i class="fa fa-chevron-down"></i></strong> menu to import an issue from an external source.</p> -->
+      <%= render 'empty' %>
+      <%= render :partial => 'empty' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
1. Move away from the HelpScout "magic" toolbar that appears in the center of the screen on selecting a table row to a Gmail toolbar that contains some static button groups, and some more are shown when there are rows selected.

2. Allow for showing / hiding of columns (although the selection is not persisted for now.

3. Filter the table contents from input in the upper-right