### PR TITLE
NodeProperties - dedup Hash properties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,174 @@
+v3.2 (Sep 2016)
+ - Nodes only show :expand when they have children
+ - Add multiple-nodes
+ - Always display :services as table
+ - Bugs fixed: #334
+ - Updated Rails framework
+
+v3.1 (Mar 2016)
+ - Issue tags
+ - Testing methodologies
+ - Node properties
+ - New add-ons: Brakeman, Metasploit, etc.
+ - Millions of bug fixes
+
+.... sorry for the hiatus!
+
+v2.10
+ - New drag'n'drop file uploads with preview
+ - Updated NeXpose plugin: add NeXpose-Full support
+ - Feature requests implemented: #2312560, #2332708, #2706007
+ - Bugs fixed: #55, #67, #72
+ - Updated to Rails 3.2.3
+
+v2.9 (1st of February 2012)
+ - New Retina Network Security Scanner plugin
+ - New Zed Attack Proxy upload plugin
+ - Updated VulnDB import plugin
+ - Faster Nikto upload plugin
+ - Faster (60x times) Nessus upload plugin
+ - Faster Nmap upload plugin (through ruby-nmap gem)
+ - Updated First Time User's Wizard
+ - Upgrade to Rails 3.2
+
+v2.8 (10th of October 2011)
+ - Cleaner three-column layout
+ - Smarter Ajax polling and auto-updating
+ - New version of the Nmap upload plugin
+ - New version of the Nessus upload plugin
+ - ./verify.sh now checks that libxml2 is installed
+ - Bugs fixed: #17, #31, #37, #43, #48
+
+v2.7.2 (1st of August 2011)
+ - Updated to Rails 3.0.9
+ - Improved startup scripts
+ - Bugs fixed: #5, #9, #13, #14, #15, #16, #19, #20
+
+v2.7.1 (24th of May 2011)
+ - Improved note editor: more space, less Ajax
+ - Bugs fixed: #3, #4, #6, #7, #8, #10
+
+v2.7 (19th of April 2011)
+ - Improved command line API with Thor (thor -T)
+ - New Configuration Manager
+ - New Upload Manager
+ - New plugins:
+   * Metasploit import
+   * NeXpose (.xml) upload
+   * OpenVAS (.xml) upload
+   * SureCheck (.sc) upload
+   * w3af (.xml) upload
+   * Web Exploitation Framework (wXf) upload
+ - Updated plugins:
+   * Nessus plugin supports .nessus v2
+   * Vuln::DB import plugin updated to work with the latest release
+ - Bugs fixed: #2888332, #2973256
+ - Updated to Rails 3.0.6
+
+v2.6.1 (11th of February 2011)
+ - Fixed a 'back slash' vs 'forward slash' issue in start.sh
+ - Smarten up verify.sh to find the Bundler binary
+ - Deal with Burp Scanner's opinionated handling of null bytes
+ - SSL certificate updated for 2011 / 2012
+ - Updated libraries RedCloth 4.2.6 and Rails 3.0.4
+
+v2.6 (2nd of December 2010)
+ - New first-time repository content
+ - New helper scripts to run and reset the environment
+ - Upgraded libraries: ExtJS 3.3, Rails 3.0.3
+ - Improved performance through asset caching
+ - Bugs fixed: #3021312, #3030629, #3076709
+
+v2.5.2 (18th of May 2010)
+ - bugs fixed: #2974460
+ - security patch
+
+v2.5.1 (7th of March 2010)
+ - The NotesBrowser does a better job of keeping track of the current node
+ - New notes are no longer out of sync with the server
+ - upgraded library: ExtJS 3.1.1
+ - bugs fixed: #2964273, #2932569, #2963253
+
+
+v2.5 (5th of February 2010)
+ - improved Note editor (supports formatting)
+ - new HTML export plugin to generate reports in HTML format
+ - new Nikto Upload plugin: your favourite web server scanner output in Dradis.
+ - new Burp Upload plugin: you can now import your Burp Scanner results.
+ - improved 'First Time User Wizard' introduction
+ - keep track of all the activity with the built-in RSS feed
+ - new Rake task: dradis:backup
+ - Rake dradis:reset now creates a backup of the project by default
+ - Rake dradis:reset now clears the old log files
+ - the Nmap Upload plugin organizes the nodes in a more structured way
+ - upgraded libraries: ExtJS 3.0, Rails 2.3.5
+ - bugs fixed: #2936554, #2938593
+
+v2.4.1 (31st of October 2009)
+ - bugs fixed: #2881746, #2888245, #2889402
+
+v2.4 (10th of September 2009)
+ - drag'n'drop your notes
+ - new Rake tasks to backup the project, reset the environment, etc.
+ - better upload plugin feedback in case of exception
+ - new 'feedback' link in the top-right corner
+ - Nmap Upload now uses the Nmap::Parser library
+ - notification icon displayed in the attachments tab when a node has
+   attachments
+ - new plugin to import data from the OSVDB
+
+v2.3 (5th of August 2009)
+ - expand / collapse buttons in the tree
+ - add a new node filtering facility to the tree
+ - import from file functionality (nmap, nessus, etc.)
+ - refactor the WordExport plugin:
+     - create templates using Word only
+     - convert any document into a dradis template in < 10 minutes
+     - read more about it here:-
+         http://dradisframework.org/WordExport_templates.html
+
+ - project management plugin update:
+     - create project templates (read 'methodologies')
+     - export project in .zip format (DB + attachments)
+     - import projects/templates
+     - checkout / commit project revisions from and to the Meta-Server
+
+ - "what's new in this version?" widget in the status bar to learn the latest
+ features added to the framework.
+
+v2.2 (11th of June 2009)
+ - add attachments to nodes
+ - add 'refresh' buttons to the tree and the notes list
+ - force 'webrick' even if mongrel is installed (no SSL support in mongrel)
+ - centralise the framework version information.
+ - autoExpandColumn now works on IE
+ - Rails runs in "production" mode
+
+v2.1.1 (17th  of April 2009)
+ - the version string was not properly updated across the different modules.
+
+v2.1 (16th of April 2009)
+ - import/export plugin architecture
+ - import/export plugin generators
+ - sample WordXML export plugin
+ - sample WikiMedia import plugin
+
+v2.0.1 (23rd of February 2009)
+ - first security patch
+
+v2.0 (29th of January 2009)
+ - Forget Hosts, Services and Protocols. Embrace the freedom of Nodes.
+ - Forget SOAP, embrace REST
+ - Powered by Rails 2.0 and ExtJS 2.2 (http://www.extjs.com/)
+ - Now with security! (SSL transport and user authentication)
+
+v1.2 (4th of April 2008)
+ - a slightly less annoying implementation of the web interface 'auto refresh'
+ functionality.
+ - the services added through the web interface can have a name now :)
+ - simple prevention against embedded XSS.
+ - the missing submit.png image is included in the release now.
+
+v1.1 (29th of February 2008)
+ - new web interface, the old summary is gone, the new one is much neater and
+ ajax powered.

