### PR TITLE
bin/setup - remove --local from bundle install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -45,7 +45,7 @@ Dir.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
-  system "bundle check || bundle install --local"
+  system "bundle check || bundle install"
 
   puts "\n== Copying sample files =="
   unless File.exist?("Gemfile.plugins")


### PR DESCRIPTION
Since we're not caching gems under ./vendor/cache/ the --local doesn't
give us anything and it is confusing for first-time users.