### PR TITLE
Move notes to other nodes

### DIFF
--- a/app/assets/javascripts/snowcrash.js
+++ b/app/assets/javascripts/snowcrash.js
@@ -14,6 +14,7 @@
 
 //= require snowcrash/plugins/jquery.breadcrums
 //= require snowcrash/plugins/jquery.treemodal
+//= require snowcrash/plugins/jquery.treemodalForNote
 //= require snowcrash/plugins/jquery.treenav
 
 //= require snowcrash/behaviors

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -69,7 +69,7 @@ jQuery ->
 
   # Activate jQuery.treeModal
   $('.modal-node-selection-form').treeModal()
-  $('.modal-note-selection-form').treeModal()
+  $('.modal-note-selection-form').treeModalForNote()
 
 
   # ------------------------------------------------------- Bootstrap behaviors

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -69,6 +69,7 @@ jQuery ->
 
   # Activate jQuery.treeModal
   $('.modal-node-selection-form').treeModal()
+  $('.modal-note-selection-form').treeModal()
 
 
   # ------------------------------------------------------- Bootstrap behaviors

--- a/app/assets/javascripts/snowcrash/plugins/jquery.treemodalForNote.js.coffee
+++ b/app/assets/javascripts/snowcrash/plugins/jquery.treemodalForNote.js.coffee
@@ -1,0 +1,81 @@
+# jQuery.treeModal
+#
+# This plugin handles the node-selection modal tree FOR NOTES
+# operation. See ./app/views/nodes/modals/
+
+do ($ = jQuery, window, document) ->
+
+  pluginName = "treeModalForNote"
+
+  # The actual plugin constructor
+  class Plugin
+    constructor: (@element) ->
+      @_name = pluginName
+      @init()
+
+    init: ->
+      @$el = $(@element)
+      @$tree = @$el.find('.tree-modal-for-note-box')
+      @$el.find('.add-subnode').hide()
+
+      @$nodeIdHiddenInput = @$el.find("#note_node_id")
+
+      @disableSubmitBtn()
+
+      current_node_container = "#node_#{@$el.data('node-id')}"
+      @$el.find("input[name='note_move_destination']").click(@selectMoveDestination)
+
+      # When the user selects a node to move to...
+      # Bind to $tree rather than to the individual links, because not all
+      # links will be present on page load (most are lazy-loaded)
+      linkSelector = "a:not('.invalid-selection'):not('.toggle')"
+      @$tree.on "click", linkSelector, @selectNode
+
+
+    markAsInvalid: ($nodeLink) ->
+      # This will prevent the click handler from being called again for this
+      # particular link:
+      $nodeLink.addClass('invalid-selection').attr('href', 'javascript:void(0)')
+
+
+    makeActiveSelection: ($nodeLink) =>
+      @$el.find('.active-selection').removeClass('active-selection')
+      $nodeLink.addClass('active-selection')
+
+
+    selectNode: (e) =>
+      e.preventDefault()
+
+      $nodeLink = $(e.currentTarget)
+
+      # Nodes can't be moved underneath one of their own descendants:
+      @makeActiveSelection($nodeLink)
+
+      selectedNodeId = $nodeLink.parent().data('node-id')
+      @$nodeIdHiddenInput.val(selectedNodeId)
+
+      @$el.find('#current-selection').text($nodeLink.text())
+      @enableSubmitBtn()
+
+
+    selectMoveDestination: (e) =>
+        @prepareForMoveToNode()
+        @disableSubmitBtn()
+
+
+    prepareForMoveToNode: ->
+      @$el.find("#move-under").show()
+
+
+    disableSubmitBtn: ->
+      @$el.find(".btn-primary").prop("disabled", true)
+
+
+    enableSubmitBtn: ->
+      @$el.find(".btn-primary").prop("disabled", false)
+
+
+  $.fn[pluginName] = ->
+    @each ->
+      if !$.data(@, "plugin_#{pluginName}")
+        $.data(@, "plugin_#{pluginName}", new Plugin(@))

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -41,7 +41,7 @@ class NotesController < NestedNodeResourceController
     if @note.update_attributes(note_params)
       track_updated(@note)
       check_for_edit_conflicts(@note, updated_at_before_save)
-      redirect_to node_note_path(@node, @note), notice: 'Note updated.'
+      redirect_to node_note_path(@note.node, @note), notice: 'Note updated.'
     else
       initialize_nodes_sidebar
       render 'edit'

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -73,6 +73,6 @@ class NotesController < NestedNodeResourceController
   end
 
   def note_params
