### PR TITLE
Multi delete issues

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -83,13 +83,18 @@ class IssueTable
         method: 'POST'
         dataType: 'json'
         data: {ids: issue_ids}
-        success:  ->
+        success: ->
           for id in issue_ids
             $("input#issue_#{id}").closest('tr').remove()
             $("#issue_#{id}").remove()
 
           if $(@selectedIssuesSelector).length == 0
             that.resetToolbar()
+
+        error: ->
+          for id in issue_ids
+            $row = $("input#issue_#{id}").closest('tr')
+            $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
       }
 
     # prevent Rails UJS from doing anything else.

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -73,26 +73,24 @@ class IssueTable
   onDeleteSelected: (element, answer) =>
     if answer
       that = this
+      issue_ids = []
       $('.js-tbl-issues').find(@selectedIssuesSelector).each ->
         $row = $(this).parent().parent()
         $($row.find('td')[2]).replaceWith("<td class=\"loading\">Deleting...</td>")
-        $.ajax $(this).data('url'), {
-          method: 'DELETE'
-          dataType: 'json'
-          success: (data) ->
-            # Delete row from the table
-            $row.remove()
-            # TODO: show placeholder if no issues left
+        issue_ids.push($(this).val())
 
-            # Delete link from the sidebar
-            $("#issue_#{data.id}").remove()
+      $.ajax $('#issue-table').data('destroy-url'), {
+        method: 'POST'
+        dataType: 'json'
+        data: {ids: issue_ids}
+        success:  ->
+          for id in issue_ids
+            $("#issue_#{id}").closest('tr').remove()
+            $("#issue_#{id}").remove()
 
-            if $(@selectedIssuesSelector).length == 0
-              that.resetToolbar()
-
-          error: (foo,bar,foobar) ->
-            $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
-        }
+          if $(@selectedIssuesSelector).length == 0
+            that.resetToolbar()
+      }
 
     # prevent Rails UJS from doing anything else.
     false

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -85,7 +85,7 @@ class IssueTable
         data: {ids: issue_ids}
         success:  ->
           for id in issue_ids
-            $("#issue_#{id}").closest('tr').remove()
+            $("input#issue_#{id}").closest('tr').remove()
             $("#issue_#{id}").remove()
 
           if $(@selectedIssuesSelector).length == 0

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -87,6 +87,18 @@ class IssuesController < ProjectScopedController
     end
   end
 
+  def multiple_destroy
+    respond_to do |format|
+      if Issue.destroy(params[:ids])
+        format.html { redirect_to issues_url, notice: 'Issues deleted.' }
+        format.json
+      else
+        format.html { redirect_to issues_url, notice: "Error while deleting issue: #{@issue.errors}" }
+        format.json
+      end
+    end
+  end
+
 
   def import
     importer = IssueImporter.new(params)
@@ -157,6 +169,12 @@ class IssuesController < ProjectScopedController
     if (tag_name = issue.fields['Tags'].split(',').first)
       issue.tag_list = tag_name
       issue.save
+    end
+  end
+
+  def track_destroyed_issues(issue_ids)
+    issue_ids.each do |id|
+      track_destroyed(Issue.find(id))
     end
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -175,8 +175,7 @@ class IssuesController < ProjectScopedController
   def destroy_multiple_issues(issue_ids)
     issue_ids.each do |id|
       issue = Issue.find_by_id(id)
-      if issue
-        issue.destroy
+      if issue && issue.destroy
         track_destroyed(issue)
       end
     end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -89,11 +89,11 @@ class IssuesController < ProjectScopedController
 
   def multiple_destroy
     respond_to do |format|
-      if Issue.destroy(params[:ids])
+      if destroy_multiple_issues(params[:ids])
         format.html { redirect_to issues_url, notice: 'Issues deleted.' }
         format.json
       else
-        format.html { redirect_to issues_url, notice: "Error while deleting issue: #{@issue.errors}" }
+        format.html { redirect_to issues_url, notice: "Error while deleting issues." }
         format.json
       end
     end
@@ -172,9 +172,15 @@ class IssuesController < ProjectScopedController
     end
   end
 
-  def track_destroyed_issues(issue_ids)
+  def destroy_multiple_issues(issue_ids)
     issue_ids.each do |id|
-      track_destroyed(Issue.find(id))
+      issue = Issue.find_by_id(id)
+      if issue
+        issue.destroy
+        track_destroyed(issue)
+      end
     end
+
+    true
   end
 end

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -10,7 +10,7 @@
   <div class="inner note-text-inner">
 
     <% if @issues.any? %>
-      <div id="issue-table">
+      <div id="issue-table" data-destroy-url="<%= multiple_destroy_issues_path %>">
         <%= render 'toolbar' %>
         <%= render 'table', issues: @issues %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   resources :issues do
     collection do
       post :import
+      post :multiple_destroy
       resources :merge, only: [:new, :create], controller: 'issues/merge'
     end
     resources :revisions, only: [:index, :show]

