### PR TITLE
Restyle the secondary sidebar

### DIFF
--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -372,21 +372,25 @@ body {
         padding: 0;
 //        margin-top: -$breadCrumbHeight;
         display: table;
-
+//        display: flex;
+//        flex-direction: row;
       }
     }
 
 
 
     .secondary-navbar {
-      display: table-cell;
-      vertical-align: top;
       background: $secondaryNavBarBgColor;
-      width: 25%;
+      border-right: 1px solid #ddd;
+      display: table-cell;
+//flex-grow: 1;
       margin-left: -$mainContentPadding;
+      vertical-align: top;
+      width: $secondarySidebarWidth;
+
       > .inner {
         background: $secondaryNavBarBgColor;
-        padding: 2em;
+        padding: 1em;
         min-height: 600px;
 
 
@@ -476,8 +480,9 @@ body {
 
     .secondary-navbar-content {
       background: #fff;
-      vertical-align: top;
       display: table-cell;
+      vertical-align: top;
+//flex-grow: 4;
       position: relative;
       margin: 0 0 0 (350px -$mainContentPadding);
       width: 100%;

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -43,8 +43,9 @@
     }
 
     .list-item-actions {
-      display: none;
       padding-right: 1ex;
+      text-align: right;
+      visibility: hidden;
     }
 
     .list-item-edit {
@@ -53,11 +54,10 @@
     }
 
     &:hover {
-      background-color: lighten(#ccc,10%);
+      background-color: lighten($secondaryNavBarBgColor,10%);
 
       .list-item-actions {
-        display: block;
-        text-align: right;
+        visibility: visible;
       }
     }
   }

--- a/app/assets/stylesheets/snowcrash/variables.scss
+++ b/app/assets/stylesheets/snowcrash/variables.scss
@@ -12,12 +12,13 @@ $asphaltDark: darken($asphalt,10);
 
 $primaryBgColor: $asphaltDark;
 $secondaryBgColor: lighten($grayLight, 5%);
-$secondaryNavBarBgColor: darken( $secondaryBgColor, 10%);
+$secondaryNavBarBgColor: darken( $secondaryBgColor, 1%);
 $mainContentPadding: 0;
 
 $navbarHeight: 60px;
 $sidebarWidth: 250px;
 $breadCrumbHeight: 48px;
+$secondarySidebarWidth: 25%;
 
 @font-face {
   font-family: 'OpenSans';


### PR DESCRIPTION
### Summary

- less padding
- lighter background
- :hover background is in line with the sidebar's background
- action links are rendered but hidden, avoiding the movement elements

Old:

![old_sidebar](https://user-images.githubusercontent.com/53006/31176286-992d7060-a912-11e7-8626-2b253e34331f.gif)


New

![new_sidebar](https://user-images.githubusercontent.com/53006/31176292-9ddf1e1a-a912-11e7-89a8-9105bb073d9d.gif)





