### PR TITLE
fix merge issues spec by disabling bootstrap transitions

### DIFF
--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -77,6 +77,8 @@ describe "Issues pages" do
         end
 
         it "merges issues into a new one" do
+          # disable bootstrap transitions
+          page.evaluate_script('$.support.transition = false')
 
           expect(page).to have_content "You're merging 2 Issues into a target Issue"
 


### PR DESCRIPTION
Still requires js.

This was just to test that transitions is our problem here.

Transitions and capybara run on different threads, sometimes we may have this race condition:
- [capybara] find "Merge issues" button, with coordinates (x1, y1)
- [phantomjs] moves button down to coordinates (x2, y2), because accordion is still performing a smooth unfolding
- [capybara] clicks on (x1, y1) (no button there!)