### PR TITLE
Issues#index - add column list to cache key

### DIFF
--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -1,4 +1,4 @@
-<% cache ['issues-table', issues.map(&:id), @issues.map(&:updated_at).map(&:to_i).sort.last] do %>
+<% cache ['issues-table', @columns, issues.map(&:id), @issues.map(&:updated_at).map(&:to_i).sort.last] do %>
   <table class="table table-striped tbl-issues js-tbl-issues">
     <thead>
       <tr>
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
       <% issues.each do |issue| %>
-      <% cache [issue, issue.affected_count, 'issues-table'] do%>
+      <% cache [issue, @columns, issue.affected_count, 'issues-table'] do%>
       <tr>
         <td class="column-checkbox"><%= check_box_tag dom_id(issue), issue.id, false, class: 'js-multicheck', data: { url: issue_path(issue, format: :json) } %></td>
         <% @columns.each do |column| %>


### PR DESCRIPTION
If a new Issue is added that brings in a extra field not already present
in the project, the original implementation would result in the already
existing issue rows being read from the cache. These rows don't have the
new field and as a result the table gets all out of wack.