### PR TITLE
evidence toolbar: fix non-deterministic failing spec

### DIFF
--- a/spec/support/items_table_toolbar_examples.rb
+++ b/spec/support/items_table_toolbar_examples.rb
@@ -78,8 +78,8 @@ shared_examples 'an index table toolbar' do
 
     context 'with filters' do
       it 'does not delete filtered items' do
-        filter = first('td:nth-child(2)').text
-        find('.js-table-filter').set(filter)
+        to_delete = items.first
+        find('.js-table-filter').set(to_delete.title)
         expect(
           all(
             'input[type=checkbox].js-multicheck',
@@ -89,8 +89,8 @@ shared_examples 'an index table toolbar' do
         find('#select-all').click
         find('.js-items-table-delete').click
         expect(page).to have_text(/deleted/)
-        klass = items.last.class
-        expect(klass.exists?(items.first.id)).to be false
+        klass = to_delete.class
+        expect(klass.exists?(to_delete.id)).to be false
         expect(klass.count).to be items.size - 1
       end
     end


### PR DESCRIPTION
This spec was failing for some seeds, e.g.:

rspec ./spec/features/node_pages/evidence_table_toolbar_spec.rb --seed 6159

The problem is (was) that the first element in the table isn't
necessarily the first item in the `items` array. So an evidence was
being deleted as expected, but the spec then checked if a different
evidence had been deleted.