-    params.require(:note).permit(:category_id, :text)
+    params.require(:note).permit(:category_id, :text, :node_id)
   end
 end

--- a/app/views/notes/modals/_move.html.erb
+++ b/app/views/notes/modals/_move.html.erb
@@ -1,0 +1,23 @@
+<div id="modal_move_note" class="modal hide" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <%= simple_form_for [@note.node, @note], html: {class: 'form-horizontal modal-note-selection-form', data: {node_id: @note.node_id} } do |f| %>
+    <%= f.hidden_field :node_id %>
+
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+      <h3 id="myModalLabel">Move <%= @note.title %> note</h3>
+    </div>
+    <div class="modal-body">
+      <p>Where do you want to move the <strong><%= @note.title %></strong> note?</p>
+      <div class="tree-modal-for-note-box">
+        <%= render "layouts/snowcrash/nodes" %>
+      </div>
+      <p id="move-under">
+        Move under: <strong><span id="current-selection"></span></strong>
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary">Move</button>
+      <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -33,6 +33,7 @@
       <h3>Content for this note -
         <span class="actions">
           <%= link_to 'edit', edit_node_note_path(@node, @note) %>
+          <a href="#modal_move_note" data-toggle="modal">move</a>
           <%= link_to 'delete',
                   [@node, @note],
                   class: 'text-error',
@@ -65,3 +66,4 @@
     </div>
   </div>
 </div>
+<%= render partial: 'notes/modals/move' %>

--- a/spec/features/note_moving_spec.rb
+++ b/spec/features/note_moving_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe "moving a note", js: true do
+
+  subject { page }
+
+  before do
+    login_to_project_as_user
+ 
+    @note_0 = create_note
+    # We're specifying the node label so the notes don't get assigned to the
+    # same node
+    @note_1 = create_note(node: create_node(label: "OtherNode-#{Time.now}"))
+  end
+
+  before do
+    visit node_note_path(current_note.node, current_note)
+    click_link "move"
+  end
+
+  let(:current_note) { @note_0 }
+
+  example "moving a note to another node" do
+    within_move_note_modal do
+      click_link @note_1.node.label
+      click_button "Move"
+    end
+    expect(@note_0.reload.node).to eq @note_1.node
+    expect(current_path).to eq node_note_path(@note_0.node, @note_0)
+  end
+
+  def create_note(attrs={})
+    create(:note, attrs)
+  end
+
+  def create_node(attrs={})
+    create(:node, attrs)
+  end
+  
+  def within_move_note_modal
+    within("#modal_move_note") { yield }
+  end
+end

--- a/spec/features/note_moving_spec.rb
+++ b/spec/features/note_moving_spec.rb
@@ -29,6 +29,24 @@ describe "moving a note", js: true do
     expect(current_path).to eq node_note_path(@note_0.node, @note_0)
   end
 
+  example "choosing same node for note" do
+    within_move_note_modal do
+      click_link @note_0.node.label
+      click_button "Move"
+    end
+    expect(@note_0.reload.node).not_to eq @note_1.node
+    expect(current_path).not_to eq node_note_path(@note_1.node, @note_0)
+  end
+
+  example "closing the modal" do
+    within_move_note_modal do
+      click_link @note_1.node.label
+      click_button "Close"
+    end
+    expect(@note_0.reload.node).not_to eq @note_1.node
+    expect(current_path).to eq node_note_path(@note_0.node, @note_0)
+  end
+  
   def create_note(attrs={})
     create(:note, attrs)
   end

--- a/spec/features/note_moving_spec.rb
+++ b/spec/features/note_moving_spec.rb
@@ -6,7 +6,7 @@ describe "moving a note", js: true do
 
   before do
     login_to_project_as_user
- 
+
     @note_0 = create_note
     # We're specifying the node label so the notes don't get assigned to the
     # same node
@@ -36,7 +36,7 @@ describe "moving a note", js: true do
   def create_node(attrs={})
     create(:node, attrs)
   end
-  
+
   def within_move_note_modal
     within("#modal_move_note") { yield }
   end


### PR DESCRIPTION
<span class="emoji-outer emoji-sizer"><span class="emoji-inner" style="background: url(chrome-extension://immhpnclomdloikkpcefncmfgjbkojmh/emoji-data/sheet_apple_64.png);background-position:35% 92.5%;background-size:4100%" title="wave"></span></span>  @etdsoft, @georgemillo:

Tried to use existing patterns as much as possible. 

See commit bodies for details on some choices (like creating a new plugin for the note moving modal).

Let me know if there's some other cases I should cover. Still not super familiar with how folks use Dradis day-to-day and haven't used it myself yet.
