### PR TITLE
bug fix: issue 'select all' btn not working on Firefox

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -152,6 +152,12 @@ jQuery ->
     $('#select-all').click ->
       $('input[type=checkbox].js-multicheck').not(this).prop('checked', $(this).prop('checked'))
 
+    $('.js-select-all-issues').click (e) ->
+      $selectAll = $('#select-all')
+      return if e.target == $selectAll[0]
+      isChecked = !$selectAll.prop('checked')
+      $selectAll.prop('checked', isChecked)
+      $('input[type=checkbox].js-multicheck').prop('checked', isChecked)
 
     $('input[type=checkbox].js-multicheck').click ->
       _select_all = $(this).prop('checked')

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -4,9 +4,9 @@
 %>
 <div class="btn-toolbar">
   <div class="btn-group">
-     <button class="btn js-select-all-issues">
+     <span class="btn js-select-all-issues">
        <input type="checkbox" id="select-all" />
-     </button>
+     </span>
   </div>
 
   <div class="btn-group issue-actions js-issue-actions">


### PR DESCRIPTION
[Trello](https://trello.com/c/Uv79D16V/199-bug-fix-when-using-firefox-the-select-all-button-does-not-work)

The JS 'click' handler doesn't get called in Firefox, but changing the
wrapping '\<button\>' to a '\<span\>' fixes it.

"\<input\>" tags shouldn't be nested in a "\<button\>" anyway as this as a
violation of the HTML spec. Try it on validator.w3.org and you'll get
an error:

<img width="756" alt="screen shot 2016-08-02 at 14 06 42" src="https://cloud.githubusercontent.com/assets/2656485/17328078/e369ae30-58bb-11e6-8d78-b48eed3269f3.png">
