### PR TITLE
Evidence#edit - track where we came from so we can return there

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -78,7 +78,7 @@ class EvidenceController < NestedNodeResourceController
       if @evidence.update_attributes(evidence_params)
         track_updated(@evidence)
         check_for_edit_conflicts(@evidence, updated_at_before_save)
-        format.html { redirect_to [@node, @evidence], notice: 'Evidence updated.' }
+        format.html { redirect_to issue_or_node_path, notice: 'Evidence updated.' }
       else
         format.html {
           initialize_nodes_sidebar
@@ -162,5 +162,13 @@ class EvidenceController < NestedNodeResourceController
 
   def evidence_params
     params.require(:evidence).permit(:author, :content, :issue_id, :node_id)
+  end
+
+  def issue_or_node_path
+    if params[:back_to] == 'issue'
+      @evidence.issue
+    else
+      [@node, @evidence]
+    end
   end
 end

--- a/app/views/evidence/_form.html.erb
+++ b/app/views/evidence/_form.html.erb
@@ -11,6 +11,7 @@
   <% end %>
 
   <div class="form-actions">
+    <%= hidden_field_tag :back_to, :issue if params[:back_to] == 'issue' %>
     <%= f.button :submit, nil, class: 'btn btn-primary' %> or
     <%= link_to 'Cancel', node_path(@node) %>
   </div>

--- a/app/views/issues/_evidence.html.erb
+++ b/app/views/issues/_evidence.html.erb
@@ -28,7 +28,7 @@
                 <h3>
                   Evidence for <%= link_to node.label, node %> -
                   <span class="actions">
-                    <%= link_to edit_node_evidence_path(node, instances.first) do %>
+                    <%= link_to edit_node_evidence_path(node, instances.first, back_to: :issue) do %>
                       <i class="fa fa-pencil"></i> Edit
                     <% end %>
                     <%= link_to [node, instances.first],


### PR DESCRIPTION
When editing evidence from an issue, return to the issue. When editing form a node, return to the node.