### PR TITLE
Attachments api

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -43,7 +43,7 @@ class AttachmentsController < ProjectScopedController
     attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
     attachment.close
     new_name    = CGI::unescape(params[:rename])
-    destination = Attachment.pwd.join(@node.id, new_name).to_s
+    destination = Attachment.pwd.join(@node.id.to_s, new_name).to_s
 
     if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
       File.rename attachment.fullpath, destination

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -61,7 +61,7 @@ class AttachmentsController < ProjectScopedController
     @attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
     send_options = { filename: @attachment.filename }
 
-    # Figure out the best way of displaying the file (by default send the it as
+    # Figure out the best way of displaying the file (by default send it as
     # an attachment).
     extname = File.extname(filename)
     send_options[:disposition] = 'attachment'
@@ -90,10 +90,10 @@ class AttachmentsController < ProjectScopedController
   # the :node_id parameter.
   def destroy
     filename = params[:id]
-    
+
     @attachment = Attachment.find(filename, conditions: { node_id: @node.id} )
     @attachment.delete
-    
+
     render json: { success: true }
   end
 
@@ -102,7 +102,7 @@ class AttachmentsController < ProjectScopedController
   # we are working with. This filter sets the @node instance variable if the
   # give :node_id is valid.
   def find_or_initialize_node
-    begin 
+    begin
       @node = Node.find(params[:node_id])
     rescue
       redirect_to root_path, alert: 'Node not found'

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -39,7 +39,7 @@ class AttachmentsController < ProjectScopedController
   # It is possible to rename attachments and this function provides that
   # functionality.
   def update
-    filename    = params[:id]
+    filename    = params[:filename]
     attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
     attachment.close
     new_name    = CGI::unescape(attachment_params[:filename])
@@ -56,7 +56,7 @@ class AttachmentsController < ProjectScopedController
   # displayed inline. By default the <tt>Content-disposition</tt> will be set to
   # +attachment+.
   def show
-    filename = params[:id]
+    filename = params[:filename]
 
     @attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
     send_options = { filename: @attachment.filename }
@@ -89,7 +89,7 @@ class AttachmentsController < ProjectScopedController
   # attachment's file name in the :id parameter and the corresponding node in
   # the :node_id parameter.
   def destroy
-    filename = params[:id]
+    filename = params[:filename]
 
     @attachment = Attachment.find(filename, conditions: { node_id: @node.id} )
     @attachment.delete

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -108,23 +108,4 @@ class AttachmentsController < ProjectScopedController
       redirect_to root_path, alert: 'Node not found'
     end
   end
