### PR TITLE
add metadata to paper_trail outside of controllers

### DIFF
--- a/app/jobs/multi_destroy_job.rb
+++ b/app/jobs/multi_destroy_job.rb
@@ -7,6 +7,8 @@ class MultiDestroyJob < ApplicationJob
     # FIXME: migrate logs#uid to uuid ?
     logger = Log.new(uid: uid)
 
+    PaperTrail.whodunnit = author_email
+
     items = klass.constantize.where(id: ids)
 
     logger.write do


### PR DESCRIPTION
### Spec
When we delete items in a bg task the `autor_email` column in `versions` table is not being stored.
Items are being deleted in both cases (bg and inline) with the MultiDestroyJob. Noticed that in the bg case the items are stored in the `versions` table, but whithout `author_email` column. 


### Proposed solution
Have to make sure that PaperTrail has all available metadata even when we are not deleting from a controller.