### PR TITLE
Enable code highlight via the %%{{}}%% syntax in code blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,18 +45,28 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 3.0'
 
+# ---------------------------------------------------- Dradis Community Edition
 # Organize Node tree
 gem 'acts_as_tree'
 
 gem 'builder'
 
-gem 'rails_autolink', '~> 1.1'
-gem 'thor', '~> 0.18'
+gem 'differ', '~> 0.1.2'
+
+
+# HTML processing filters and utilities
+gem 'html-pipeline'
+
+gem 'kaminari', '~> 0.16.1'
 
 gem 'paper_trail', '~> 4.0.0'
-gem 'differ', '~> 0.1.2'
-gem 'kaminari', '~> 0.16.1'
+
+# gem 'rails_autolink', '~> 1.1'
+
 gem 'record_tag_helper'
+
+gem 'thor', '~> 0.18'
+
 
 # ------------------------------------------------------ With native extensions
 # These require native extensions.
@@ -86,6 +96,9 @@ gem 'mysql2', '0.3.18'
 # the last one supported by Traveling Ruby
 # gem 'RedCloth', '4.2.9', require: 'redcloth'
 gem 'RedCloth', '4.3.1', require: 'redcloth'
+
+# html-pipeline dependency for auto-linking
+gem 'rinku'
 
 # SQLite3 DB driver
 gem 'sqlite3'#,  '1.3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 PATH
   remote: ../dradis-brakeman/
   specs:
-    dradis-brakeman (3.0.0)
+    dradis-brakeman (3.0.1)
       dradis-plugins (~> 3.2)
 
 PATH
@@ -202,6 +202,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    html-pipeline (2.5.0)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
     i18n (0.7.0)
     image_size (1.3.1)
     jbuilder (2.6.1)
@@ -324,6 +327,7 @@ GEM
       vegas (~> 0.1.2)
     resque-status (0.5.0)
       resque (~> 1.19)
