### PR TITLE
fix 'before_filter is deprecated' warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'html-pipeline'
 
 gem 'kaminari', '~> 1.0.1'
 
-gem 'paper_trail', '~> 4.0.0'
+gem 'paper_trail', '~> 4.2.0'
 
 # gem 'rails_autolink', '~> 1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    paper_trail (4.0.2)
+    paper_trail (4.2.0)
       activerecord (>= 3.0, < 6.0)
       activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
@@ -551,7 +551,7 @@ DEPENDENCIES
   local_time
   mysql2 (= 0.3.18)
   nokogiri (= 1.7.2)
-  paper_trail (~> 4.0.0)
+  paper_trail (~> 4.2.0)
   parslet (~> 1.4.0)
   poltergeist
   rails (~> 5.0.2)


### PR DESCRIPTION
When starting rails in local environment, we see: 
```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <top (required)> at /Users/xavi/Projects/dradis/dradis-ce/config/application.rb:16)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <top (required)> at /Users/xavi/Projects/dradis/dradis-ce/config/application.rb:16)
```

That `before_filter` was not on our code, so it must be in one of the gems. After a bit of search it happen to be `paper_trail`. 
Looks like `4.2.0` is the version that fixes the warning and keeps our tests green.