### PR TITLE
Reuse table js: minor edits after using this code

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
@@ -178,8 +178,7 @@ class IndexTable
     setTimeout(ConsoleUpdater.updateConsole, 200);
 
   storageKey: ->
-    projectId = $('.brand').data('project') || 'ce'
-    @project ||= projectId
+    @project ||= $('.brand').data('project') || 'ce'
     "project.#{@project}.#{@itemName}_columns"
 
   refreshToolbar: =>

--- a/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
@@ -25,14 +25,15 @@ class IndexTable
     @$columnMenu.find('a').on 'click', @onColumnPickerClick
 
     # Checkbox behavior: select all, show 'btn-group', etc.
-    $('.js-index-table-select-all').click (e)=>
+    that = this
+    $('.js-index-table-select-all').click (e) ->
       $allCheckbox = $(this).find('input[type=checkbox]')
       isChecked = $allCheckbox.prop('checked')
       if e.target != $allCheckbox[0]
         isChecked = !isChecked
         $allCheckbox.prop('checked', isChecked)
 
-      $("#{@checkboxSelector}:visible").prop('checked', isChecked)
+      $("#{that.checkboxSelector}:visible").prop('checked', isChecked)
 
     # when selecting standalone items, check if we must also check 'select all'
     $(@checkboxSelector).click ->
@@ -110,14 +111,15 @@ class IndexTable
           if $(that.selectedItemsSelector).length == 0
             that.resetToolbar()
 
-          $('#modal-console').modal()
-          ConsoleUpdater.jobId = data.jobId
-          $('#console').empty()
-          $('#result').data('id', ConsoleUpdater.jobId)
-          $('#result').show()
-
-          ConsoleUpdater.parsing = true;
-          setTimeout(ConsoleUpdater.updateConsole, 200);
+          if data.success
+            if data.jobId?
+              # background deletion
+              that.showConsole(data.jobId)
+            else
+              # inline deletion
+              that.showAlert(data.msg, 'success')
+          else
+            that.showAlert(data.msg, 'error')
 
           # TODO: show placeholder if no items left
 
@@ -151,6 +153,26 @@ class IndexTable
         else
           that.$table.find("td:nth-child(#{index + 1})").css('display', 'none')
           $th.css('display', 'none')
+
+  showAlert: (msg, klass) =>
+    $('.secondary-navbar-content').prepend(
+      "<div class='alert alert-#{klass}'>
+        <a class='close' data-dismiss='alert' href='javascript:void(0)'>x</a>
+        #{msg}
+      </div>"
+    )
+
+  showConsole: (jobId) =>
+    # show console
+    $('#modal-console').modal()
+    ConsoleUpdater.jobId = jobId
+    $('#console').empty()
+    $('#result').data('id', ConsoleUpdater.jobId)
+    $('#result').show()
+
+    # start console
+    ConsoleUpdater.parsing = true;
+    setTimeout(ConsoleUpdater.updateConsole, 200);
 
   storageKey: ->
     projectId = $('.brand').data('project') || 'ce'

--- a/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
@@ -106,7 +106,7 @@ class IndexTable
         success: (data) ->
           for id in ids
             $("#checkbox_#{that.itemName}_#{id}").closest('tr').remove()
-            $("##{that.itemName}_#{id}").remove()
+            $("##{that.itemName}_#{id}_link").remove()
 
           if $(that.selectedItemsSelector).length == 0
             that.resetToolbar()
@@ -170,6 +170,9 @@ class IndexTable
     $('#result').data('id', ConsoleUpdater.jobId)
     $('#result').show()
 
+    # set what page to visit when closing console
+    $('#modal-console').on('hidden', @refreshPage)
+
     # start console
     ConsoleUpdater.parsing = true;
     setTimeout(ConsoleUpdater.updateConsole, 200);
@@ -185,5 +188,9 @@ class IndexTable
       $('.js-index-table-actions').css('display', 'inline-block')
     else
       $('.js-index-table-actions').css('display', 'none')