+    rinku (2.0.2)
     rprogram (0.3.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -459,6 +463,7 @@ DEPENDENCIES
   font-awesome-sass (~> 4.3.0)
   foreman
   guard-rspec
+  html-pipeline
   image_size (~> 1.3.0)
   jbuilder (~> 2.5)
   jquery-fileupload-rails (~> 0.3.4)
@@ -476,12 +481,12 @@ DEPENDENCIES
   parslet (~> 1.4.0)
   poltergeist
   rails (~> 5.0.1)
-  rails_autolink (~> 1.1)
   record_tag_helper
   redis (~> 3.0)
   rerun
   resque
   resque-status
+  rinku
   rspec-rails (~> 3.1)
   sass-rails (~> 5.0)
   shoulda-matchers (~> 2.8.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,27 @@
 module ApplicationHelper # :nodoc:
   def markup(text)
-    return unless text.present?
+    # return unless text.present?
+    #
+    # output = text.dup
+    # Hash[ *text.scan(/#\[(.+?)\]#[\r|\n](.*?)(?=#\[|\z)/m).flatten.collect{ |str| str.strip } ].keys.each do |field|
+    #   output.gsub!(/#\[#{Regexp.escape(field)}\]#[\r|\n]/, "h4. #{field}\n\n")
+    # end
+    #
+    # auto_link(RedCloth.new(output, [:filter_html, :no_span_caps]).to_html, :sanitize => false ).html_safe
+    new_markup(text)
+  end
 
-    output = text.dup
-    Hash[ *text.scan(/#\[(.+?)\]#[\r|\n](.*?)(?=#\[|\z)/m).flatten.collect{ |str| str.strip } ].keys.each do |field|
-      output.gsub!(/#\[#{Regexp.escape(field)}\]#[\r|\n]/, "h4. #{field}\n\n")
-    end
+  def new_markup(text)
+    context = { }
 
-    auto_link(RedCloth.new(output, [:filter_html, :no_span_caps]).to_html, :sanitize => false ).html_safe
+    textile_pipeline = HTML::Pipeline.new [
+      HTML::Pipeline::DradisFieldableFilter,
+      HTML::Pipeline::DradisTextileFilter,
+      HTML::Pipeline::DradisCodeHighlightFilter,
+      HTML::Pipeline::AutolinkFilter
+    ], context
+
+    result = textile_pipeline.call(text)
+    result[:output].to_s.html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,17 +1,7 @@
 module ApplicationHelper # :nodoc:
   def markup(text)
-    # return unless text.present?
-    #
-    # output = text.dup
-    # Hash[ *text.scan(/#\[(.+?)\]#[\r|\n](.*?)(?=#\[|\z)/m).flatten.collect{ |str| str.strip } ].keys.each do |field|
-    #   output.gsub!(/#\[#{Regexp.escape(field)}\]#[\r|\n]/, "h4. #{field}\n\n")
-    # end
-    #
-    # auto_link(RedCloth.new(output, [:filter_html, :no_span_caps]).to_html, :sanitize => false ).html_safe
-    new_markup(text)
-  end
+    return unless text.present?
 
-  def new_markup(text)
     context = { }
 
     textile_pipeline = HTML::Pipeline.new [

--- a/lib/html/pipeline/dradis_code_highlight_filter.rb
+++ b/lib/html/pipeline/dradis_code_highlight_filter.rb
@@ -1,4 +1,3 @@
-%%{{}}%%
 module HTML
   class Pipeline
     # HTML Filter that highlights post-processed Textile code blocks.

--- a/lib/html/pipeline/dradis_code_highlight_filter.rb
+++ b/lib/html/pipeline/dradis_code_highlight_filter.rb
@@ -11,13 +11,10 @@ module HTML
       # Locate the %%{{}}%% sequence inside code blocks and highlight it (via
       # <mark> tags)
       def call
-        doc.search('code').each do |element|
-          # element.inner_html = element.text.gsub(/(https|http)?:\/\/.+\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
-          #   %|<img src="#{match}" alt=""/>|
-          # end
-          element.inner_html = element.text.gsub(/%%\{\{(.+)\}\}%%/mi) do |match|
+        doc.search('pre').each do |element|
+          element.inner_html = '<code>' + element.text.gsub(/%%\{\{(.+)\}\}%%/i) do |match|
             %|<mark>#{$1}</mark>|
-          end
+          end + '</code>'
         end
         doc
       end

--- a/lib/html/pipeline/dradis_code_highlight_filter.rb
+++ b/lib/html/pipeline/dradis_code_highlight_filter.rb
@@ -1,0 +1,26 @@
+%%{{}}%%
+module HTML
+  class Pipeline
+    # HTML Filter that highlights post-processed Textile code blocks.
+    #
+    # Context options:
+    #   n/a
+    #
+    # This filter does not write any additional information to the context hash.
+    class DradisCodeHighlightFilter < Filter
+      # Locate the %%{{}}%% sequence inside code blocks and highlight it (via
+      # <mark> tags)
+      def call
+        doc.search('code').each do |element|
+          # element.inner_html = element.text.gsub(/(https|http)?:\/\/.+\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+          #   %|<img src="#{match}" alt=""/>|
+          # end
+          element.inner_html = element.text.gsub(/%%\{\{(.+)\}\}%%/mi) do |match|
+            %|<mark>#{$1}</mark>|
+          end
+        end
+        doc
+      end
+    end
+  end
+end

--- a/lib/html/pipeline/dradis_fieldable_filter.rb
+++ b/lib/html/pipeline/dradis_fieldable_filter.rb
@@ -1,0 +1,22 @@
+module HTML
+  class Pipeline
+    # HTML Filter that converts Dradis-style field syntax into Textile headers.
+    #
+    # Context options:
+    #   n/a
+    #
+    # This filter does not write any additional information to the context hash.
+    class DradisFieldableFilter < TextFilter
+      # Convert the #[Field]# syntax into h4. headers
+      def call
+        output = @text.dup
+
+        Hash[ *@text.scan(/#\[(.+?)\]#[\r|\n](.*?)(?=#\[|\z)/m).flatten.collect{ |str| str.strip } ].keys.each do |field|
+          output.gsub!(/#\[#{Regexp.escape(field)}\]#[\r|\n]/, "h4. #{field}\n\n")
+        end
+
+        output
+      end
+    end
+  end
+end

--- a/lib/html/pipeline/dradis_textile_filter.rb
+++ b/lib/html/pipeline/dradis_textile_filter.rb
@@ -1,0 +1,34 @@
+begin
+  require "redcloth"
+rescue LoadError => _
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'RedCloth' for TextileFilter. See README.md for details."
+end
+
+module HTML
+  class Pipeline
+    # HTML Filter that converts Textile text into HTML and converts into a
+    # DocumentFragment. This is different from most filters in that it can take a
+    # non-HTML as input. It must be used as the first filter in a pipeline.
+    #
+    # Context options:
+    #   :autolink => false    Disable autolinking URLs
+    #
+    # This filter does not write any additional information to the context hash.
+    #
+    # NOTE This filter is provided for really old comments only. It probably
+    # shouldn't be used for anything new.
+    class DradisTextileFilter < TextFilter
+
+      # Convert Textile to HTML and convert into a DocumentFragment. We need to
+      # enclose everything in a root element.
+      #
+      # See:
+      #   https://github.com/jch/html-pipeline#1-why-doesnt-my-pipeline-work-when-theres-no-root-element-in-the-document
+      def call
+        '<div>' +
+        RedCloth.new(@text, [:filter_html, :no_span_caps]).to_html +
+        '</div>'
+      end
+    end
+  end
+end


### PR DESCRIPTION
The feature is implemented by splitting our old `#markup` helper in an [HTML Pipeline](https://github.com/jch/html-pipeline/) with the following filters:

1. First we convert the field syntax (e.g. `#[Title]#`) into valid Textile (i.e. 'h4.')
2. Then we process Textile
3. Then we add code-highlights to textile code blocks
4. We do auto-linking of URLs

The results:

<img width="719" alt="code-highlight-01" src="https://cloud.githubusercontent.com/assets/53006/22464313/85ad1fd6-e7b6-11e6-9f21-c2fc9ffdae5e.png">

<img width="721" alt="code-highlight-02" src="https://cloud.githubusercontent.com/assets/53006/22464314/85b1142e-e7b6-11e6-9faa-fbebf06593aa.png">
