### PR TITLE
de-duplicated services table

### DIFF
--- a/app/models/concerns/node_properties.rb
+++ b/app/models/concerns/node_properties.rb
@@ -120,14 +120,9 @@ private
   def merge_service(new_row)
     table = self.properties[:services]
 
-    # work always with an array of hashes
-    table = [table] if table.is_a?(Hash)
-    table = [] if table.nil?
+    table = to_array_of_hashes(table)
 
-    # find new_row in table
-    position = table.find_index do |row|
-      row.values_at(:port, :protocol) == new_row.values_at(:port, :protocol)
-    end
+    position = find_position_in_table(table, new_row)
 
     if position.nil?
       # if the row was not in the table, add it
@@ -172,14 +167,9 @@ private
   def merge_service_extra(new_row)
     table = self.properties[:services_extra]
 
-    # work always with an array of hashes
-    table = [table] if table.is_a?(Hash)
-    table = [] if table.nil?
+    table = to_array_of_hashes(table)
 
-    # find new_row in table
-    position = table.find_index do |row|
-      row.values_at(:port, :protocol) == new_row.values_at(:port, :protocol)
-    end
+    position = find_position_in_table(table, new_row)
 
     if position.nil?
       # if the row was not in the table, add it
@@ -195,5 +185,17 @@ private
     end
 
     self.properties[:services_extra] = table
+  end
+
+  def to_array_of_hashes(table)
+    table = [table] if table.is_a?(Hash)
+    table = [] if table.nil?
+    table
+  end
+
+  def find_position_in_table(table, new_row)
+    table.find_index do |row|
+      row.values_at(:port, :protocol) == new_row.values_at(:port, :protocol)
+    end
   end
 end

--- a/app/models/concerns/node_properties.rb
+++ b/app/models/concerns/node_properties.rb
@@ -34,7 +34,9 @@ module NodeProperties
     value_is_there = (current_value == value) || (current_value.is_a?(Array) && current_value.include?(value))
     return current_value if value.blank? || value_is_there
 
-    if current_value.blank?
+    if key == :services
+      add_service(value)
+    elsif current_value.blank?
       self.properties[key] = value
     else
       self.properties[key] = [current_value, value].flatten.uniq
@@ -46,9 +48,8 @@ module NodeProperties
   end
 
   def has_any_property?
-    self.properties.keys.any?{ |p| self.properties[p].present? }
+    self.properties.keys.any? { |p| self.properties[p].present? }
   end
-
 
   # -------------------------------------- :raw_properties accessors for the UI
   def raw_properties
@@ -71,5 +72,75 @@ module NodeProperties
     self.properties = @raw_properties
   rescue JSON::ParserError => exception
     @raw_properties = value
+  end
+
+private
+
+  # Private: Adding a :services key to the node properties is a special case:
+  #   * We check if a row exists in the services table by matching the port
+  #     and protocol columns
+  #   * We only allow a set of known columns in the :services table. The rest
+  #     of columns are moved to an extra data table called 'supplemental'. The
+  #     allowed columms are :name, :port, :product, :protocol, :reason, :state,
+  #     :version
+  # value - The new entry (Hash) we want to add to :services table
+  #
+  # Returns the updated services table
+  def add_service(value)
+    services     = self.properties[:services]
+    supplemental = self.properties[:supplemental]
+
+    # extract extra info from value
+    extra_value = value.except(:name, :product, :reason, :state, :version)
+    value.slice!(:name, :port, :product, :protocol, :reason, :state, :version)
+
+    self.properties[:services] = merge_by_port_and_protocol(services, value)
+
+    if extra_value.except(:port, :protocol).any?
+      supplemental = merge_by_port_and_protocol(supplemental, extra_value)
+      supplemental = supplemental.first if supplemental.size == 1
+      self.properties[:supplemental] = supplemental
+    end
+
+    self.properties[:services]
+  end
+
+  # Private: Merges a Hash into an Array of Hashes by :port and :protocol keys.
+  # If a row exists in the table with the new row port and protocol values, the
+  # rest of the columns that have the same name are concatenated.
+  #
+  # table   - the existing table where we want to merge a new entry.
+  #         May be nil, a Hash or an Array of hashes
+  # new_row - the new entry (a Hash) we want to put in the existing table.
+  #
+  # Returns table with new_row merged
+  def merge_by_port_and_protocol(table, new_row)
+    # work always with an array of hashes
+    table = [table] if table.is_a?(Hash)
+    table = [] if table.nil?
+
+    # find new_row in table
+    position = table.find_index do |row|
+      row.values_at(:port, :protocol) == new_row.values_at(:port, :protocol)
+    end
+
+    if position.nil?
+      # if the row was not in the table, add it
+      table << new_row
+    else
+      # if the row is in th etable, merge it
+      target = table[position]
+      target.merge!(new_row) do |_key, oldvalue, newvalue|
+        if oldvalue == newvalue
+          oldvalue
+        else
+          [oldvalue.split(' | '), newvalue].flatten.uniq.join(' | ')
+        end
+      end
+
+      table[position] = target
+    end
+
+    table
   end
 end

