### PR TITLE
Minor updates to Poltergeist-related config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       thor (~> 0.18)
     byebug (9.0.6)
     cancancan (1.16.0)
-    capybara (2.14.0)
+    capybara (2.14.3)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -213,7 +213,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    rack (2.0.2)
+    rack (2.0.3)
     rack-protection (2.0.0.beta2)
       rack
     rack-test (0.6.3)
@@ -361,7 +361,7 @@ GEM
     websocket-extensions (0.1.2)
     whenever (0.9.7)
       chronic (>= 0.6.3)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -433,4 +433,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,7 +36,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 
 Capybara.register_driver :poltergeist do |app|
-  options = { js_errors: false, timeout: 30, window_size: [1920, 1080] }
+  options = { js_errors: false, timeout: 60, window_size: [1920, 1080] }
   Capybara::Poltergeist::Driver.new(app, options)
 end
 


### PR DESCRIPTION
From Codeship support:

Several things to try here.

Bundler is indicating version 1.12.0 is being used and there is a newer version, 1.15.0 available. Probably not the root problem, but maybe worth a look.

```
Using poltergeist 1.12.0
```

In the driver config what about turning up the timeout limit from 30 to maybe 60 or 90 seconds?

```
Capybara.register_driver :poltergeist do |app|
  options = { js_errors: true, timeout: 30, window_size: [1920, 1080] }
  Capybara::Poltergeist::Driver.new(app, options)
end
```

Finally, could this thread possibly help in regard to precompiling assets before tests run? https://github.com/teampoltergeist/poltergeist/issues/791#issuecomment-228814972