### PR TITLE
Add 'Page intentionally left blank' message to the /configurations

### DIFF
--- a/app/views/configurations/index.html.erb
+++ b/app/views/configurations/index.html.erb
@@ -2,9 +2,14 @@
 
 <div class="row-fluid">
   <div class="span7 offset1">
-    <%= form_tag configurations_path do %>
-      <% @configs.each do |configuration| %>
-        <%= render partial: configuration[:type], object: configuration %>
+    <% if @configs.count == 0 %>
+      <h2>This page intentionally left blank</h2>
+      <p>You haven't enabled any add-ons that require configuration. To enable them, see our <a href="http://dradisframework.org/documentation/add-ons.html" target="_blank">Enable/Disable Add-ons</a> guide.</p>
+    <% else %>
+      <%= form_tag configurations_path do %>
+        <% @configs.each do |configuration| %>
+          <%= render partial: configuration[:type], object: configuration %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/configurations/index.html.erb
+++ b/app/views/configurations/index.html.erb
@@ -4,7 +4,8 @@
   <div class="span7 offset1">
     <% if @configs.count == 0 %>
       <h2>You haven't enabled any add-ons that require configuration</h2>
-      <p>For more information on working with add-ons, see our <a href="http://dradisframework.org/documentation/add-ons.html" target="_blank">Enable/Disable Add-ons</a> guide.</p>
+      <p>Import plugins like <a href="http://dradisframework.org/addons/vulndb.html" target="_blank">VulnDB</a> or <a href="http://dradisframework.org/addons/mediawiki.html" target="_blank">MediaWiki</a> require configuration and will display here when they are enabled.</p>
+      <p>For more details on enabling add-ons, see our <a href="http://dradisframework.org/documentation/add-ons.html" target="_blank">Enable/Disable Add-ons</a> guide.</p>
     <% else %>
       <%= form_tag configurations_path do %>
         <% @configs.each do |configuration| %>

--- a/app/views/configurations/index.html.erb
+++ b/app/views/configurations/index.html.erb
@@ -3,8 +3,8 @@
 <div class="row-fluid">
   <div class="span7 offset1">
     <% if @configs.count == 0 %>
-      <h2>This page intentionally left blank</h2>
-      <p>You haven't enabled any add-ons that require configuration. To enable them, see our <a href="http://dradisframework.org/documentation/add-ons.html" target="_blank">Enable/Disable Add-ons</a> guide.</p>
+      <h2>You haven't enabled any add-ons that require configuration</h2>
+      <p>For more information on working with add-ons, see our <a href="http://dradisframework.org/documentation/add-ons.html" target="_blank">Enable/Disable Add-ons</a> guide.</p>
     <% else %>
       <%= form_tag configurations_path do %>
         <% @configs.each do |configuration| %>


### PR DESCRIPTION
Add 'Page intentionally left blank' message to the /configurations page if no configurable add-ons are enabled

We currently display a blank page if no configurable add-ons (MediaWiki, VulnDB, etc) are enabled: http://dradisframework.org/FAQ.html#configuration

This change allows us to remove the confusion about the blank page. 