### PR TITLE
Fix CSS styling of sidebar collection items

### DIFF
--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -448,6 +448,29 @@ body {
             color: $linkColorHover;
           }
         }
+        .list-item-actions {
+          font-size: 90%;
+
+          a {
+            padding: 0 4px;
+          }
+
+          a.list-item-action-delete {
+            color: $errorText;
+            &:hover,
+            &:focus {
+              color: darken($errorText, 10%);
+            }
+          }
+
+          a.list-item-action-edit {
+            color: $linkColor;
+            &:hover,
+            &:focus {
+              color: $linkColorHover;
+            }
+          }
+        }
       }
     }
 

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -436,6 +436,14 @@ body {
           }
         }
 
+        // Keep the original light blue color for the Edit link.
+        a.list-item-edit {
+          color: $linkColor;
+          &:hover,
+          &:focus {
+            color: $linkColorHover;
+          }
+        }
       }
     }
 

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -346,7 +346,11 @@ body {
 
           .actions {
             color: $grayLight;
-            font-size: 85%;
+            font-size: 80%;
+
+            a {
+              padding: 0 4px;
+            }
           }
         }
 

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -27,6 +27,8 @@
   margin-bottom: 2em;
   .list-item {
     line-height: 2em;
+    padding-left: 1ex;
+
     &.note-editor{
       border-bottom: 0;
       .form-actions {
@@ -37,6 +39,18 @@
 
     p {
       line-height: 1.5em;
+    }
+
+    .list-item-edit {
+      padding-right: 1ex;
+      visibility: hidden;
+    }
+
+    &:hover {
+      background-color: lighten(#ccc,10%);
+      .list-item-edit {
+        visibility: visible;
+      }
     }
   }
 

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -41,6 +41,11 @@
       line-height: 1.5em;
     }
 
+    .list-item-actions {
+      display: none;
+      padding-right: 1ex;
+    }
+
     .list-item-edit {
       display: none;
       padding-right: 1ex;
@@ -49,12 +54,9 @@
     &:hover {
       background-color: lighten(#ccc,10%);
 
-      .list-item-icon {
-        display: none;
-      }
-
-      .list-item-edit {
-        display: inline;
+      .list-item-actions {
+        display: block;
+        text-align: right;
       }
     }
   }

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -42,14 +42,19 @@
     }
 
     .list-item-edit {
+      display: none;
       padding-right: 1ex;
-      visibility: hidden;
     }
 
     &:hover {
       background-color: lighten(#ccc,10%);
+
+      .issue-icon {
+        display: none;
+      }
+
       .list-item-edit {
-        visibility: visible;
+        display: inline;
       }
     }
   }

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -49,7 +49,7 @@
     &:hover {
       background-color: lighten(#ccc,10%);
 
-      .issue-icon {
+      .list-item-icon {
         display: none;
       }
 

--- a/app/assets/stylesheets/snowcrash/modules/issues.scss
+++ b/app/assets/stylesheets/snowcrash/modules/issues.scss
@@ -119,11 +119,29 @@ body.issues.index {
       padding-left: 20px;
     }
 
+    .column-actions {
+      text-align: right;
+      width: 125px;
+
+      a {
+        padding-right: 8px;
+        visibility: hidden;
+      }
+    }
+
     .column-checkbox {
       padding: 0;
       text-align: center;
       vertical-align: middle;
       width: 36px;
+
+      input {
+        margin: 0;
+      }
+    }
+
+    tr:hover {
+      .column-actions a { visibility: visible; }
     }
   }
   //------------------------------------------------------------- /Issues table

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -63,7 +63,7 @@ module IssuesHelper
     if tag = issue.tags.first
       content_tag :span, style: "color: #{tag.color}" do
         [
-          icon_for_model(issue, 'fa-bug'),
+          colored_icon_for_model(issue, 'fa-bug'),
           h(tag.display_name)
         ].join(' ').html_safe
       end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -63,22 +63,12 @@ module IssuesHelper
     if tag = issue.tags.first
       content_tag :span, style: "color: #{tag.color}" do
         [
-          tag_icon_for(issue),
+          icon_for_model(issue, 'fa-bug'),
           h(tag.display_name)
         ].join(' ').html_safe
       end
     else
       content_tag :span, '(no tag)', class: 'muted'
     end
-  end
-
-  # Output a Font Awesome tag with the right color
-  def tag_icon_for(issue, css_class=nil)
-    options = { class: "fa fa-bug #{css_class if css_class}"}
-
-    if tag = issue.tags.first
-      options[:style] = "color: #{tag.color}"
-    end
-    content_tag :i, nil, options
   end
 end

--- a/app/helpers/snowcrash_helper.rb
+++ b/app/helpers/snowcrash_helper.rb
@@ -40,4 +40,29 @@ module SnowcrashHelper
     yield presenter if block_given?
     presenter
   end
+
+
+  def icon_for_model(model, icon_class, extra_class = nil)
+
+    css =  ['fa']
+    css << icon_class
+    css << extra_class if extra_class
+
+    options = { class: css.join(' ') }
+    tag     = nil
+
+    case model
+    when Evidence
+      tag = model.issue.tags.first
+    when Issue
+      tag = model.tags.first
+    end
+
+    if tag
+      options[:style] = "color: #{tag.color}"
+    end
+
+    content_tag :i, nil, options
+  end
+
 end

--- a/app/helpers/snowcrash_helper.rb
+++ b/app/helpers/snowcrash_helper.rb
@@ -42,7 +42,7 @@ module SnowcrashHelper
   end
 
 
-  def icon_for_model(model, icon_class, extra_class = nil)
+  def colored_icon_for_model(model, icon_class, extra_class = nil)
 
     css =  ['fa']
     css << icon_class

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -1,4 +1,9 @@
-<%= content_tag :div, id: "#{dom_id(evidence)}_link", class: ('list-item' << ' active' if (request.format.html? and @evidence == evidence)) do %>
+<%
+  item_css = ['list-item']
+  item_css << ' active' if (request.format.html? and @evidence == evidence)
+%>
+
+<%= content_tag :div, id: "#{dom_id(evidence)}_link", class: item_css.join do %>
   <div class="expansion-container">
     <%= link_to node_evidence_path(@node, evidence) do %>
       <% if tag = evidence.issue.tags.first %>

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -9,13 +9,7 @@
       <i class="fa fa-pencil"></i> Edit
     <% end %>
     <%= link_to node_evidence_path(@node, evidence) do %>
-      <%
-        options = { class: 'fa fa-flag list-item-icon' }
-        if tag = evidence.issue.tags.first
-          options[:style] = "color: #{tag.color}"
-        end
-      %>
-      <%= content_tag :i, nil, options%>
+      <%= icon_for_model(evidence, 'fa-flag', 'list-item-icon') %>
       <%= evidence.issue.title %>
     <% end %>
   </div>

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -4,13 +4,25 @@
 %>
 
 <%= content_tag :div, id: "#{dom_id(evidence)}_link", class: item_css.join do %>
+
   <div class="expansion-container">
-    <%= link_to edit_node_evidence_path(@node, evidence), class: 'list-item-edit' do %>
-      <i class="fa fa-pencil"></i> Edit
-    <% end %>
     <%= link_to node_evidence_path(@node, evidence) do %>
       <%= icon_for_model(evidence, 'fa-flag', 'list-item-icon') %>
       <%= evidence.issue.title %>
     <% end %>
   </div>
-  <% end %>
+
+  <div class="list-item-actions">
+    <%= link_to edit_node_evidence_path(@node, evidence), class:'list-item-action-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
+
+    <%= link_to [@node, evidence],
+          method: :delete,
+          data: { confirm: 'Are you sure?' },
+          class: 'list-item-action-delete' do %>
+      <i class="fa fa-trash"></i> Delete
+    <% end %>
+  </div>
+
+<% end %>

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -5,12 +5,17 @@
 
 <%= content_tag :div, id: "#{dom_id(evidence)}_link", class: item_css.join do %>
   <div class="expansion-container">
+    <%= link_to edit_node_evidence_path(@node, evidence), class: 'list-item-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
     <%= link_to node_evidence_path(@node, evidence) do %>
-      <% if tag = evidence.issue.tags.first %>
-        <i class="fa fa-flag" style="color: <%= tag.color %>"></i>
-      <% else %>
-        <i class="fa fa-flag"></i>
-      <% end %>
+      <%
+        options = { class: 'fa fa-flag list-item-icon' }
+        if tag = evidence.issue.tags.first
+          options[:style] = "color: #{tag.color}"
+        end
+      %>
+      <%= content_tag :i, nil, options%>
       <%= evidence.issue.title %>
     <% end %>
   </div>

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -7,7 +7,7 @@
 
   <div class="expansion-container">
     <%= link_to node_evidence_path(@node, evidence) do %>
-      <%= icon_for_model(evidence, 'fa-flag', 'list-item-icon') %>
+      <%= colored_icon_for_model(evidence, 'fa-flag', 'list-item-icon') %>
       <%= evidence.issue.title %>
     <% end %>
   </div>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -5,12 +5,16 @@
 <% end %>
 
 <ul class="nav nav-tabs main-tabs">
-  <li class="active"><a href="#evidence-tab" data-toggle="tab">
-    <% if tag = @evidence.issue.tags.first %>
-      <i class="fa fa-flag" style="color: <%= tag.color %>"></i>
-    <% else %>
-      <i class="fa fa-flag"></i>
-    <% end %>Evidence</a></li><li><a href="#info-tab" data-toggle="tab"><i class="fa fa-bug"></i> Information</a></li>
+  <li class="active">
+    <a href="#evidence-tab" data-toggle="tab">
+      <%= icon_for_model(@evidence, 'fa-flag')%> Evidence
+    </a>
+  </li>
+  <li>
+    <a href="#info-tab" data-toggle="tab">
+      <i class="fa fa-bug"></i> Information
+    </a>
+  </li>
   <li><a href="#activity-tab" data-toggle="tab"><i class="fa fa-refresh"></i> Recent activity</a></li>
 </ul>
 

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -51,7 +51,7 @@
           <h3>
             Issue information -
             <span class="actions">
-            <%= link_to 'open', issue_path(@issue)%> -
+            <%= link_to 'Open', issue_path(@issue)%> -
             <%= tag_and_name_for(@issue) %>
             </span>
           </h3>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -22,8 +22,15 @@
         <h3>
           Evidence for this instance -
           <span class="actions">
-            <%= link_to 'edit', edit_node_evidence_path(@node, @evidence) %>
-            <%= link_to 'delete', [@node, @evidence], class: 'text-error', data: { confirm: 'Are you sure?' }, method: :delete %>
+            <%= link_to edit_node_evidence_path(@node, @evidence) do %>
+              <i class="fa fa-pencil"></i> Edit
+            <% end %>
+            <%= link_to [@node, @evidence],
+                  class: 'text-error',
+                  data: { confirm: 'Are you sure?' },
+                  method: :delete do %>
+              <i class="fa fa-trash"></i> Delete
+            <% end %>
           </span>
         </h3>
 

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -7,7 +7,7 @@
 <ul class="nav nav-tabs main-tabs">
   <li class="active">
     <a href="#evidence-tab" data-toggle="tab">
-      <%= icon_for_model(@evidence, 'fa-flag')%> Evidence
+      <%= colored_icon_for_model(@evidence, 'fa-flag')%> Evidence
     </a>
   </li>
   <li>

--- a/app/views/issues/_evidence.html.erb
+++ b/app/views/issues/_evidence.html.erb
@@ -1,4 +1,4 @@
-<h3>Evidence information - <span class="actions"><a href="javascript:void(0)" class="js-add-evidence">add new</a></span></h3>
+<h3>Evidence information - <span class="actions"><a href="javascript:void(0)" class="js-add-evidence">Add new</a></span></h3>
 <% cache [@issue, @nodes_for_add_evidence] do %>
   <%= render 'issues/add_evidence'%>
 <% end %>
@@ -28,8 +28,15 @@
                 <h3>
                   Evidence for <%= link_to node.label, node %> -
                   <span class="actions">
-                  <%= link_to 'edit', edit_node_evidence_path(node, instances.first) %>
-                  <%= link_to 'delete', [node, instances.first], class: 'text-error', data: { confirm: 'Are you sure?' }, method: :delete %>
+                    <%= link_to edit_node_evidence_path(node, instances.first) do %>
+                      <i class="fa fa-pencil"></i> Edit
+                    <% end %>
+                    <%= link_to [node, instances.first],
+                          class: 'text-error',
+                          data: { confirm: 'Are you sure?' },
+                          method: :delete do %>
+                      <i class="fa fa-trash"></i> Delete
+                    <% end %>
                   </span>
                 </h3>
                 <div class="content-textile" id="node_<%= node.id %>_instance_0">
@@ -49,8 +56,15 @@
                       <h3>
                         Evidence for this instance -
                         <span class="actions">
-                        <%= link_to 'edit', edit_node_evidence_path(node, evidence) %>
-                        <%= link_to 'delete', [node, evidence], class: 'text-error', data: { confirm: 'Are you sure?' }, method: :delete %>
+                          <%= link_to edit_node_evidence_path(node, evidence) do %>
+                            <i class="fa fa-pencil"></i> Edit
+                          <% end %>
+                          <%= link_to [node, evidence],
+                                class: 'text-error',
+                                data: { confirm: 'Are you sure?' },
+                                method: :delete do %>
+                            <i class="fa fa-trash"></i> Delete
+                          <% end %>
                         </span>
                       </h3>
                       <div class="content-textile">

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -1,8 +1,17 @@
-<%= content_tag :div, id: dom_id(issue), class: ('list-item' << ' active' if (request.format.html? and @issue == issue)) do %>
+<%
+  item_css = ['list-item']
+  item_css << ' active' if (request.format.html? and @issue == issue)
+%>
+
+<%= content_tag :div, id: dom_id(issue), class: item_css.join do %>
   <div class="expansion-container">
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
       <%= tag_icon_for(issue) %>
       <%= issue.title %>
+      <%= link_to edit_issue_path(issue), class: 'pull-right list-item-edit' do %>
+        <i class="fa fa-edit"></i> Edit
+      <% end %>
+
     <% end %>
   </div>
 <% end %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -9,7 +9,7 @@
       <i class="fa fa-pencil"></i> Edit
     <% end %>
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
-      <%= tag_icon_for(issue, 'issue-icon') %>
+      <%= tag_icon_for(issue, 'list-item-icon') %>
       <%= issue.title %>
       <!--
       <%= link_to edit_issue_path(issue), class: 'pull-right list-item-edit' do %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -7,7 +7,7 @@
 
   <div class="expansion-container">
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
-      <%= icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
+      <%= colored_icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
       <%= issue.title %>
     <% end %>
   </div>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -9,7 +9,7 @@
       <i class="fa fa-pencil"></i> Edit
     <% end %>
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
-      <%= tag_icon_for(issue, 'list-item-icon') %>
+      <%= icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
       <%= issue.title %>
     <% end %>
   </div>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -4,13 +4,25 @@
 %>
 
 <%= content_tag :div, id: dom_id(issue), class: item_css.join do %>
+
   <div class="expansion-container">
-    <%= link_to edit_issue_path(issue), class: 'list-item-edit' do %>
-      <i class="fa fa-pencil"></i> Edit
-    <% end %>
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
       <%= icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
       <%= issue.title %>
     <% end %>
   </div>
+
+  <div class="list-item-actions">
+    <%= link_to edit_issue_path(issue), class:'list-item-action-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
+
+    <%= link_to issue,
+          method: :delete,
+          data: { confirm: 'Are you sure?' },
+          class: 'list-item-action-delete' do %>
+      <i class="fa fa-trash"></i> Delete
+    <% end %>
+  </div>
+
 <% end %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -5,12 +5,20 @@
 
 <%= content_tag :div, id: dom_id(issue), class: item_css.join do %>
   <div class="expansion-container">
-    <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
-      <%= tag_icon_for(issue) %>
-      <%= issue.title %>
-      <%= link_to edit_issue_path(issue), class: 'pull-right list-item-edit' do %>
-        <i class="fa fa-edit"></i> Edit
+
+    <span class="actions">
+      <%= link_to edit_issue_path(issue), class: 'list-item-edit' do %>
+        <i class="fa fa-pencil"></i> Edit
       <% end %>
+    </span>
+    <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
+      <%= tag_icon_for(issue, 'issue-icon') %>
+      <%= issue.title %>
+      <!--
+      <%= link_to edit_issue_path(issue), class: 'pull-right list-item-edit' do %>
+        <i class="fa fa-pencil"></i> Edit
+      <% end %>
+      -->
 
     <% end %>
   </div>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -5,12 +5,9 @@
 
 <%= content_tag :div, id: dom_id(issue), class: item_css.join do %>
   <div class="expansion-container">
-
-    <span class="actions">
-      <%= link_to edit_issue_path(issue), class: 'list-item-edit' do %>
-        <i class="fa fa-pencil"></i> Edit
-      <% end %>
-    </span>
+    <%= link_to edit_issue_path(issue), class: 'list-item-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
       <%= tag_icon_for(issue, 'issue-icon') %>
       <%= issue.title %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -11,12 +11,6 @@
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
       <%= tag_icon_for(issue, 'list-item-icon') %>
       <%= issue.title %>
-      <!--
-      <%= link_to edit_issue_path(issue), class: 'pull-right list-item-edit' do %>
-        <i class="fa fa-pencil"></i> Edit
-      <% end %>
-      -->
-
     <% end %>
   </div>
 <% end %>

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -18,7 +18,7 @@
           <%=
           case column
           when 'Title'
-            link_to issue.title, issue
+            link_to(issue.title, issue)
           when 'Tags'
             tag_and_name_for(issue)
           when 'Affected'
@@ -36,6 +36,14 @@
           %>
         </td>
         <% end  %>
+        <td class="column-actions">
+          <%= link_to edit_issue_path(issue), class: '' do %>
+            <i class="fa fa-pencil"></i> Edit
+          <% end %>
+          <%= link_to issue, method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-error' do %>
+            <i class="fa fa-trash"></i> Delete
+          <% end %>
+        </td>
       </tr>
       <% end %>
       <% end %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -31,8 +31,16 @@
       <div class="inner note-text-inner">
         <h3>Issue information -
           <span class="actions">
-            <%= link_to 'edit', edit_issue_path(@issue), class: 'view-toggle-off editor-toggle-off' %>
-            <%= link_to 'delete', @issue, class: 'text-error', data: { confirm: 'Are you sure?' }, method: :delete %> -
+            <%= link_to edit_issue_path(@issue),
+                  class: 'view-toggle-off editor-toggle-off' do %>
+              <i class="fa fa-pencil"></i> Edit
+            <% end %>
+            <%= link_to @issue,
+                  class: 'text-error',
+                  data: { confirm: 'Are you sure?' },
+                  method: :delete do %>
+              <i class="fa fa-trash"></i> Delete
+            <% end %> -
             <%= tag_and_name_for(@issue) %>
           </span>
           <small class="pull-right">Author: <%= @issue.author %></small>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -15,12 +15,11 @@
 </ul>
 
 <ul class="nav nav-tabs main-tabs">
-  <li class="active"><a href="#info-tab" data-toggle="tab">
-    <% if tag = @issue.tags.first %>
-      <i class="fa fa-bug" style="color: <%= tag.color %>"></i>
-    <% else %>
-      <i class="fa fa-bug"></i>
-    <% end %> Information</a></li>
+  <li class="active">
+    <a href="#info-tab" data-toggle="tab">
+      <%= icon_for_model(@issue, 'fa-bug') %> Information
+    </a>
+  </li>
   <li><a href="#evidence-tab" data-toggle="tab"><i class="fa fa-laptop"></i> Evidence <span class="badge"><%= @issue.evidence.count %></span></a></li>
   <li><a href="#activity-tab" data-toggle="tab"><i class="fa fa-refresh"></i> Recent activity</a></li>
 </ul>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -17,7 +17,7 @@
 <ul class="nav nav-tabs main-tabs">
   <li class="active">
     <a href="#info-tab" data-toggle="tab">
-      <%= icon_for_model(@issue, 'fa-bug') %> Information
+      <%= colored_icon_for_model(@issue, 'fa-bug') %> Information
     </a>
   </li>
   <li><a href="#evidence-tab" data-toggle="tab"><i class="fa fa-laptop"></i> Evidence <span class="badge"><%= @issue.evidence.count %></span></a></li>

--- a/app/views/methodologies/index.html.erb
+++ b/app/views/methodologies/index.html.erb
@@ -54,8 +54,15 @@
     <% for methodology in @methodologies do %>
     <%= content_tag :div, class: 'tab-pane', id: methodology.to_html_anchor, data: { url: update_task_methodology_path(methodology) } do %>
       <div class="pull-right">
-        <%= link_to 'edit', edit_methodology_path(methodology)  %>
-        <%= link_to 'delete', methodology_path(methodology), class: 'text-error', method: :delete, data: { confirm: "Are you sure you want to delete the '#{methodology.name}' methodology?" } %>
+        <%= link_to edit_methodology_path(methodology) do %>
+          <i class="fa fa-pencil"></i> Edit
+        <% end %>
+        <%= link_to methodology_path(methodology),
+              class: 'text-error',
+              method: :delete,
+              data: { confirm: "Are you sure you want to delete the '#{methodology.name}' methodology?" } do %>
+          <i class="fa fa-trash"></i> Delete
+        <% end %>
       </div>
       <% for section in methodology.sections do %>
       <div class="section">

--- a/app/views/nodes/show.html.erb
+++ b/app/views/nodes/show.html.erb
@@ -15,7 +15,12 @@
   <div class="tab-pane active" id="properties-tab">
     <div class="node-content" id="<%= dom_id(@node) %>_content">
       <div class="inner">
-        <h3>Properties - <%= link_to 'edit', edit_node_path(@node) %></h3>
+        <h3>Properties - <span class="actions">
+          <%= link_to edit_node_path(@node) do %>
+            <i class="fa fa-pencil"></i> Edit
+          <% end %>
+          </span>
+        </h3>
 
         <% if @node.has_any_property?  %>
           <% @node.properties.sort.each do |key, value| %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -4,13 +4,25 @@
 %>
 
 <%= content_tag :div, id: "#{dom_id(note)}_link", class: item_css.join do %>
+
   <div class="expansion-container">
-    <%= link_to edit_node_note_path(@node, note), class: 'list-item-edit' do %>
-      <i class="fa fa-pencil"></i> Edit
-    <% end %>
     <%= link_to node_note_path(@node, note) do %>
       <i class="fa fa-file-text list-item-icon"></i>
       <%= note.title %>
     <% end %>
   </div>
+
+  <div class="list-item-actions">
+    <%= link_to edit_node_note_path(@node, note), class:'list-item-action-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
+
+    <%= link_to [@node, note],
+          method: :delete,
+          data: { confirm: 'Are you sure?' },
+          class: 'list-item-action-delete' do %>
+      <i class="fa fa-trash"></i> Delete
+    <% end %>
+  </div>
+
 <% end %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,4 +1,9 @@
-<%= content_tag :div, id: "#{dom_id(note)}_link", class: ('list-item' << ' active' if (request.format.html? and @note == note)) do %>
+<%
+  item_css = ['list-item']
+  item_css << ' active' if (request.format.html? and @note == note)
+%>
+
+<%= content_tag :div, id: "#{dom_id(note)}_link", class: item_css.join do %>
   <div class="expansion-container">
     <%= link_to node_note_path(@node, note) do %>
       <i class="fa fa-file-text"></i>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -5,8 +5,11 @@
 
 <%= content_tag :div, id: "#{dom_id(note)}_link", class: item_css.join do %>
   <div class="expansion-container">
+    <%= link_to edit_node_note_path(@node, note), class: 'list-item-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
     <%= link_to node_note_path(@node, note) do %>
-      <i class="fa fa-file-text"></i>
+      <i class="fa fa-file-text list-item-icon"></i>
       <%= note.title %>
     <% end %>
   </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -33,13 +33,18 @@
       <div id="<%= dom_id(@note) %>" class="inner note-text-inner">
         <h3>Content for this note -
           <span class="actions">
-            <%= link_to 'edit', edit_node_note_path(@node, @note) %>
-            <%= link_to 'delete',
-                    [@node, @note],
-                    class: 'text-error',
-                    data: { confirm: 'Are you sure?' },
-                    method: :delete %>
-            <a href="#modal_move_note" tabindex="-1" data-toggle="modal">move</a>
+            <%= link_to edit_node_note_path(@node, @note) do %>
+              <i class="fa fa-pencil"></i> Edit
+            <% end %>
+            <%= link_to [@node, @note],
+                  class: 'text-error',
+                  data: { confirm: 'Are you sure?' },
+                  method: :delete do %>
+              <i class="fa fa-trash"></i> Delete
+            <% end %>
+            <a href="#modal_move_note" tabindex="-1" data-toggle="modal">
+              <i class="fa fa-mail-forward"></i> Move
+            </a>
           </span>
         </h3>
         <div class="content-textile">

--- a/spec/features/evidence_spec.rb
+++ b/spec/features/evidence_spec.rb
@@ -39,8 +39,7 @@ describe "evidence" do
     it_behaves_like "a page with an activity feed"
 
     describe "clicking 'delete'" do
-      let(:submit_form) { click_link "delete" }
-
+      let(:submit_form) { within('.note-text-inner') { click_link "Delete" } }
       it "deletes the Evidence" do
         id = @evidence.id
         submit_form

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -225,7 +225,7 @@ describe "Issues pages" do
         describe "clicking 'delete'" do
           before { visit issue_path(@issue) }
 
-          let(:submit_form) { click_link "delete" }
+          let(:submit_form) { click_link "Delete" }
 
           it "deletes the issue" do
             id = @issue.id

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -225,7 +225,7 @@ describe "Issues pages" do
         describe "clicking 'delete'" do
           before { visit issue_path(@issue) }
 
-          let(:submit_form) { click_link "Delete" }
+          let(:submit_form) { within('.note-text-inner') { click_link "Delete" } }
 
           it "deletes the issue" do
             id = @issue.id

--- a/spec/features/note_pages_spec.rb
+++ b/spec/features/note_pages_spec.rb
@@ -38,7 +38,7 @@ describe "note pages" do
     it_behaves_like "a page with an activity feed"
 
     describe "clicking 'delete'" do
-      let(:submit_form) { click_link "delete" }
+      let(:submit_form) { within('.note-text-inner') { click_link "Delete" } }
 
       it "deletes the note and redirects to the node's page" do
         id = @note.id


### PR DESCRIPTION
I just realised that a piece of code dealing with the CSS classes that list items of the sidebar were supposed to get wasn't actually working as expected.

Independently, there is a recurring request for being able to edit from the sidebar list instead of having to click on the item, then click on edit. Thoughts on this approach?


![list-hover](https://cloud.githubusercontent.com/assets/53006/22143992/6e1a2174-defc-11e6-9ced-744915ce3c6d.gif)

* Adding the :hover effect
* Adding the edit link


And along the same lines... how do we allow direct edit from the Issues table? Any of these two options any good? Is there a better way?

Edit link in its own column:

![table-hover-01](https://cloud.githubusercontent.com/assets/53006/22144902/a2333448-deff-11e6-8165-5367453f5014.gif)

Edit link in Title column:

![table-hover-02](https://cloud.githubusercontent.com/assets/53006/22144903/a234c65a-deff-11e6-8d78-d0a8c99d7f4e.gif)


