### PR TITLE
jQuery.TreeModal - Use the already existing node-id in the parent :li …

### DIFF
--- a/app/assets/javascripts/snowcrash/plugins/jquery.treemodal.js.coffee
+++ b/app/assets/javascripts/snowcrash/plugins/jquery.treemodal.js.coffee
@@ -28,7 +28,7 @@ do ($ = jQuery, window, document) ->
         $nodeLink.parents(current_node_container).length > 0
 
       @isCurrentNode = ($nodeLink) ->
-        $nodeLink.data('node-id') == @$el.data('node-id')
+        $nodeLink.parent().data('node-id') == @$el.data('node-id')
 
       @$el.find("input[name='node_move_destination']").click(@selectMoveDestination)
 

--- a/app/views/layouts/snowcrash/_node.html.erb
+++ b/app/views/layouts/snowcrash/_node.html.erb
@@ -12,12 +12,12 @@
     <i class="fa fa-caret-right"></i>
   <% end %>
 
-  <a href="<%= main_app.node_path(node) %>" data-node-id="<%= node.id %>">
+  <%= link_to main_app.node_path(node) do %>
     <% if node.type_id == Node::Types::HOST %>
       <i class="fa fa-laptop"></i>
     <% end %>
     <%= node.label %>
-  </a>
+  <% end %>
 
   <% if node.children_count > 0 %>
     <%= content_tag :ul, data: {id: dom_id(node, 'menu')}, class: "children #{css_class_for_sub_nodes(node)}" do %>


### PR DESCRIPTION
### Spec

At the moment the Nodes#show breadcrumbs are broken and show the current node twice in the trail.

Breadcrumbs are calculated client-side through `jquery.breadcrums.js.coffee` and rely on the Nodes' tree structure to build the trail of ancestors of the given node. It did this by traversing the nodes tree using `<li>` item's `data-node-id` attribute.

The problem was introduced in the Move Note PR:

https://github.com/dradis/dradis-ce/commit/2d1acb046ed2a042cd95c079e7f7414b9b7a0b93

Which also added a `data-node-id` attribute to the `<a>` tag nested inside the `<li>` item.


**Proposed solution**

Instead of adding a `data-node-id` attribute to the link as well as the parent list item that it already had it, just inspect the parent's.


### How to test

1. Create a structure of nodes
2. Add a note to one of them
3. Verify that navigating the structure results in correct breadcrumb trails
4. Verify you can move around a node (but can't move onto itself)
5. Verify you can move around a note (but can't move it to the same not it currently is).
6. Verify there are no JS errors in the browser's console.