### PR TITLE
Issues#show - scope @nodes_for_add_evidence with :user_nodes

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -15,7 +15,7 @@ class IssuesController < ProjectScopedController
 
     # We can't use the existing @nodes variable as it only contains root-level
     # nodes, and we need the auto-complete to have the full list.
-    @nodes_for_add_evidence = Node.order(:label)
+    @nodes_for_add_evidence = Node.user_nodes.order(:label)
 
     load_conflicting_revisions(@issue)
   end

--- a/spec/features/attachments_spec.rb
+++ b/spec/features/attachments_spec.rb
@@ -31,7 +31,7 @@ describe "Describe attachments" do
       expect(File.exist?(Attachment.pwd.join(@node.id.to_s, 'rails.png'))).to be true
     end
 
-    it "auto-renames the upload if an attachment with the same name already exists", focus: true do
+    it "auto-renames the upload if an attachment with the same name already exists" do
       node_attachments = Attachment.pwd.join(@node.id.to_s)
       FileUtils.rm_rf(node_attachments)
       FileUtils.mkdir_p(node_attachments)

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -305,7 +305,7 @@ describe "Issues pages" do
 
           it "filters nodes" do
             find('.js-add-evidence').click
-            expect(all('#existing-node-list label').count).to be Node.count
+            expect(all('#existing-node-list label').count).to be Node.user_nodes.count
 
             # find('#evidence_node').native.send_key('192')
             fill_in 'evidence_node', with: '192'


### PR DESCRIPTION
### Spec

At the moment we're listing all the nodes in the database as part of the "Add to existing nodes" list. This includes the "hidden" All Issues and Methodologies nodes.

If a user ticks any of these two check boxes, they're going to end in a murky place where the Issue or Methodology library is displayed as a Node, the Issues and Methodologies as notes, etc.


**Proposed solution**

When generating the list of nodes to populate the UI make sure we only include user-created nodes and not the system ones.


### How to test

1. Add 2 or 3 nodes to your project.
2. Browse to Issues > Evidence > add new and verify that only your own nodes are listed there.