### PR TITLE
restrict version number of 'listen' gem; fix CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,6 +158,11 @@ group :test do
   gem 'capybara', '~> 2.4.4'
   gem 'poltergeist'#, '~> 1.6.0'
   gem 'guard-rspec', require: false
+  # guard-rspec depends on `guard`, which depends on `listen`, but versions of
+  # listen higher than 3.1.1 require Ruby version >= 2.2.3 (we're currently on
+  # 2.2.2). Restrict the version of `listen` to prevent `guard-rspec`
+  # introducing an incompatible dependency:
+  gem 'listen', '<= 3.1.1'
   gem 'shoulda-matchers', '~> 2.8.0'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,6 +531,7 @@ DEPENDENCIES
   json (= 1.8.2)
   kaminari (~> 0.16.1)
   letter_opener
+  listen (<= 3.1.1)
   local_time
   mysql2 (= 0.3.18)
   nokogiri (= 1.6.8)


### PR DESCRIPTION
`bundle install` is failing on CI because guard-rspec introduces a
dependency that's incompatible with our current version of Ruby.
Fix it by restricting the version of `listen` to `<= 3.1.1`.

This same error is making CI fail on #40, but I've fixed it in this new PR as opposed to over there because the error isn't really to do with #40.