### PR TITLE
Add tags and taggings to reset:database

### DIFF
--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -147,6 +147,8 @@ class DradisTasks < Thor
       Note.destroy_all
       Node.destroy_all
       Category.destroy_all
+      Tag.destroy_all
+      Tagging.destroy_all
 
       Log.destroy_all
 


### PR DESCRIPTION
Clear tags from the database when using the command `thor dradis:reset:database`.