### PR TITLE
Move ajax-console CSS to /shared

### DIFF
--- a/app/assets/stylesheets/shared/mixins.scss
+++ b/app/assets/stylesheets/shared/mixins.scss
@@ -1,0 +1,13 @@
+@mixin ajax-console {
+  background-color: #000;
+  border-radius: 5px;
+  color: #CCC;
+  margin: 4ex;
+  height: 400px;
+  overflow: scroll;
+  padding: 2ex 1ex;
+
+  .log {
+    margin-bottom: 5px;
+  }
+}

--- a/app/assets/stylesheets/snowcrash.scss
+++ b/app/assets/stylesheets/snowcrash.scss
@@ -1,4 +1,5 @@
 @import "bootstrap/mixins";
+@import "shared/mixins";
 @import "snowcrash/mixins";
 
 // theme-level imports and overrides

--- a/app/assets/stylesheets/snowcrash/mixins.scss
+++ b/app/assets/stylesheets/snowcrash/mixins.scss
@@ -53,5 +53,4 @@
   .log {
     margin-bottom: 5px;
   }
-
 }

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -1,6 +1,7 @@
 @import "snowcrash/modules/activities";
 @import "snowcrash/modules/alerts";
 @import "snowcrash/modules/configurations";
+@import "snowcrash/modules/console";
 @import "snowcrash/modules/export";
 @import "snowcrash/modules/issues";
 @import "snowcrash/modules/issues/merge";

--- a/app/assets/stylesheets/snowcrash/modules/console.scss
+++ b/app/assets/stylesheets/snowcrash/modules/console.scss
@@ -1,0 +1,7 @@
+@import 'shared/mixins';
+
+#console {
+  @include ajax-console;
+
+  max-height: 200px;
+}

--- a/app/assets/stylesheets/snowcrash/modules/items_table.scss
+++ b/app/assets/stylesheets/snowcrash/modules/items_table.scss
@@ -51,9 +51,3 @@
     .column-actions a { visibility: visible; }
   }
 }
-
-#console {
-  @include ajax-console;
-
-  max-height: 200px;
-}

--- a/app/assets/stylesheets/snowcrash/modules/uploads.scss
+++ b/app/assets/stylesheets/snowcrash/modules/uploads.scss
@@ -17,10 +17,6 @@ body.upload {
   .bar { background-color: #B4F5B4; width:0%; height:20px; border-radius: 3px; }
   .percent { position:absolute; display:inline-block; top:3px; left:48%; }
 
-  #console {
-    @include ajax-console;
-  }
-
   a[data-behavior~="show-hide"].collapsed:before
   {
     content:'(show)' ;


### PR DESCRIPTION
Port of changes from Pro (the console is now used by both Snowcrash and
Mintcreek, so the CSS neds to live in /shared)