### PR TITLE
Fix dradis reset

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -34,7 +34,7 @@ class Category < ApplicationRecord
     if (self.id == 1)
       self.errors.add :base, 'Cannot delete Default category.'
     end
-    if Note.count(conditions: { category_id: self.id }) > 0
+    if Note.where(category_id: self.id).count > 0
       self.errors.add :base, 'Cannot delete Category with notes.'
     end
     return errors.count.zero? ? true : false


### PR DESCRIPTION
Should fix: https://github.com/dradis/dradis-ce/issues/76
Prerequisite: https://github.com/dradis/dradis-ce/pull/114

### Spec
Even after fixing on `dradis:backup` fix, the `dradis:reset` command still fails with a stack trace. 

The following sample command: 
`$ bundle exec thor dradis:reset`

fails with the following stack trace:

```
** Cleaning database...                                               /Users/xavi/.rvm/gems/ruby-2.2.2/gems/sqlite3-1.3.12/lib/sqlite3/database.rb:91:in `initialize': SQLite3::SQLException: unrecognized token: "{": SELECT COUNT({:conditions=>{:category_id=>1}}) FROM "notes" (ActiveRecord::StatementInvalid)
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/sqlite3-1.3.12/lib/sqlite3/database.rb:91:in `new'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/sqlite3-1.3.12/lib/sqlite3/database.rb:91:in `prepare'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:196:in `block in exec_query'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:193:in `exec_query'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:373:in `select'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:41:in `select_all'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:95:in `select_all'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/relation/calculations.rb:248:in `execute_simple_calculation'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/relation/calculations.rb:207:in `perform_calculation'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/relation/calculations.rb:121:in `calculate'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/relation/calculations.rb:40:in `count'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/querying.rb:13:in `count'
	from /Users/xavi/Work/ce/dradis-ce/app/models/category.rb:37:in `valid_destroy'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:382:in `block in make_lambda'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:169:in `call'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:169:in `block (2 levels) in halting'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:770:in `call'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:770:in `block (2 levels) in deprecated_false_terminator'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:769:in `catch'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:769:in `block in deprecated_false_terminator'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:170:in `call'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:170:in `block in halting'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:454:in `call'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:454:in `block in call'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:454:in `each'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:454:in `call'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:750:in `_run_destroy_callbacks'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/callbacks.rb:283:in `destroy'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/transactions.rb:314:in `block in destroy'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/transactions.rb:211:in `transaction'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/transactions.rb:314:in `destroy'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/relation.rb:467:in `each'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/relation.rb:467:in `destroy_all'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/activerecord-5.0.2/lib/active_record/querying.rb:8:in `destroy_all'
	from /Users/xavi/Work/ce/dradis-ce/lib/tasks/thorfile.rb:149:in `database'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/invocation.rb:115:in `invoke'
	from /Users/xavi/Work/ce/dradis-ce/lib/tasks/thorfile.rb:28:in `reset'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/runner.rb:44:in `method_missing'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:29:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:126:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/bin/thor:6:in `<top (required)>'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/thor:22:in `load'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/thor:22:in `<main>'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'
```


### How to test
Make sure that a command like: 
`$ bundle exec thor dradis:reset`
completes without an error.
