### PR TITLE
Nodes use acts as tree

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -14,7 +14,7 @@ class Node < ApplicationRecord
     ISSUELIB = 3
   end
 
-  acts_as_tree counter_cache: true
+  acts_as_tree counter_cache: true, order: :label
 
   # -- Relationships --------------------------------------------------------
   has_many :notes, dependent: :destroy
@@ -53,7 +53,7 @@ class Node < ApplicationRecord
 
   # -- Scopes ---------------------------------------------------------------
   scope :in_tree, -> {
-    user_nodes.where(parent_id: nil)
+    user_nodes.roots
   }
 
   scope :user_nodes, -> {
@@ -95,10 +95,6 @@ class Node < ApplicationRecord
   # -- Instance Methods -----------------------------------------------------
   def ancestor_of?(node)
     node && node.ancestors.include?(self)
-  end
-
-  def root_node?
-    parent.nil?
   end
 
   # Return all the Attachment objects associated with this Node.

--- a/app/views/activities/poll.js.erb
+++ b/app/views/activities/poll.js.erb
@@ -66,7 +66,7 @@
       <% node = activity.trackable %>
 
       <% if activity.action == "create" %>
-        <% if node.root_node? %>
+        <% if node.root? %>
           ActivitiesPoller.addRootNode(
             "<%=j render "layouts/snowcrash/node", node: node %>"
           )

--- a/app/views/layouts/snowcrash/_breadcrumb.html.erb
+++ b/app/views/layouts/snowcrash/_breadcrumb.html.erb
@@ -11,7 +11,7 @@
   <div class="span5">
     <ul class="nav nav-pills pull-right">
       <li><a href="#modal_add_child_node" tabindex="-1" data-toggle="modal"><i class="fa fa-plus"></i> Add subnode</a></li>
-      <li><a href="#modal_delete_node" tabindex="-1" data-toggle="modal"><i class="fa fa-trash"></i> Delete</a></li>
+      <li><a href="#modal_delete_node" class="text-error" tabindex="-1" data-toggle="modal"><i class="fa fa-trash"></i> Delete</a></li>
       <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
       <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
     </ul>

--- a/app/views/nodes/modals/_move.html.erb
+++ b/app/views/nodes/modals/_move.html.erb
@@ -9,7 +9,7 @@
     <div class="modal-body">
       <p>Where do you want to move the <strong><%= @node.label %></strong> node?</p>
 
-      <% unless @node.root_node? %>
+      <% unless @node.root? %>
         <div class="radio">
           <%= label_tag do %>
             <%= radio_button_tag :node_move_destination, :root %>


### PR DESCRIPTION
Make use of more `acts_as_tree` features inside `Node`, including:

* A default order by `:label`
* The `root?` / `roots` helper methods.