--- a/spec/features/issue_pages/table_spec.rb
+++ b/spec/features/issue_pages/table_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
-describe "issue pages" do
+describe 'issue pages' do
 
 
-  describe "#index table", js2: true do
+  describe '#index table', js2: true do
     subject { page }
 
     before do
       login_to_project_as_user
 
-      @issue = create(:issue, text: "#[Risk]#\nHigh\n\n#[Description]#\nn/a")
+      @issue = create(:issue, text: "#[Title]#\nIssue1\n\n#[Risk]#\nHigh\n\n#[Description]#\nn/a")
       visit issues_path
     end
 
-    it "displays column controls for Title, Tags and Affected" do
+    it 'displays column controls for Title, Tags and Affected' do
 
       # Prime the element's text, as it is hidden by default
       find('.js-table-columns', visible: false).text(:all)
@@ -23,7 +23,7 @@ describe "issue pages" do
       expect(find('.js-table-columns', visible: false)).to have_text('Affected')
     end
 
-    it "displays custom columns based on Issue content" do
+    it 'displays custom columns based on Issue content' do
       # Prime the element's text, as it is hidden by default
       find('.js-table-columns', visible: false).text(:all)
 

--- a/spec/features/issue_pages/table_toolbar_spec.rb
+++ b/spec/features/issue_pages/table_toolbar_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe "issue table" do
+describe 'issue table' do
 
-  describe "toolbar", js: true do
+  describe 'toolbar', js: true do
     subject { page }
 
     before do
@@ -14,47 +14,47 @@ describe "issue table" do
       visit issues_path
     end
 
-    context "when Select All is clicked" do
+    context 'when Select All is clicked' do
       before do
         find('.js-select-all-issues').click
       end
 
-      it "selects all issues" do
+      it 'selects all issues' do
         all('input[type=checkbox].js-multicheck').each do |el|
           expect(el['checked']).to be true
         end
       end
 
-      it "shows the issue actions bar" do
+      it 'shows the issue actions bar' do
         expect(find('.js-issue-actions')).to be_visible
       end
     end
 
-    context "when clicking issues" do
-      it "displays action buttons (delete, tag ...) if 1 issue is clicked" do
+    context 'when clicking issues' do
+      it 'displays action buttons (delete, tag ...) if 1 issue is clicked' do
         expect(find('.js-issue-actions', visible: :all)).to_not be_visible
         check "issue_#{@issue1.id}"
         expect(find('.js-issue-actions')).to be_visible
       end
 
-      it "displays merge button if more than 1 issues clicked" do
+      it 'displays merge button if more than 1 issues clicked' do
         check "issue_#{@issue1.id}"
         expect(page).to have_selector('#merge-selected', visible: false)
         check "issue_#{@issue2.id}"
         expect(page).to have_selector('#merge-selected', visible: true)
       end
 
-      it "resets toolbar after applying tags" do
+      it 'resets toolbar after applying tags' do
         check "issue_#{@issue1.id}"
         expect(page).to have_css('.js-issue-actions')
         find('#tag-selected').click
         find('a[data-tag="!6baed6_low"]').click
         expect(page).to_not have_css('.js-issue-actions')
         @issue1.reload
-        expect(@issue1.tags.first.name).to eq "!6baed6_low"
+        expect(@issue1.tags.first.name).to eq '!6baed6_low'
       end
 
-      it "resets toolbar after deleting issues" do
+      it 'resets toolbar after deleting issues' do
         check "issue_#{@issue1.id}"
         expect(page).to have_css('.js-issue-actions')
         find('#delete-selected').click
@@ -63,8 +63,8 @@ describe "issue table" do
       end
     end
 
-    context "when filtering issues" do
-      it "should not delete filtered issues" do
+    context 'when filtering issues' do
+      it 'does not delete filtered issues' do
         find('.js-table-filter').set('1')
         expect(page).to have_selector("#issue_#{@issue2.id}", visible: false)
         find('#select-all').click
@@ -72,6 +72,16 @@ describe "issue table" do
         expect(page).to_not have_selector("#issue_#{@issue1.id}")
         expect(Issue.exists?(@issue1.id)).to be false
         expect(Issue.exists?(@issue2.id)).to be true
+      end
+    end
+
+    context 'when deleting issues' do
+      it 'successfully deletes multiple issues' do
+        find('#select-all').click
+        find('#delete-selected').click
+        expect(page).to_not have_selector("#issue_#{@issue1.id}")
+        expect(Issue.exists?(@issue1.id)).to be false
+        expect(Issue.exists?(@issue2.id)).to be false
       end
     end
   end


### PR DESCRIPTION
### Spec

Currently, when deleting multiple issues, multiple calls for deletion are issued at a small amount of time. This causes the mysql server to issue a deadlock error and fail to delete most of the issues, requiring a refresh from the user.

**Proposed solution**

One solution is to delete multiple issues in one delete call.

### How to test
1. Upload a file with multiple issues
2. Go to the All Issues page
3. Select all issues and delete all
4. Assert that there were no undeleted issues.