### PR TITLE
Fix 130

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.8 (XXX 2017)
  - Upgrade to Rails 5.1 and Ruby 2.4
+ - Bugs fixed: #130
  
 v3.7 (July 2017)
  - Fix dradis:reset thor task.

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -61,7 +61,7 @@ body {
       > a{
         text-shadow: 0 0 0;
         padding: 0 1em;
-        &:hover {
+        &:focus, &:hover {
           color: $blue;
         }
       }


### PR DESCRIPTION
Fix the :focus CSS class of top navigation links.

This PR closes securityroots/dradispro-tracker#130.