### PR TITLE
Use the new visual style for the attachment list

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -94,7 +94,7 @@ class AttachmentsController < ProjectScopedController
     @attachment = Attachment.find(filename, conditions: { node_id: @node.id} )
     @attachment.delete
     
-    render json: { success: true }
+    redirect_to node_path(@node), notice: 'Attachment deleted'
   end
 
   private

--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -7,44 +7,48 @@
     </div>
   </div>
 
+  <div id="attachments" class="note-list">
+    <% if node.attachments.any? %>
+
+      <% node.attachments.each do |attachment| %>
+        <div class="list-item">
+          <div class="expansion-container">
+            <%= link_to node_attachment_path(node, attachment.filename, download: attachment.filename) do %>
+              <i class="fa fa-paperclip"></i> <%= short_filename(attachment.filename) %>
+            <% end %>
+          </div>
+          <div class="list-item-actions">
+            <small><%= number_to_human_size(File.size(attachment)) %></small>
+
+            <%= link_to node_attachment_path(node, attachment.filename),
+                  method: :delete,
+                  data: { confirm: 'Are you sure?' },
+                  class: 'list-item-action-delete' do %>
+              <i class="fa fa-trash"></i> Delete
+            <% end %>
+
+            <%= link_to 'javascript:void(0)',
+                  data: {
+                    clipboard_text: "!#{node_attachment_path(node, attachment.filename)}!"
+                  },
+                  class: 'js-attachment-url-copy' do %><i class="fa fa-link"></i> Link<% end %>
+          </div>
+        </div>
+      <% end %>
+
+    <% else %>
+      <div class="list-item">
+        <div class="note placeholder">(nothing yet)</div>
+      </div>
+    <% end %>
+  </div>
+
+
   <!-- The table listing the files available for upload/download -->
   <table class="table">
     <tbody class="files" data-toggle="modal-gallery" data-target="#modal-gallery">
       <% if node.attachments.any? %>
-        <% for attachment in node.attachments do %>
-      <tr class="template-download">
-        <td class="name" colspan="4">
-          <div>
-            <%= link_to node_attachment_path(node, attachment.filename), download: attachment.filename, title: attachment.filename do %>
-            <i class="fa fa-paperclip"></i> <%= short_filename(attachment.filename) %>
-            <% end %>
 
-            <div class="text-right">
-              <span class="size">
-                <small><%= number_to_human_size(File.size(attachment)) %></small>
-              </span>
-
-              <span class="delete">
-                <button
-                  class="btn btn-transparent btn-danger"
-                  data-type="DELETE"
-                  data-url="<%= node_attachment_path(node,attachment.filename) %>"
-                >
-                  <i class="fa fa-trash"></i>
-                </button>
-              </span>
-
-              <button
-                class="btn btn-transparent js-attachment-url-copy"
-                data-clipboard-text="!<%= node_attachment_path(node, attachment.filename) %>!"
-              >
-                <i class="fa fa-link"></i>
-              </button>
-            </div>
-          </div>
-        </td>
-      </tr>
-        <% end %>
       <% else %>
         <%# display some sort of Nothing yet message %>
       <% end %>


### PR DESCRIPTION
Doing some unrelated testing I realised that now the Attachments are the only list in the sidebar without the :hover styling.

This screenie shows the new behaviour vs the existing one (where links are always shown):

![attachments-01](https://cloud.githubusercontent.com/assets/53006/22461991/c9a4ab24-e7ab-11e6-93af-3d656799cf49.gif)


Now this change is not as straightforward because we're using `jquery-fileupload` for the upload box, and that plugin needs / assumes that uploaded files will be rendered as a table (maybe not 100% true, but all of the code we've got at the moment assumes so).

This isn't too bad if we've got some attachments in the node and decide to drag'n'drop a few more for upload like this:

<img width="305" alt="attachments-02" src="https://cloud.githubusercontent.com/assets/53006/22461990/c9a3c06a-e7ab-11e6-94b6-f32bc10ac633.png">

However it isn't as pretty after we upload the attachments because `jquery-fileupload` takes care of re-rendering this already-uploaded attachments as rows of the table in the old style, so we'd have situation where both styles are mixed.

The video bellow shows the initial state of some new-style attachments and some recently uploaded, old-style ones coexisting. After a browser refresh, everything goes back to new-style:

![attachments-03](https://cloud.githubusercontent.com/assets/53006/22461993/c9a7bb3e-e7ab-11e6-8208-b161c7782f62.gif)


And the final piece of the puzzle is the `Nothing yet` placeholder that we use for Notes and Evidence. Because we're relying completely on `jquery-fileupload` to handle the UI refresh, we can end up with a view that shows both the `Nothing yet` message AND some recently uploaded attachments.

<img width="271" alt="attachments-04" src="https://cloud.githubusercontent.com/assets/53006/22461992/c9a6c954-e7ab-11e6-8799-1ffa73781f93.png">


So a few questions:

* Does it make sense to use the new :hover style here?
* Can we live with the quirks listed above or should we dig deeper into `jquery-fileupload` to figure everything out and make the UI smoother?