### PR TITLE
Always render :services property as a table

### DIFF
--- a/app/helpers/nodes_helper.rb
+++ b/app/helpers/nodes_helper.rb
@@ -19,8 +19,15 @@ module NodesHelper # :nodoc:
     values = node.properties[property]
     return if values.blank?
 
+    # There is the rare occasion in which a single port is open in a node, this
+    # creates a :services property with a single nested object, but still want
+    # to render it as an array.
+    if property == 'services' && !values.is_a?(Array)
+      values = [values]
+    end
+
     column_names = values.map(&:keys).flatten.uniq.sort.map(&:to_sym)
-    sorted_entries = column_names.include?(:port) ? values.sort_by{ |h| h[:port] } : values
+    sorted_entries = column_names.include?(:port) ? values.sort_by{ |h| h[:port].to_i } : values
 
     thead = content_tag(:thead) do
       content_tag(:tr) do

--- a/app/views/nodes/edit.html.erb
+++ b/app/views/nodes/edit.html.erb
@@ -7,7 +7,7 @@
 
       <%= f.input :type_id, collection: [["Default", Node::Types::DEFAULT], ["Host", Node::Types::HOST]], include_blank: false %>
 
-      <%= f.input :raw_properties, as: :text, label: false, value: @node.raw_properties, input_html: { class: :json } %>
+      <%= f.input :raw_properties, as: :text, label: 'Properties', value: @node.raw_properties, input_html: { class: :json, rows: 20 } %>
 
       <div class="form-actions">
         <%= f.button :submit, nil, class: 'btn btn-dradispro' %> or

--- a/app/views/nodes/show.html.erb
+++ b/app/views/nodes/show.html.erb
@@ -14,7 +14,7 @@
               <h4><%= key.to_s.titleize.singularize  %></h4>
             <% end %>
 
-            <% if value.is_a?(Array) && value[0].is_a?(Hash) %>
+            <% if (value.is_a?(Array) && value[0].is_a?(Hash)) || key == 'services' %>
               <p><%= render_property_table(@node, key) %></p>
             <% else %>
               <p><%= render_property(@node, key) %></p>


### PR DESCRIPTION
We want the 'services' property to always render as a table, so users
can rely on it to create their reports.

Unfortunately when a host has a single port associated with it, the
standard node properties mechanism would store :services as a simple
value instead of an array. This commit patches the rendering code to
make sure :services are always displayed in a table.