--- a/app/models/concerns/node_properties.rb
+++ b/app/models/concerns/node_properties.rb
@@ -21,6 +21,13 @@ module NodeProperties
   def set_property(key, value)
     current_value = self.properties[key]
 
+    # Even though we're serializing JSONWithIndifferentAccess, and the
+    # properties can be returned using String or Symbol keys, the
+    # :value_is_there variable defined bellow is depending on Array's #include?
+    # and this method wouldn't match two hashes unless they're both
+    # #with_indifferent_access
+    value = value.with_indifferent_access if value.is_a?(Hash)
+
     value_is_there = (current_value == value) || (current_value.is_a?(Array) && current_value.include?(value))
     return current_value if value.blank? || value_is_there
 


### PR DESCRIPTION
When we set a hash value as a property (by itself or inside an Array),
ActiveModel's serialization (JSONWithIndifferentAccess) will end up
stringifying the keys. Which works as expected.

The problem is when we try to re-set the property to the same value
(which can happen for instance if we upload the same Nmap file twice).
In this case, NodeProperties is pulling a stringified Hash from the
database, but the plugin is sending a hash with symbols as keys, and the
previous logic wouldn't detect the differenc.

This commit calls #with_indifferent_access on the new value we're trying
to store before doing the comparison with the values already stored.

This commit combined with [i] closes dradis/dradis-ce#43

[i]
https://github.com/dradis/dradis-nmap/commit/e2e562197fa8ea83063b934421f052d966556578