### PR TITLE
Issues#show cache keys - more tweaks were needed

### DIFF
--- a/app/views/issues/_evidence.html.erb
+++ b/app/views/issues/_evidence.html.erb
@@ -1,5 +1,5 @@
 <h3>Evidence information - <span class="actions"><a href="javascript:void(0)" class="js-add-evidence">add new</a></span></h3>
-<% cache @nodes_for_add_evidence do %>
+<% cache [@issue, @nodes_for_add_evidence] do %>
   <%= render 'issues/add_evidence'%>
 <% end %>
 

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
       <% issues.each do |issue| %>
-      <% cache [issue, 'issues-table'] do%>
+      <% cache [issue, issue.affected_count, 'issues-table'] do%>
       <tr>
         <td class="column-checkbox"><%= check_box_tag dom_id(issue), issue.id, false, class: 'js-multicheck', data: { url: issue_path(issue, format: :json) } %></td>
         <% @columns.each do |column| %>


### PR DESCRIPTION
* Make sure we bust the cache if the count of Evidence changes.
* Scope the New Evidence form cache to the current Issue (to get the right :issue_id hidden field)