### PR TITLE
Use routes concern for multi_destroy

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,12 @@ Rails.application.routes.draw do
   resource :session
 
   # ------------------------------------------------------------ Project routes
+  concern :multiple_destroy do
+    collection do
+      delete :multiple_destroy
+    end
+  end
+
   get '/summary' => 'projects#show'
 
   resources :activities, only: [] do
@@ -24,10 +30,9 @@ Rails.application.routes.draw do
     collection { get :status }
   end
 
-  resources :issues do
+  resources :issues, concerns: :multiple_destroy do
     collection do
       post :import
-      delete :multiple_destroy
       resources :merge, only: [:new, :create], controller: 'issues/merge'
     end
     resources :revisions, only: [:index, :show]
@@ -51,20 +56,12 @@ Rails.application.routes.draw do
       get :tree
     end
 
-    resources :notes do
+    resources :notes, concerns: :multiple_destroy do
       resources :revisions, only: [:index, :show]
-
-      collection do
-        delete :multiple_destroy
-      end
     end
 
-    resources :evidence, except: :index do
+    resources :evidence, except: :index, concerns: :multiple_destroy do
       resources :revisions, only: [:index, :show]
-
-      collection do
-        delete :multiple_destroy
-      end
     end
 
     constraints(:filename => /.*/) do


### PR DESCRIPTION
### Spec

Currently, when an item type in Dradis is implemented to have a multi-destroy feature, a `multi_destroy` routes is also added. Example:

```
    resources :notes do
      resources :revisions, only: [:index, :show]

      collection do
        delete :multiple_destroy
      end
    end

    resources :evidence, except: :index do
      resources :revisions, only: [:index, :show]

      collection do
        delete :multiple_destroy
      end
    end

```

Ideally, we want to DRY up this code with a routing concern

**Proposed solution**

See: http://edgeguides.rubyonrails.org/routing.html#routing-concerns


### How to test

1. Open a project with notes, evidences and issues.
2. Assert that multiple destroying multiple items work as intended.