### PR TITLE
Clone file uploads instead

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 v3.8 (XXX 2017)
  - Upgrade to Rails 5.1 and Ruby 2.4
- - Bugs fixed: #130
+ - Bugs fixed: #130, #349
  
 v3.7 (July 2017)
  - Fix dradis:reset thor task.

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -18,9 +18,10 @@ jQuery ->
 
     paste: (e, data)->
       $.each data.files, (index, file) ->
-        if (!file.name?)
-          file.name = prompt('Please provide a filename for the pasted image', 'screenshot-XX.png') || 'unnamed.png'
-
+        filename = prompt('Please provide a filename for the pasted image', 'screenshot-XX.png') || 'unnamed.png'
+        # Clone file object, edit, then reapply to the data object
+        newFile = new File [file], filename, { type: file.type }
+        data.files[index] = newFile
 
   # Initialize clipboard.js:
   clipboard = new Clipboard('.js-attachment-url-copy')


### PR DESCRIPTION
Fix: https://github.com/securityroots/dradispro-tracker/issues/349

### Spec

Due to an update in Chrome, copy pasted files have their file names not preserved.

**Proposed solution**

For some reason, copy-pasted files have a default File object created for them with the name "image.png". This makes the code not run the prompt. The simplest solution here is to run the prompt everytime.

Another upload quirk found was that File object changes to their name do not persist. So the solution applied here is to create a clone of the file object, copy the file name then reapply the new file object to the data object.


### How to test

1. Select a node in a project.
2. Copy a sample image file.
3. Paste the file into the attachments box.
4. Assert that you can input the file name.
5. Upload the file.
6. Assert that the file was uploaded with the chosen file name.