### PR TITLE
Add migration to increase node properties db limit

### DIFF
--- a/db/migrate/20180403094945_increase_node_properties_limit.rb
+++ b/db/migrate/20180403094945_increase_node_properties_limit.rb
@@ -1,0 +1,5 @@
+class IncreaseNodePropertiesLimit < ActiveRecord::Migration[5.1]
+  def change
+    change_column :nodes, :properties, :text, limit: 4.gigabytes - 1
+  end
+end

--- a/db/migrate/20180403094945_increase_node_properties_limit.rb
+++ b/db/migrate/20180403094945_increase_node_properties_limit.rb
@@ -1,5 +1,9 @@
 class IncreaseNodePropertiesLimit < ActiveRecord::Migration[5.1]
-  def change
-    change_column :nodes, :properties, :text, limit: 4.gigabytes - 1
+  def up
+    change_column :nodes, :properties, :longtext
+  end
+
+  def down
+    change_column :nodes, :properties, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 20180403094945) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
-    t.text "properties", limit: 4294967295
+    t.text "properties"
     t.integer "children_count", default: 0, null: false
     t.index ["parent_id"], name: "index_nodes_on_parent_id"
     t.index ["type_id"], name: "index_nodes_on_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160629084016) do
+ActiveRecord::Schema.define(version: 20180403094945) do
 
   create_table "activities", force: :cascade do |t|
     t.string "user", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 20160629084016) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
-    t.text "properties"
+    t.text "properties", limit: 4294967295
     t.integer "children_count", default: 0, null: false
     t.index ["parent_id"], name: "index_nodes_on_parent_id"
     t.index ["type_id"], name: "index_nodes_on_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180403094945) do
+ActiveRecord::Schema.define(version: 20160629084016) do
 
   create_table "activities", force: :cascade do |t|
     t.string "user", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160629084016) do
+ActiveRecord::Schema.define(version: 20180403094945) do
 
   create_table "activities", force: :cascade do |t|
     t.string "user", null: false


### PR DESCRIPTION
### Spec

When uploading from a plugin (ex: Nessus), it's possible for the process to encounter the error: `ActiveRecord::ValueTooLong: Mysql2::Error: Data too long for column 'properties'`. This is usually caused by a node with a significant amount of open ports, which is then stored in the node's properties attribute.

**Proposed solution**

Add a migration to increase the db limit of the node's properties attribute to accommodate all the data.


### How to test

1. Upload a large nessus file through the command line.
2. Assert that there was no error with the upload.