### PR TITLE
Quick pasting feature

### DIFF
--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -75,6 +75,16 @@
         </button>
       </div>
 
+      <div class="span8">
+        <!-- #144 switches -->
+        <div class="controls">
+          <div class="checkbox">
+            <label><input class="enhanced-switch" id="quick-pasting" type="checkbox"><strong>Quick Pasting</strong></label>
+            <label><input class="enhanced-switch" id="auto-increasing" type="checkbox">Auto Increasing?</label>
+          </div>
+        </div>
+      </div>
+
       <div class="span4">
         <!-- The global progress bar -->
         <div class="progress progress-success progress-striped active fade">


### PR DESCRIPTION
split from #15, users can add attachments quickly to focus on evidence writing.
### quick pasting image

> images would upload automatically from clipboard pasting while its checkbox is checked.
### auto increasing identity

> increase attachment identity likes `High-SQLi-Search-3.png`, `High-SQLi-Search-4.png` automatically while its checkbox is checked.
## REF:

[Better picture naming from Ctrl+C](https://github.com/securityroots/dradispro-tracker/issues/144)

> we're suggesting that you eliminate the .png/.jpg/.etc picture extensions,
> which is added by the code automatically and let the user focus on the picture name (rather than extension).

implemented, but seems wont work while pasting from clipboard.

> It would also be great if the name of the last saved image name would be remembered and the number after it would be automatically increased by 1:
> instead of always presenting a default name, which needs to be deleted and renamed every single time.

implemented, and it could be switch of/off by checkbox.

> We suggest you save the name of the picture in a cookie,
> which would make it browser based and each user/browser can have it's own remembered name.

implemented, but saves it in HTML5 [sessionstorage](http://www.w3schools.com/html/html5_webstorage.asp).

> this requires some work, but not much,
> but if you don't have time to actually implement this,
> you should at least remember the last picture name and present the test1.png to the user (rather than screenshot-XX.png).

implemented, as above.
