### PR TITLE
issues spec possible fix: clicking button with js instead of capybara

### DIFF
--- a/app/views/issues/merge/new.html.erb
+++ b/app/views/issues/merge/new.html.erb
@@ -85,7 +85,7 @@
       <% end %>
 
       <div class="form-actions">
-        <%= button_tag 'Merge issues', class: 'btn btn-dradispro' %> or
+        <%= button_tag 'Merge issues', id: 'merge_button', class: 'btn btn-dradispro' %> or
         <%= link_to 'Cancel', issues_path, class: 'cancel-link' %>
       </div>
     <% end %>

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -88,7 +88,8 @@ describe "Issues pages" do
           # new issue form should be visible now
           expect(page).to have_selector('#new_issue', visible: true)
 
-          click_button "Merge issues"
+          # click_button "Merge issues" (why this sometimes doesn't submit the form?)
+          page.execute_script("$('#merge_button').click()")
 
           expect(page).to have_content("2 issues merged into ")
 


### PR DESCRIPTION
My understanding is that when we choose the "merge into new issue" option, we alter the page in some way that prevents capybara from finding the form button (sometimes).
The thing was that `click_button` didn't raise an error, but the form was never submitted (sometimes).

Clicking the button with `excecute_script` I've not seen any error yet.