### PR TITLE
Capybara is acting on CI - try screen size

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,12 @@ require 'shoulda/matchers'
 require 'capybara/rspec'
 
 require "capybara/poltergeist"
+
+Capybara.register_driver :poltergeist do |app|
+  options = { js_errors: false, timeout: 30, window_size: [1920, 1080] }
+  Capybara::Poltergeist::Driver.new(app, options)
+end
+
 Capybara.javascript_driver = :poltergeist
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Capybara is detecting the modal as being displayed on top of the rest of
the interface and then throwing

`
Poltergeist detected another element with CSS selector
`

Not completely sure this is the solution, but worth giving it a try.

See:
  https://makandracards.com/foxsoft/38755-poltergeist-detected-another-element-with-css-selector