+
+  refreshPage: =>
+    Turbolinks.clearCache()
+    Turbolinks.visit($('#result').data('close-url'))
 
 window.IndexTable = IndexTable

--- a/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/index_table.js.coffee
@@ -91,29 +91,38 @@ class IndexTable
   onDeleteSelected: (element, answer) =>
     if answer
       that   = this
-      issueIds = []
+      ids = []
 
       @$table.find(@selectedItemsSelector).each ->
         $row = $(this).parent().parent()
         $($row.find('td')[2]).replaceWith("<td class=\"loading\">Deleting...</td>")
-        issueIds.push($(this).val())
+        ids.push($(this).val())
 
       $.ajax @$jsTable.data('destroy-url'), {
-        method: 'POST'
+        method: 'DELETE'
         dataType: 'json'
-        data: {ids: issueIds}
-        success: ->
-          for id in issueIds
+        data: {ids: ids}
+        success: (data) ->
+          for id in ids
             $("#checkbox_#{that.itemName}_#{id}").closest('tr').remove()
             $("##{that.itemName}_#{id}").remove()
 
           if $(that.selectedItemsSelector).length == 0
             that.resetToolbar()
 
+          $('#modal-console').modal()
+          ConsoleUpdater.jobId = data.jobId
+          $('#console').empty()
+          $('#result').data('id', ConsoleUpdater.jobId)
+          $('#result').show()
+
+          ConsoleUpdater.parsing = true;
+          setTimeout(ConsoleUpdater.updateConsole, 200);
+
           # TODO: show placeholder if no items left
 
         error: ->
-          for id in issueIds
+          for id in ids
             $row = $("#checkbox_#{that.itemName}_#{id}").closest('tr')
             $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
       }

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -3,7 +3,7 @@
   item_css << ' active' if (request.format.html? and @issue == issue)
 %>
 
-<%= content_tag :div, id: dom_id(issue), class: item_css.join do %>
+<%= content_tag :div, id: "#{dom_id(issue)}_link", class: item_css.join do %>
 
   <div class="expansion-container">
     <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   resources :issues do
     collection do
       post :import
-      post :multiple_destroy
+      delete :multiple_destroy
       resources :merge, only: [:new, :create], controller: 'issues/merge'
     end
     resources :revisions, only: [:index, :show]

--- a/spec/features/issue_pages/table_toolbar_spec.rb
+++ b/spec/features/issue_pages/table_toolbar_spec.rb
@@ -79,7 +79,7 @@ describe 'issue table' do
       it 'successfully deletes multiple issues' do
         find('#select-all').click
         find('#delete-selected').click
-        expect(page).to_not have_selector("#issue_#{@issue1.id}")
+        expect(page).to_not have_selector("#issue_#{@issue1.id}_link")
         expect(Issue.exists?(@issue1.id)).to be false
         expect(Issue.exists?(@issue2.id)).to be false
       end

--- a/spec/features/issue_pages/table_toolbar_spec.rb
+++ b/spec/features/issue_pages/table_toolbar_spec.rb
@@ -66,7 +66,7 @@ describe 'issue table' do
     context 'when filtering issues' do
       it 'does not delete filtered issues' do
         find('.js-table-filter').set('1')
-        expect(page).to have_selector("#issue_#{@issue2.id}", visible: false)
+        expect(page).to have_selector("#issue_#{@issue2.id}_link", visible: false)
         find('#select-all').click
         find('#delete-selected').click
         expect(page).to_not have_selector("#checkbox_issue_#{@issue1.id}")


### PR DESCRIPTION
Some changes after using the table js code extracted from issues table in the new notes table: 
- renamed `issueIds` to `ids`
- I used `DELETE` instead of `POST`, I think this makes sense, but feel free to reject it
- some code used to setup a modal console when a multi-delete background task is successfully set