### PR TITLE
Fix issue in SessionsController#new

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -56,9 +56,7 @@ class SessionsController < ApplicationController
   # If the database doesn't contain a valid password, a new one needs to be
   # created.
   def ensure_setup
-    if ::Configuration.shared_password.nil?
-      render action: :not_ready
-    elsif (::Configuration.shared_password == 'improvable_dradis')
+    if (::Configuration.shared_password == 'improvable_dradis')
       redirect_to action: :init
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -57,7 +57,7 @@ class SessionsController < ApplicationController
   # created.
   def ensure_setup
     if (::Configuration.shared_password == 'improvable_dradis')
-      redirect_to action: :init
+      redirect_to setup_path
     end
   end
 


### PR DESCRIPTION
The first commit removes some code that never gets executed (and would crash anyway if it did execute.)

The second commit fixes an obscure crashing bug:

1. Log in
2. In the console, delete the `shared_password` configuration setting (or change it to the default setting of `improvable_dradis`.)
3. Let your session time out (or just edit `config/initializers/warden_99_timeout.rb` so that you'll timeout on the next request.)
4. Try to visit the root path (or any path that doesn't live under SessionsController).
5. You'll see an error about the action `init` not being found.

What's happening is that Warden's `failure_app` is calling `SessionsController.action(:new).call`, which runs `SessionController#new` within the context of `HomeController`... meaning that ` redirect_to` looks for `HomeController#init` (which doesn't exist) rather the `SessionsController#init` - and can't find it, so raises an error.  (see `config/initializers/warden_00_shared_password.rb`)

This may be a sign of deeper problem within the code, but changing `redirect_to action: :init` to `redirect_to sessions_path` fixes the symptom and stops the crash from occurring, which should stop someone in the future from wasting as much time on this error as I did this morning :wink:
