### PR TITLE
Require node parent

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -24,7 +24,7 @@ class NodesController < NestedNodeResourceController
       redirect_to @node
     else
       parent = @node.parent
-      if parent && parent.is_user_node
+      if parent && parent.user_node?
         redirect_to parent, alert: @node.errors.full_messages.join('; ')
       else
         redirect_to summary_path, alert: @node.errors.full_messages.join('; ')

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -24,7 +24,7 @@ class NodesController < NestedNodeResourceController
       redirect_to @node
     else
       parent = @node.parent
-      if parent
+      if parent && parent.is_user_node
         redirect_to parent, alert: @node.errors.full_messages.join('; ')
       else
         redirect_to summary_path, alert: @node.errors.full_messages.join('; ')

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -51,6 +51,7 @@ class Node < ApplicationRecord
 
   # -- Validations ----------------------------------------------------------
   validates_presence_of :label
+  validates_presence_of :parent, if: Proc.new { |node| node.parent_id }
 
   # -- Scopes ---------------------------------------------------------------
   scope :in_tree, -> {

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -12,6 +12,7 @@ class Node < ApplicationRecord
     HOST = 1
     METHODOLOGY = 2
     ISSUELIB = 3
+    USER_TYPES = [DEFAULT, HOST]
   end
 
   acts_as_tree counter_cache: true, order: :label
@@ -59,7 +60,7 @@ class Node < ApplicationRecord
   }
 
   scope :user_nodes, -> {
-    where("type_id IN (?)", user_node_types)
+    where("type_id IN (?)", Types::USER_TYPES)
   }
 
 
@@ -94,10 +95,6 @@ class Node < ApplicationRecord
     find_or_create_by(label: 'Recovered', type_id: Node::Types::DEFAULT)
   end
 
-  def self.user_node_types
-    [Node::Types::DEFAULT, Node::Types::HOST]
-  end
-
   # -- Instance Methods -----------------------------------------------------
   def ancestor_of?(node)
     node && node.ancestors.include?(self)
@@ -109,7 +106,7 @@ class Node < ApplicationRecord
   end
 
   def user_node?
-    Node.user_node_types.include?(self.type_id)
+    Types::USER_TYPES.include?(self.type_id)
   end
 
   private

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -51,7 +51,7 @@ class Node < ApplicationRecord
 
   # -- Validations ----------------------------------------------------------
   validates_presence_of :label
-  validates_presence_of :parent, if: Proc.new { |node| node.parent_id }
+  validate :parent_node, if: Proc.new { |node| node.parent_id }
 
   # -- Scopes ---------------------------------------------------------------
   scope :in_tree, -> {
@@ -110,5 +110,14 @@ class Node < ApplicationRecord
   def destroy_attachments
     attachments_dir = Attachment.pwd.join(self.id.to_s)
     FileUtils.rm_rf attachments_dir if File.exists?(attachments_dir)
+  end
+
+  def parent_node
+    if self.parent.nil? ||
+      !(self.parent.type_id == Node::Types::DEFAULT ||
+        self.parent.type_id == Node::Types::HOST)
+
+      errors.add(:base, 'Invalid parent.')
+    end
   end
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -108,7 +108,7 @@ class Node < ApplicationRecord
     Attachment.find(:all, :conditions => {:node_id => self.id})
   end
 
-  def is_user_node
+  def user_node?
     Node.user_node_types.include?(self.type_id)
   end
 
@@ -126,7 +126,7 @@ class Node < ApplicationRecord
       return false
     end
 
-    if !(self.parent.is_user_node)
+    if !(self.parent.user_node?)
       errors.add(:parent_id, 'has an invalid type.')
       return false
     end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -58,6 +58,27 @@ describe Node do
     end
   end
 
+  describe '#parent' do
+    it 'does not create with an invalid parent_id' do
+      lib_node = create(:node, type_id: 2)
+      node.parent_id = lib_node.id
+      expect(node.save).to eq(false)
+    end
+
+    it 'creates a root node with a nil parent_id' do
+      node.parent_id = nil
+      expect(node.save).to eq(true)
+      expect(node.parent).to eq(nil)
+    end
+
+    it 'creates the node as a child of the parent node' do
+      parent_node = create(:node)
+      node.parent_id = parent_node.id
+      node.save!
+      expect(node.parent).to eq(parent_node)
+    end
+  end
+
   describe '#position' do
     it { should respond_to(:position)  }
     it { should respond_to(:position=) }

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -60,8 +60,16 @@ describe Node do
 
   describe '#parent' do
     it 'does not create with an invalid parent_id' do
-      lib_node = create(:node, type_id: 2)
+      lib_node = create(:node, type_id: Node::Types::METHODOLOGY)
       node.parent_id = lib_node.id
+      expect(node.save).to eq(false)
+    end
+
+    it 'does not create with a missing parent' do
+      create(:node) if Node.maximum(:id).nil?
+
+      missing_parent_id = Node.maximum(:id) + 1
+      node.parent_id = missing_parent_id
       expect(node.save).to eq(false)
     end
 


### PR DESCRIPTION
### Spec
You can currently create "invisible" Nodes (that don't show up in the sidebar of the project but can be access if you browse directly to them) if you use the REST API `POST` command and set the "parent_id" to an ID not found in the project.

Steps to replicate:

* Use the POST command and make sure that the value you pass in `parent_id` is not one of the Nodes in your project.
* Confirm that the Node is created and can be accessed by navigating to `/api/nodes/#ID#` in the browser. And, confirm that the Node does not appear in the sidebar or with the other Nodes.

**Proposed solution**
Make sure that the REST API doesn't allow you to create a Node with an invalid `parent_id`. If the `parent_id` value is not a Node in the project, the Node should not be created.


### How to test
1. Use the POST command and make sure that the value you pass in `parent_id` is not one of the Nodes in your project.
2. Confirm that the Node is not created and we get a validation error message.
3. Use the POST command and make sure that the value you pass in `parent_id` is your `issue_library` node.
4. Confirm that the Node is not created and we get a validation error message.