### PR TITLE
Search - case insensitive SQL

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -52,7 +52,7 @@ class Search
 
   def issues
     Issue.where(
-      "node_id = :node AND text LIKE :q",
+      "node_id = :node AND LOWER(text) LIKE LOWER(:q)",
       node: Node.issue_library,
       q: "%#{query}%"
     ).order(updated_at: :desc)
@@ -60,7 +60,7 @@ class Search
 
   def nodes
     Node.user_nodes
-      .where("label LIKE :q", q: "%#{query}%")
+      .where("LOWER(label) LIKE LOWER(:q)", q: "%#{query}%")
       .order(updated_at: :desc)
   end
 
@@ -68,7 +68,7 @@ class Search
     system_nodes = [Node.issue_library.id, Node.methodology_library.id]
 
     Note.where(
-      "node_id NOT IN (:nodes) AND text LIKE :q",
+      "node_id NOT IN (:nodes) AND LOWER(text) LIKE LOWER(:q)",
       nodes: system_nodes,
       q: "%#{query}%"
     )
@@ -77,7 +77,7 @@ class Search
   end
 
   def evidence
-    Evidence.where("content LIKE :q", q: "%#{query}%")
+    Evidence.where("LOWER(content) LIKE LOWER(:q)", q: "%#{query}%")
       .includes(:issue, :node)
       .order(updated_at: :desc)
   end


### PR DESCRIPTION
This is a case-insensitive SQL query implementation that has the benefit
of working both in SQLite3 and MySQL.

    LOWER(label) LIKE LOWER(:q)

The MySQL-only solution could have been:

    label LIKE :q COLLATE UTF8_GENERAL_CI

However, a benchmark yielded very similar results:

```
$ bundle exec rails runner sql-lower-vs-collate.rb
       user     system      total        real
collate:  0.870000   0.010000   0.880000 (  0.875807)
  lower:  0.840000   0.010000   0.850000 (  0.853030)
```

From:

```
queries = [
  "label LIKE :q COLLATE UTF8_GENERAL_CI",
  "LOWER(label) LIKE LOWER(:q)"
]

n = 10_000

Benchmark.bm do |x|
  x.report('collate:') do
    n.times do
      Node.user_nodes.where(queries[0], q: "%host%").order(updated_at: :desc)
    end
  end

  x.report('  lower:') do
    n.times do
      Node.user_nodes.where(queries[1], q: "%host%").order(updated_at: :desc)
    end
  end
end
```