--- a/app/models/concerns/node_properties.rb
+++ b/app/models/concerns/node_properties.rb
@@ -97,9 +97,11 @@ private
 
     merge_service(value)
 
-    value_extra[:extra].select! { |extra| !extra[:output].blank? }
-    if value_extra[:extra].any?
-      merge_service_extra(value_extra)
+    unless value_extra[:extra].nil?
+      value_extra[:extra].select! { |extra| !extra[:output].blank? }
+      if value_extra[:extra].any?
+        merge_service_extra(value_extra)
+      end
     end
 
     self.properties[:services]

--- a/app/models/concerns/node_properties.rb
+++ b/app/models/concerns/node_properties.rb
@@ -97,7 +97,7 @@ private
 
     merge_service(value)
 
-    unless value_extra[:extra].nil?
+    if value_extra[:extra]
       value_extra[:extra].select! { |extra| !extra[:output].blank? }
       if value_extra[:extra].any?
         merge_service_extra(value_extra)

--- a/app/presenters/property_presenter.rb
+++ b/app/presenters/property_presenter.rb
@@ -77,16 +77,16 @@ private
       else
         thead = content_tag(:thead) do
           content_tag(:tr) do
-            column_names.collect do |column_name|
+            column_names.map do |column_name|
               concat content_tag(:th, column_name)
             end.join.html_safe
           end
         end
 
         tbody = content_tag(:tbody) do
-          sorted_entries.collect do |entry|
+          sorted_entries.map do |entry|
             content_tag(:tr) do
-              column_names.collect do |column_name|
+              column_names.map do |column_name|
                 concat content_tag(:td, entry[column_name])
               end.join.html_safe
             end

--- a/app/presenters/property_presenter.rb
+++ b/app/presenters/property_presenter.rb
@@ -64,8 +64,12 @@ private
   def render_table
     values         = property_value
     column_names   = values.map(&:keys).flatten.uniq.sort.map(&:to_sym)
-    sorted_entries = column_names.include?(:port) \
-                   ? values.sort_by { |h| h[:port] } : values
+    sorted_entries =
+      if column_names.include?(:port)
+        values.sort_by { |h| h[:port] }
+      else
+        values
+      end
 
     output =
       if property_key == 'services_extra'

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -261,15 +261,11 @@ describe Node do
           { 'source' => 'nmap', 'id' => 'ssh-script', 'output' => 'extra info 2' },
         ]
 
-        node.set_property(
-          :services, port: 80, protocol: 'tcp', name: 'www', extra: extra1
-        )
-        node.set_property(
-          :services, port: 80, protocol: 'tcp', name: 'www', extra: extra2
-        )
-        node.set_property(
-          :services, port: 80, protocol: 'tcp', name: 'www', extra: extra1
-        )
+        [extra1, extra2, extra1].each do |extra|
+          node.set_property(
+            :services, port: 80, protocol: 'tcp', name: 'www', extra: extra
+          )
+        end
 
         expect(node.properties[:services_extra].size).to eq 1
         expect(node.properties[:services_extra][0][:extra].size).to eq 2


### PR DESCRIPTION
### Spec

Currently, the Services tables are de-duplicated based on the contents of the entire row. 

The attached screenshot is created when you upload the 3 attached files (Nmap, Qualys, Nessus). There are many duplicate entries (rows) in the table. For example, multiple entries exist for tcp/22 when there should only be one! 

Plus, the Services table exports extra columns that should not appear in the Services table by default. 

### Proposed solution
**De-duplicate**

De-duplicate the Service tables entries based on the Port + Protocol column contents. Instead of the 

**Only 7 Columns**
There should only be the following columns in both the display **and** in the exported Services table: 

* name
* port
* product
* protocol
* reason
* state
* version

Currently, these 7 columns display in Dradis but extra columns (e.g. Scripts) are added on export. 

**Extra data**
The extra columns (e.g. scripts, X Nessus, etc) should go into the services extra data section below the Services table. 

Check out the attached screenshot showing the current configuration of the NSE script output. This should become a Services Extra data section (instead of NSE script output). Each port should have a tab (as shown), then each type of data gets a new row in the table. Add a new row to that table for the source of the data like so: 
```
|_ source |_. id |_. output |
|Nmap NSE script output | ssh-hostkey | <foo> |
|Nessus | X Nessus | <bar>
```

### How to test
Upload the Nmap, Nessus, and Qualys files to a (blank) sample project

Check to confirm that the Services table is created as expected: 

* There are no duplicate entries (rows) in the Services table, just 1 row for each unique port/protocol combination
* There are only the correct 7 columns in the Services table (list above!) 
* All extra columns, e.g. `X Nessus` have been moved to the Services Extras data below the table. 

Also upload these files:
https://github.com/dradis/dradis-nmap/blob/master/spec/fixtures/files/nse-01.xml
https://github.com/dradis/dradis-metasploit/blob/master/spec/fixtures/files/msf5.xml
Check that what we have in `Services Extras` table makes sense.