### PR TITLE
Add Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ $ bundle exec rails server
 
 You can browse to the app at http://localhost:3000/
 
+### Using Vagrant
+
+If you'd like to use dradis in Vagrant, you can use the included Vagrantfile.
+
+```
+# Clone the repo
+git clone https://github.com/dradis/dradis-ce.git
+
+# install/start the vagrant box
+vagrant up
+# ssh into the box
+vagrant ssh
+
+# install ruby in the vagrant box
+cd /dradis/dradis-ce
+rvm install "$(cat .ruby-version)"
+
+
+# Then you can proceed with standard setup from within Vagrant
+ruby bin/setup
+# You'll need to tell the server to bind to 0.0.0.0 for port forwarding:
+bundle exec rails server -b 0.0.0.0
+```
 
 ### Stable release
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The '2' in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure('2') do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = 'ubuntu/xenial64'
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing 'localhost:8080' will access port 80 on the guest machine.
+  config.vm.network 'forwarded_port', guest: 3000, host: 3000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network 'private_network', ip: '192.168.33.10'
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network 'public_network'
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder '..', '/dradis', create: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider 'virtualbox' do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+    # Customize the amount of memory on the VM:
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define 'atlas' do |push|
+  #   push.app = 'YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME'
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision 'shell', inline: <<-SHELL
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server mysql-client libmysqlclient-dev
+    su ubuntu -c '( gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 ) && ( curl -sSL https://get.rvm.io | bash -s stable )'
+    su ubuntu -c 'cd /dradis/dradis-ce/ && source "$HOME/.profile" && rvm install "$(cat .ruby-version)"'
+  SHELL
+end


### PR DESCRIPTION
## What

- Support for running the Dradis-CE dev environment inside a Vagrant box.
- Updated the README.md 

## Why

I want to add features, but don't really want the dependencies running locally on my machine. Vagrant lets me run the whole thing in a VM, syncs files between machines, and exposes a port for the dev server.

/tag @etdsoft