### PR TITLE
Remove :resque from queue adapter app config

### DIFF
--- a/app/controllers/upload_controller.rb
+++ b/app/controllers/upload_controller.rb
@@ -69,14 +69,16 @@ class UploadController < ProjectScopedController
   def process_upload_background(args={})
     attachment = args.fetch(:attachment)
 
-    job = UploadJob.perform_later(
+    job_logger.write 'Enqueueing job to start in the background.'
+
+    # NOTE: call the bg job as last thing in the action helps us
+    # avoid SQLite3::BusyException when using sqlite and
+    # activejob async queue adapter
+    UploadJob.perform_later(
       file: attachment.fullpath.to_s,
       plugin_name: @uploader.to_s,
       uid: params[:item_id].to_i
     )
-
-    job_logger.write 'Enqueueing job to start in the background.'
-    job_logger.write "Job id is #{ job.job_id }."
   end
 
   def process_upload_inline(args={})

--- a/app/jobs/upload_job.rb
+++ b/app/jobs/upload_job.rb
@@ -4,8 +4,9 @@ class UploadJob < ApplicationJob
   def perform(file:, plugin_name:, uid:)
     logger = Log.new(uid: uid)
 
-    logger.write{ "Running Ruby version %s" % RUBY_VERSION }
-    logger.write{ 'Worker process starting background task.' }
+    logger.write { "Job id is #{job_id}." }
+    logger.write { 'Running Ruby version %s' % RUBY_VERSION }
+    logger.write { 'Worker process starting background task.' }
 
     plugin = plugin_name.constantize
 
@@ -16,6 +17,6 @@ class UploadJob < ApplicationJob
 
     importer.import(file: file)
 
-    logger.write{ 'Worker process completed.' }
+    logger.write { 'Worker process completed.' }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,6 @@ module Dradis
     #
     # TODO: possibly fixed by Rails 4?
     routes.default_url_options[:script_name] = ActionController::Base.config.relative_url_root || '/'
-
-    config.active_job.queue_adapter = :resque
   end
 end
 


### PR DESCRIPTION
Try to simplify CE deployment by making use of ActiveJob's in-memory implementation.

### How to test
1. Make sure neither Redis or Resque are running.
2. Upload a big Nessus file (you can copy the <ReportItem> section multiple times from a smaller file).
3. The in-memory background worker should kick in and the file should be parsed as usual.
4. using the burp uploader, upload many times this file: https://github.com/dradis/dradis-saint/blob/initial-implementation/spec/fixtures/files/saint_metasploitable_sample.xml
Assert that even the upload does not work, in the logs we don't see any `SQLite3::BusyException` exceptions