-
-  # Obtain a suitable attachment name for the recently uploaded file. If the
-  # original file name is still available, use it, otherwise, provide count-based
-  # an alternative.
-  def get_name(args={})
-    original = args.fetch(:original)
-
-    if @node.attachments.map(&:filename).include?(original)
-      attachments_pwd = Attachment.pwd.join(@node.id.to_s)
-
-      # The original name is taken, so we'll add the "_copy-XX." suffix
-      extension = File.extname(original)
-      basename  = File.basename(original, extension)
-      sequence  = Dir.glob(attachments_pwd.join("#{basename}_copy-*#{extension}")).collect { |a| a.match(/_copy-([0-9]+)#{extension}\z/)[1].to_i }.max || 0
-      "%s_copy-%02i%s" % [basename, sequence + 1, extension]
-    else
-      original
-    end
-  end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -43,7 +43,7 @@ class AttachmentsController < ProjectScopedController
     attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
     attachment.close
     new_name    = CGI::unescape(params[:rename])
-    destination = Attachment.pwd.join(params[:node_id], new_name).to_s
+    destination = Attachment.pwd.join(@node.id, new_name).to_s
 
     if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
       File.rename attachment.fullpath, destination

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -14,7 +14,7 @@ class AttachmentsController < ProjectScopedController
   def create
     uploaded_file = params.fetch('attachment_file', params.fetch('files', []).first)
 
-    attachment_name = get_name(original: uploaded_file.original_filename)
+    attachment_name = Attachment.available_name(@node, original: uploaded_file.original_filename)
 
     @attachment = Attachment.new(attachment_name, node_id: @node.id)
     @attachment << uploaded_file.read

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -42,7 +42,7 @@ class AttachmentsController < ProjectScopedController
     filename    = params[:id]
     attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
     attachment.close
-    new_name    = CGI::unescape(params[:rename])
+    new_name    = CGI::unescape(attachment_params[:filename])
     destination = Attachment.pwd.join(@node.id.to_s, new_name).to_s
 
     if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
@@ -107,5 +107,9 @@ class AttachmentsController < ProjectScopedController
     rescue
       redirect_to root_path, alert: 'Node not found'
     end
+  end
+
+  def attachment_params
+    params.require(:attachment).permit(:filename)
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -12,7 +12,7 @@ class AttachmentsController < ProjectScopedController
   # Create a new attachment for a give :node_id using a file that has been
   # submitted using an HTML form POST request.
   def create
-    uploaded_file = params.fetch('attachment_file', params.fetch('files', []).first)
+    uploaded_file = params.fetch(:attachment_file, params.fetch(:files, []).first)
 
     attachment_name = Attachment.available_name(@node, original: uploaded_file.original_filename)
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -39,7 +39,7 @@
 #   attachment = Attachment.new("images/my_image.gif", :node_id => 1)
 #
 # This will create an instance of an attachment that belongs to node with ID = 0
-# Nothing has bee saved yet
+# Nothing has been saved yet
 #
 #   attachment.save
 #

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -160,7 +160,7 @@ class Attachment < File
       # The original name is taken, so we'll add the "_copy-XX." suffix
       extension = File.extname(original)
       basename  = File.basename(original, extension)
-      sequence  = Dir.glob(attachments_pwd.join("#{basename}_copy-*#{extension}")).collect { |a| a.match(/_copy-([0-9]+)#{extension}\z/)[1].to_i }.max || 0
+      sequence  = Dir.glob(attachments_pwd.join("#{basename}_copy-*#{extension}")).map { |a| a.match(/_copy-([0-9]+)#{extension}\z/)[1].to_i }.max || 0
       "%s_copy-%02i%s" % [basename, sequence + 1, extension]
     else
       original

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -148,6 +148,25 @@ class Attachment < File
     AttachmentPwd
   end
 
+  # Obtain a suitable attachment name for a recently uploaded file. If the
+  # original file name is still available, use it, otherwise, provide count-based
+  # an alternative.
+  def self.available_name(node, args={})
+    original = args.fetch(:original)
+
+    if node.attachments.map(&:filename).include?(original)
+      attachments_pwd = Attachment.pwd.join(node.id.to_s)
+
+      # The original name is taken, so we'll add the "_copy-XX." suffix
+      extension = File.extname(original)
+      basename  = File.basename(original, extension)
+      sequence  = Dir.glob(attachments_pwd.join("#{basename}_copy-*#{extension}")).collect { |a| a.match(/_copy-([0-9]+)#{extension}\z/)[1].to_i }.max || 0
+      "%s_copy-%02i%s" % [basename, sequence + 1, extension]
+    else
+      original
+    end
+  end
+
   # -- Instance Methods  ------------------------------------------------------
 
   attr_accessor :filename, :node_id, :tempfile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,8 +51,8 @@ Rails.application.routes.draw do
       resources :revisions, only: [:index, :show]
     end
 
-    constraints(:id => /.*/) do
-      resources :attachments
+    constraints(:filename => /.*/) do
+      resources :attachments, param: :filename
     end
   end
 

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -44,7 +44,7 @@ module Dradis::CE::API
 
         begin
           new_name    = CGI::unescape(params[:attachment][:filename])
-          destination = Attachment.pwd.join(@node.id, new_name).to_s
+          destination = Attachment.pwd.join(@node.id.to_s, new_name).to_s
 
           if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
             File.rename attachment.fullpath, destination

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -18,7 +18,7 @@ module Dradis::CE::API
       end
 
       def create
-        uploaded_files = params.fetch('files', [])
+        uploaded_files = params.fetch(:files, [])
 
         @attachments = []
         uploaded_files.each do |uploaded_file|

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -14,7 +14,7 @@ module Dradis::CE::API
         begin
           @attachment = Attachment.find(filename, conditions: { node_id: @node.id } )
         rescue
-          raise ActiveRecord::RecordNotFound, "Couldn't find attachment with id '#{params[:filename]}'"
+          raise ActiveRecord::RecordNotFound, "Couldn't find attachment with filename '#{params[:filename]}'"
         end
       end
 

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -44,7 +44,7 @@ module Dradis::CE::API
 
         begin
           new_name    = CGI::unescape(params[:attachment][:filename])
-          destination = Attachment.pwd.join(params[:node_id], new_name).to_s
+          destination = Attachment.pwd.join(@node.id, new_name).to_s
 
           if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
             File.rename attachment.fullpath, destination

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -43,7 +43,7 @@ module Dradis::CE::API
         attachment.close
 
         begin
-          new_name    = CGI::unescape(params[:attachment][:filename])
+          new_name    = CGI::unescape(attachment_params[:filename])
           destination = Attachment.pwd.join(@node.id.to_s, new_name).to_s
 
           if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
@@ -72,7 +72,7 @@ module Dradis::CE::API
       end
 
       def attachment_params
-        params.require(:files).permit()
+        params.require(:attachment).permit(:filename)
       end
     end
   end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -10,9 +10,8 @@ module Dradis::CE::API
       end
 
       def show
-        filename = params[:filename]
         begin
-          @attachment = Attachment.find(filename, conditions: { node_id: @node.id } )
+          @attachment = Attachment.find(params[:filename], conditions: { node_id: @node.id } )
         rescue
           raise ActiveRecord::RecordNotFound, "Couldn't find attachment with filename '#{params[:filename]}'"
         end
@@ -40,8 +39,7 @@ module Dradis::CE::API
       end
 
       def update
-        filename    = params[:filename]
-        attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
+        attachment  = Attachment.find(params[:filename], conditions: { node_id: @node.id } )
         attachment.close
 
         begin
@@ -61,9 +59,7 @@ module Dradis::CE::API
       end
 
       def destroy
-        filename = params[:filename]
-
-        @attachment = Attachment.find(filename, conditions: { node_id: @node.id} )
+        @attachment = Attachment.find(params[:filename], conditions: { node_id: @node.id} )
         @attachment.delete
 
         render_successful_destroy_message

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -1,0 +1,101 @@
+module Dradis::CE::API
+  module V1
+    class AttachmentsController < Dradis::CE::API::V1::ProjectScopedController
+      before_action :set_node
+
+      skip_before_action :json_required, :only => [:create]
+
+      def index
+        @attachments = @node.attachments.each(&:close)
+      end
+
+      def show
+        filename = params[:id]
+        begin
+          @attachment = Attachment.find(filename, conditions: { node_id: @node.id } )
+        rescue
+          raise ActiveRecord::RecordNotFound, "Couldn't find attachment with id '#{params[:id]}'"
+        end
+      end
+
+      def create
+        uploaded_files = params.fetch('files', [])
+
+        @attachments = []
+        uploaded_files.each do |uploaded_file|
+          attachment_name = get_name(original: uploaded_file.original_filename)
+
+          attachment = Attachment.new(attachment_name, node_id: @node.id)
+          attachment << uploaded_file.read
+          attachment.save
+
+          @attachments << attachment
+        end
+
+        if @attachments.any? && @attachments.count == uploaded_files.count
+          render status: 201
+        else
+          render status: 422
+        end
+      end
+
+      def update
+        filename    = params[:id]
+        attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
+        attachment.close
+
+        begin
+          new_name    = CGI::unescape(params[:attachment][:filename])
+          destination = Attachment.pwd.join(params[:node_id], new_name).to_s
+
+          if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
+            File.rename attachment.fullpath, destination
+            @attachment = Attachment.find(new_name, conditions: { node_id: @node.id } )
+          end
+        rescue
+          @attachment = attachment
+          render status: 422
+        end
+      end
+
+      def destroy
+        filename = params[:id]
+
+        @attachment = Attachment.find(filename, conditions: { node_id: @node.id} )
+        @attachment.delete
+        
+        render_successful_destroy_message
+      end
+
+      private
+
+      def set_node
+        @node = Node.find(params[:node_id])
+      end
+
+      def attachment_params
+        params.require(:files).permit()
+      end
+
+      # Obtain a suitable attachment name for the recently uploaded file. If the
+      # original file name is still available, use it, otherwise, provide count-based
+      # an alternative.
+      def get_name(args={})
+        original = args.fetch(:original)
+
+        if @node.attachments.map(&:filename).include?(original)
+          attachments_pwd = Attachment.pwd.join(@node.id.to_s)
+
+          # The original name is taken, so we'll add the "_copy-XX." suffix
+          extension = File.extname(original)
+          basename  = File.basename(original, extension)
+          sequence  = Dir.glob(attachments_pwd.join("#{basename}_copy-*#{extension}")).collect { |a| a.match(/_copy-([0-9]+)#{extension}\z/)[1].to_i }.max || 0
+          "%s_copy-%02i%s" % [basename, sequence + 1, extension]
+        else
+          original
+        end
+      end
+
+    end
+  end
+end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -43,7 +43,7 @@ module Dradis::CE::API
         filename    = params[:filename]
         attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
         attachment.close
-
+        
         begin
           new_name    = CGI::unescape(params[:attachment][:filename])
           destination = Attachment.pwd.join(params[:node_id], new_name).to_s
@@ -51,6 +51,8 @@ module Dradis::CE::API
           if !File.exist?(destination) && !destination.match(/^#{Attachment.pwd}/).nil?
             File.rename attachment.fullpath, destination
             @attachment = Attachment.find(new_name, conditions: { node_id: @node.id } )
+          else
+            raise "Destination file already exists"
           end
         rescue
           @attachment = attachment

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/attachments_controller.rb
@@ -10,11 +10,11 @@ module Dradis::CE::API
       end
 
       def show
-        filename = params[:id]
+        filename = params[:filename]
         begin
           @attachment = Attachment.find(filename, conditions: { node_id: @node.id } )
         rescue
-          raise ActiveRecord::RecordNotFound, "Couldn't find attachment with id '#{params[:id]}'"
+          raise ActiveRecord::RecordNotFound, "Couldn't find attachment with id '#{params[:filename]}'"
         end
       end
 
@@ -40,7 +40,7 @@ module Dradis::CE::API
       end
 
       def update
-        filename    = params[:id]
+        filename    = params[:filename]
         attachment  = Attachment.find(filename, conditions: { node_id: @node.id } )
         attachment.close
 
@@ -59,11 +59,11 @@ module Dradis::CE::API
       end
 
       def destroy
-        filename = params[:id]
+        filename = params[:filename]
 
         @attachment = Attachment.find(filename, conditions: { node_id: @node.id} )
         @attachment.delete
-        
+
         render_successful_destroy_message
       end
 

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/_attachment.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/_attachment.json.jbuilder
@@ -1,0 +1,2 @@
+json.filename attachment.filename
+json.link main_app.node_attachment_path(@node, attachment.filename)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/create.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @attachments, partial: 'attachment', as: :attachment

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/index.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @attachments, partial: 'attachment', as: :attachment

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/show.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'attachment', attachment: @attachment

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/update.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/attachments/update.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'attachment', attachment: @attachment

--- a/engines/dradis-api/config/routes.rb
+++ b/engines/dradis-api/config/routes.rb
@@ -6,6 +6,9 @@ Dradis::CE::API::Engine::routes.draw do
         resources :nodes do
           resources :evidence
           resources :notes
+          constraints(:id => /.*/) do
+            resources :attachments
+          end
         end
       end
     end

--- a/engines/dradis-api/config/routes.rb
+++ b/engines/dradis-api/config/routes.rb
@@ -7,7 +7,7 @@ Dradis::CE::API::Engine::routes.draw do
           resources :evidence
           resources :notes
           constraints(:id => /.*/) do
-            resources :attachments
+            resources :attachments, param: :filename
           end
         end
       end

--- a/engines/dradis-api/config/routes.rb
+++ b/engines/dradis-api/config/routes.rb
@@ -6,7 +6,7 @@ Dradis::CE::API::Engine::routes.draw do
         resources :nodes do
           resources :evidence
           resources :notes
-          constraints(:id => /.*/) do
+          constraints(:filename => /.*/) do
             resources :attachments, param: :filename
           end
         end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -1,0 +1,303 @@
+require 'spec_helper'
+
+describe "Attachments API" do
+
+  include_context "project scoped API"
+  include_context "https"
+
+  let(:node) { create(:node) }
+
+  context "as unauthenticated user" do
+    describe "GET /api/nodes/:node_id/attachments" do
+      it "throws 401" do
+        get "/api/nodes/#{node.id}/attachments", env: @env
+        expect(response.status).to eq 401
+      end
+    end
+    describe "GET /api/nodes/:node_id/attachments/:id" do
+      it "throws 401" do
+        get "/api/nodes/#{node.id}/attachments/image.jpg", env: @env
+        expect(response.status).to eq 401
+      end
+    end
+    describe "POST /api/nodes/:node_id/attachments" do
+      it "throws 401" do
+        post "/api/nodes/#{node.id}/attachments", env: @env
+        expect(response.status).to eq 401
+      end
+    end
+    describe "PUT /api/nodes/:node_id/attachments/:id" do
+      it "throws 401" do
+        put "/api/nodes/#{node.id}/attachments/image.jpg", env: @env
+        expect(response.status).to eq 401
+      end
+    end
+    describe "DELETE /api/nodes/:node_id/attachments/:id" do
+      it "throws 401" do
+        delete "/api/nodes/#{node.id}/attachments/image.jpg", env: @env
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
+  context "as authenticated user" do
+    include_context "authenticated API user"
+
+    include AttachmentsHelper
+
+    after do
+      FileUtils.rm_rf(Attachment.pwd.join(node.id.to_s))
+    end
+
+    describe "GET /api/nodes/:node_id/attachments" do
+      before do
+        @attachments = ["image0.png", "image1.png", "image2.png"]
+        @attachments.each do |attachment|
+          upload(attachment, node)
+        end
+
+        # an attachment in another node
+        upload("image3.png", create(:node))
+
+        get "/api/nodes/#{node.id}/attachments", env: @env
+      end
+
+      let(:retrieved_attachments) { JSON.parse(response.body) }
+
+      it "responds with HTTP code 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "retrieves all the attachments for the given node" do
+        expect(retrieved_attachments.count).to eq @attachments.count
+        retrieved_filenames = retrieved_attachments.map{ |json| json['filename'] }
+        expect(retrieved_filenames).to match_array(@attachments)
+      end
+
+      it "returns JSON information about attachments" do
+        attachment_0 = retrieved_attachments.detect { |n| n["filename"] == "image0.png" }
+        attachment_1 = retrieved_attachments.detect { |n| n["filename"] == "image1.png" }
+        attachment_2 = retrieved_attachments.detect { |n| n["filename"] == "image2.png" }
+
+        expect(attachment_0.keys).to match_array %w[filename link]
+        expect(attachment_0["filename"]).to eq "image0.png"
+        expect(attachment_0["link"]).to eq "/nodes/#{node.id}/attachments/image0.png"
+        expect(attachment_1.keys).to match_array %w[filename link]
+        expect(attachment_1["filename"]).to eq "image1.png"
+        expect(attachment_1["link"]).to eq "/nodes/#{node.id}/attachments/image1.png"
+        expect(attachment_2.keys).to match_array %w[filename link]
+        expect(attachment_2["filename"]).to eq "image2.png"
+        expect(attachment_2["link"]).to eq "/nodes/#{node.id}/attachments/image2.png"
+      end
+
+      it "doesn't return attachments from other nodes" do
+        expect(retrieved_attachments.map{ |json| json['filename'] }).not_to include "image3.png"
+      end
+    end
+
+    describe "GET /api/nodes/:node_id/attachments/:id" do
+      before do
+        upload("image.png", node)
+
+        get "/api/nodes/#{node.id}/attachments/image.png", env: @env
+      end
+
+      it "responds with HTTP code 200" do
+        expect(response.status).to eq 200
+      end
+
+      it "responds with HTTP code 404 when not found" do
+        get "/api/nodes/#{node.id}/attachments/image_ko.png", env: @env
+        expect(response.status).to eq 404
+        json_response = JSON.parse(response.body)
+        expect(json_response["message"]).to eq "Couldn't find attachment with id 'image_ko.png'"
+      end
+
+      it "returns JSON information about the attachment" do
+        retrieved_attachment = JSON.parse(response.body)
+        expect(retrieved_attachment.keys).to match_array(%w[filename link])
+        expect(retrieved_attachment["filename"]).to eq "image.png"
+        expect(retrieved_attachment["link"]).to eq "/nodes/#{node.id}/attachments/image.png"
+      end
+    end
+
+    describe "POST /api/nodes/:node_id/attachments" do
+      #let(:url) { "/api/nodes/#{node.id}/attachments" }
+      let(:post_attachment) {
+        file = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
+
+        params = {files: []}
+        params[:files] << file
+
+        url = "/api/nodes/#{node.id}/attachments"
+
+        post url , params: params, env: @env
+      }
+
+      it "returns 201 when file saved" do
+        post_attachment
+        expect(response.status).to eq 201
+        expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'rails.png'))).to be true
+      end
+
+      it "returns 422 when no file saved" do
+        url = "/api/nodes/#{node.id}/attachments"
+        post url , params: {}, env: @env
+
+        expect(response.status).to eq 422
+        expect(File.exist?(Attachment.pwd.join(node.id.to_s))).to be false
+      end
+
+      it "auto-renames the upload if an attachment with the same name already exists" do
+        node_attachments = Attachment.pwd.join(node.id.to_s)
+        FileUtils.mkdir_p( node_attachments )
+
+        upload("rails.png", node)
+        expect(Dir["#{node_attachments}/*"].count).to eq(1)
+
+        post_attachment
+
+        expect(Dir["#{node_attachments}/*"].count).to eq(2)
+      end
+
+      it "returns JSON information about the attachments" do
+        file1 = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
+        file2 = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
+
+        params = {files: []}
+        params[:files] << file1 << file2
+
+        url = "/api/nodes/#{node.id}/attachments"
+
+        post url , params: params, env: @env
+
+        retrieved_attachments = JSON.parse(response.body)
+
+        attachment_0 = retrieved_attachments.detect { |n| n["filename"] == "rails.png" }
+        attachment_1 = retrieved_attachments.detect { |n| n["filename"] == "rails_copy-01.png" }
+
+        expect(attachment_0.keys).to match_array %w[filename link]
+        expect(attachment_0["filename"]).to eq "rails.png"
+        expect(attachment_0["link"]).to eq "/nodes/#{node.id}/attachments/rails.png"
+        expect(attachment_1.keys).to match_array %w[filename link]
+        expect(attachment_1["filename"]).to eq "rails_copy-01.png"
+        expect(attachment_1["link"]).to eq "/nodes/#{node.id}/attachments/rails_copy-01.png"
+      end
+    end
+
+    describe "PUT /api/nodes/:node_id/attachments/:id" do
+      before do
+        upload("image.png", node)
+      end
+
+      let(:url) { "/api/nodes/#{node.id}/attachments/image.png" }
+      let(:put_attachment) { put url, params: params.to_json, env: @env }
+
+      context "when content_type header = application/json" do
+        include_context "content_type: application/json"
+
+        context "with params for a valid attachment" do
+          let(:params) { { attachment: { filename: "image_renamed.png" } } }
+
+          it "responds with HTTP code 200 if attachment exists" do
+            put_attachment
+            expect(response.status).to eq 200
+          end
+
+          it "responds with HTTP code 404 if attachemnt doesn't exist" do
+            bad_url = "/api/nodes/#{node.id}/attachments/image_ko.png"
+            put bad_url, params: params, env: @env
+            expect(response.status).to eq(400)
+          end
+
+          it "updates the attachment" do
+            put_attachment
+
+            expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'image.png'))).to be false
+            expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'image_renamed.png'))).to be true
+          end
+
+          it "returns the attributes of the updated attachment as JSON" do
+            put_attachment
+            retrieved_attachment = JSON.parse(response.body)
+            expect(retrieved_attachment["filename"]).to eq "image_renamed.png"
+          end
+        end
+
+        context "with params for an invalid attachment" do
+          let(:params) { { attachment: { filename: "a"*65536 } } } # too long
+
+          it "responds with HTTP code 422" do
+            put_attachment
+            expect(response.status).to eq 422
+          end
+
+          it "doesn't update the attachment" do
+            put_attachment
+            expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'image.png'))).to be true
+            expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'image_renamed.png'))).to be false
+          end
+        end
+
+        context "when no :attachment param is sent" do
+          let(:params) { {} }
+
+          it "doesn't update the attachment" do
+            put_attachment
+            expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'image.png'))).to be true
+          end
+
+          it "responds with HTTP code 422" do
+            put_attachment
+            expect(response.status).to eq 422
+          end
+        end
+
+        context "when invalid JSON is sent" do
+          it "responds with HTTP code 400" do
+            json_payload = '{"attachment":{"filename":"A malformed label", , }}'
+            put url, params: json_payload, env: @env
+            expect(response.status).to eq(400)
+          end
+        end
+      end
+
+      context "when JSON is not sent" do
+        let(:params) { { attachment: { filename: "image_renamed.jpg" } } }
+
+        it "responds with HTTP code 415" do
+          put url, params: params, env: @env
+          expect(File.exist?(Attachment.pwd.join(node.id.to_s, 'image.png'))).to be true
+          expect(response.status).to eq 415
+        end
+      end
+    end
+
+    describe "DELETE /api/nodes/:node_id/attachments/:id" do
+      let(:attachment) { "image.png" }
+
+      let(:delete_attachment) do
+        upload(attachment, node)
+        delete "/api/nodes/#{node.id}/attachments/#{attachment}", env: @env
+      end
+
+      it "deletes the attachment" do
+        delete_attachment
+        expect(File.exist?(Attachment.pwd.join(node.id.to_s, attachment))).to\
+         be false
+      end
+
+      it "responds with error code 200" do
+        delete_attachment
+        expect(response.status).to eq(200)
+      end
+
+      it "returns JSON with a success message" do
+        delete_attachment
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["message"]).to eq\
+          "Resource deleted successfully"
+      end
+    end
+  end
+end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -125,7 +125,7 @@ describe "Attachments API" do
     describe "POST /api/nodes/:node_id/attachments" do
       let(:post_attachment) {
         file = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
-        params = {files: [file]}
+        params = { files: [file] }
         url = "/api/nodes/#{node.id}/attachments"
 
         post url , params: params, env: @env
@@ -160,7 +160,7 @@ describe "Attachments API" do
       it "returns JSON information about the attachments" do
         file1 = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
         file2 = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
-        params = {files: [file1, file2]}
+        params = { files: [file1, file2] }
         url = "/api/nodes/#{node.id}/attachments"
 
         post url , params: params, env: @env

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -73,19 +73,13 @@ describe "Attachments API" do
       end
 
       it "returns JSON information about attachments" do
-        attachment_0 = retrieved_attachments.detect { |n| n["filename"] == "image0.png" }
-        attachment_1 = retrieved_attachments.detect { |n| n["filename"] == "image1.png" }
-        attachment_2 = retrieved_attachments.detect { |n| n["filename"] == "image2.png" }
-
-        expect(attachment_0.keys).to match_array %w[filename link]
-        expect(attachment_0["filename"]).to eq "image0.png"
-        expect(attachment_0["link"]).to eq "/nodes/#{node.id}/attachments/image0.png"
-        expect(attachment_1.keys).to match_array %w[filename link]
-        expect(attachment_1["filename"]).to eq "image1.png"
-        expect(attachment_1["link"]).to eq "/nodes/#{node.id}/attachments/image1.png"
-        expect(attachment_2.keys).to match_array %w[filename link]
-        expect(attachment_2["filename"]).to eq "image2.png"
-        expect(attachment_2["link"]).to eq "/nodes/#{node.id}/attachments/image2.png"
+        expect(retrieved_attachments).to eq(
+         [
+           {"filename" => "image0.png", "link" => "/nodes/#{node.id}/attachments/image0.png"},
+           {"filename" => "image1.png", "link" => "/nodes/#{node.id}/attachments/image1.png"},
+           {"filename" => "image2.png", "link" => "/nodes/#{node.id}/attachments/image2.png"},
+         ]
+        )
       end
 
       it "doesn't return attachments from other nodes" do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -14,7 +14,7 @@ describe "Attachments API" do
         expect(response.status).to eq 401
       end
     end
-    describe "GET /api/nodes/:node_id/attachments/:id" do
+    describe "GET /api/nodes/:node_id/attachments/:filename" do
       it "throws 401" do
         get "/api/nodes/#{node.id}/attachments/image.jpg", env: @env
         expect(response.status).to eq 401
@@ -26,13 +26,13 @@ describe "Attachments API" do
         expect(response.status).to eq 401
       end
     end
-    describe "PUT /api/nodes/:node_id/attachments/:id" do
+    describe "PUT /api/nodes/:node_id/attachments/:filename" do
       it "throws 401" do
         put "/api/nodes/#{node.id}/attachments/image.jpg", env: @env
         expect(response.status).to eq 401
       end
     end
-    describe "DELETE /api/nodes/:node_id/attachments/:id" do
+    describe "DELETE /api/nodes/:node_id/attachments/:filename" do
       it "throws 401" do
         delete "/api/nodes/#{node.id}/attachments/image.jpg", env: @env
         expect(response.status).to eq 401
@@ -93,7 +93,7 @@ describe "Attachments API" do
       end
     end
 
-    describe "GET /api/nodes/:node_id/attachments/:id" do
+    describe "GET /api/nodes/:node_id/attachments/:filename" do
       before do
         create(:attachment, filename: "image.png", node: node)
 
@@ -182,7 +182,7 @@ describe "Attachments API" do
       end
     end
 
-    describe "PUT /api/nodes/:node_id/attachments/:id" do
+    describe "PUT /api/nodes/:node_id/attachments/:filename" do
       before do
         create(:attachment, filename: "image.png", node: node)
       end
@@ -270,7 +270,7 @@ describe "Attachments API" do
       end
     end
 
-    describe "DELETE /api/nodes/:node_id/attachments/:id" do
+    describe "DELETE /api/nodes/:node_id/attachments/:filename" do
       let(:attachment) { "image.png" }
 
       let(:delete_attachment) do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -220,12 +220,12 @@ describe "Attachments API" do
             expect(retrieved_attachment["filename"]).to eq "image_renamed.png"
           end
 
-          it "responds with HTTP code 422 if attachemnt already exists" do
+          it "responds with HTTP code 422 if attachment already exists" do
             create(:attachment, filename: "image_renamed.png", node: node)
             put_attachment
             expect(response.status).to eq(422)
             retrieved_attachment = JSON.parse(response.body)
-            expect(retrieved_attachment["filename"]).to eq "image_renamed.png"
+            expect(retrieved_attachment["filename"]).to eq "image.png"
           end
         end
 

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -116,10 +116,7 @@ describe "Attachments API" do
     describe "POST /api/nodes/:node_id/attachments" do
       let(:post_attachment) {
         file = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
-
-        params = {files: []}
-        params[:files] << file
-
+        params = {files: [file]}
         url = "/api/nodes/#{node.id}/attachments"
 
         post url , params: params, env: @env
@@ -154,10 +151,7 @@ describe "Attachments API" do
       it "returns JSON information about the attachments" do
         file1 = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
         file2 = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
-
-        params = {files: []}
-        params[:files] << file1 << file2
-
+        params = {files: [file1, file2]}
         url = "/api/nodes/#{node.id}/attachments"
 
         post url , params: params, env: @env

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -108,7 +108,7 @@ describe "Attachments API" do
         get "/api/nodes/#{node.id}/attachments/image_ko.png", env: @env
         expect(response.status).to eq 404
         json_response = JSON.parse(response.body)
-        expect(json_response["message"]).to eq "Couldn't find attachment with id 'image_ko.png'"
+        expect(json_response["message"]).to eq "Couldn't find attachment with filename 'image_ko.png'"
       end
 
       it "returns JSON information about the attachment" do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -219,6 +219,14 @@ describe "Attachments API" do
             retrieved_attachment = JSON.parse(response.body)
             expect(retrieved_attachment["filename"]).to eq "image_renamed.png"
           end
+
+          it "responds with HTTP code 422 if attachemnt already exists" do
+            create(:attachment, filename: "image_renamed.png", node: node)
+            put_attachment
+            expect(response.status).to eq(422)
+            retrieved_attachment = JSON.parse(response.body)
+            expect(retrieved_attachment["filename"]).to eq "image_renamed.png"
+          end
         end
 
         context "with params for an invalid attachment" do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -43,8 +43,6 @@ describe "Attachments API" do
   context "as authenticated user" do
     include_context "authenticated API user"
 
-    include AttachmentsHelper
-
     after do
       FileUtils.rm_rf(Attachment.pwd.join(node.id.to_s))
     end
@@ -53,11 +51,11 @@ describe "Attachments API" do
       before do
         @attachments = ["image0.png", "image1.png", "image2.png"]
         @attachments.each do |attachment|
-          upload(attachment, node)
+          create(:attachment, filename: attachment, node: node)
         end
 
         # an attachment in another node
-        upload("image3.png", create(:node))
+        create(:attachment, filename: "image3.png", node: create(:node))
 
         get "/api/nodes/#{node.id}/attachments", env: @env
       end
@@ -97,7 +95,7 @@ describe "Attachments API" do
 
     describe "GET /api/nodes/:node_id/attachments/:id" do
       before do
-        upload("image.png", node)
+        create(:attachment, filename: "image.png", node: node)
 
         get "/api/nodes/#{node.id}/attachments/image.png", env: @env
       end
@@ -122,7 +120,6 @@ describe "Attachments API" do
     end
 
     describe "POST /api/nodes/:node_id/attachments" do
-      #let(:url) { "/api/nodes/#{node.id}/attachments" }
       let(:post_attachment) {
         file = fixture_file_upload(Rails.root.join('spec/fixtures/files/rails.png'))
 
@@ -152,7 +149,7 @@ describe "Attachments API" do
         node_attachments = Attachment.pwd.join(node.id.to_s)
         FileUtils.mkdir_p( node_attachments )
 
-        upload("rails.png", node)
+        create(:attachment, filename: "rails.png", node: node)
         expect(Dir["#{node_attachments}/*"].count).to eq(1)
 
         post_attachment
@@ -187,7 +184,7 @@ describe "Attachments API" do
 
     describe "PUT /api/nodes/:node_id/attachments/:id" do
       before do
-        upload("image.png", node)
+        create(:attachment, filename: "image.png", node: node)
       end
 
       let(:url) { "/api/nodes/#{node.id}/attachments/image.png" }
@@ -277,7 +274,7 @@ describe "Attachments API" do
       let(:attachment) { "image.png" }
 
       let(:delete_attachment) do
-        upload(attachment, node)
+        create(:attachment, filename: attachment, node: node)
         delete "/api/nodes/#{node.id}/attachments/#{attachment}", env: @env
       end
 

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -73,13 +73,22 @@ describe "Attachments API" do
       end
 
       it "returns JSON information about attachments" do
-        expect(retrieved_attachments).to eq(
-         [
-           {"filename" => "image0.png", "link" => "/nodes/#{node.id}/attachments/image0.png"},
-           {"filename" => "image1.png", "link" => "/nodes/#{node.id}/attachments/image1.png"},
-           {"filename" => "image2.png", "link" => "/nodes/#{node.id}/attachments/image2.png"},
-         ]
-        )
+        attachment_0 = retrieved_attachments.detect { |n| n["filename"] == "image0.png" }
+        attachment_1 = retrieved_attachments.detect { |n| n["filename"] == "image1.png" }
+        attachment_2 = retrieved_attachments.detect { |n| n["filename"] == "image2.png" }
+
+        expect(attachment_0).to eq({
+          "filename" => "image0.png",
+          "link" => "/nodes/#{node.id}/attachments/image0.png"
+        })
+        expect(attachment_1).to eq({
+          "filename" => "image1.png",
+          "link" => "/nodes/#{node.id}/attachments/image1.png"
+        })
+        expect(attachment_2).to eq({
+          "filename" => "image2.png",
+          "link" => "/nodes/#{node.id}/attachments/image2.png"
+        })
       end
 
       it "doesn't return attachments from other nodes" do

--- a/engines/dradis-api/spec/support/attachments_helper.rb
+++ b/engines/dradis-api/spec/support/attachments_helper.rb
@@ -1,0 +1,9 @@
+module AttachmentsHelper
+  # Simulate a file upload by copying a file already present in our
+  # file tree (fixtures folder) to that node attachments folder
+  def upload(name, node)
+    FileUtils.mkdir_p Attachment.pwd.join(node.id.to_s).to_s
+    FileUtils.cp Rails.root.join("spec/fixtures/files/rails.png").to_s,
+                 Attachment.pwd.join(node.id.to_s, name).to_s
+  end
+end

--- a/engines/dradis-api/spec/support/attachments_helper.rb
+++ b/engines/dradis-api/spec/support/attachments_helper.rb
@@ -1,9 +1,0 @@
-module AttachmentsHelper
-  # Simulate a file upload by copying a file already present in our
-  # file tree (fixtures folder) to that node attachments folder
-  def upload(name, node)
-    FileUtils.mkdir_p Attachment.pwd.join(node.id.to_s).to_s
-    FileUtils.cp Rails.root.join("spec/fixtures/files/rails.png").to_s,
-                 Attachment.pwd.join(node.id.to_s, name).to_s
-  end
-end

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :attachment do
     skip_create
-    
+
     sequence(:filename) { |n| "image#{n}.png" }
-    node { Node.issue_library }
+    node
 
     initialize_with {
       FileUtils.mkdir_p Attachment.pwd.join(node.id.to_s).to_s

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :attachment do
+    skip_create
+    
+    sequence(:filename) { |n| "image#{n}.png" }
+    node { Node.issue_library }
+
+    initialize_with {
+      FileUtils.mkdir_p Attachment.pwd.join(node.id.to_s).to_s
+      FileUtils.cp Rails.root.join("spec/fixtures/files/rails.png").to_s,
+                   Attachment.pwd.join(node.id.to_s, filename).to_s
+      Attachment.find(filename, conditions: { node_id: node.id } )
+    }
+  end
+end


### PR DESCRIPTION
Adding endpoints to the API to manage attachments.

[Trello Card](https://trello.com/c/F0CaIWJQ/267-1-when-using-the-api-i-want-to-have-endpoints-that-allow-handling-attachments-so-i-can-perform-basic-crud-operations-with-attach)