### PR TITLE
update acts_as_tree to 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'jquery-fileupload-rails', '~> 0.3.4'
 gem 'jquery-hotkeys-rails'
 
 # Organize Node tree
-gem 'acts_as_tree'
+gem 'acts_as_tree', '~> 2.7.1'
 
 gem 'builder'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts_as_tree (2.6.1)
+    acts_as_tree (2.7.1)
       activerecord (>= 3.0.0)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
@@ -134,7 +134,8 @@ GEM
     html-pipeline (2.6.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    i18n (0.8.6)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     image_size (1.3.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -186,7 +187,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_mime (0.1.4)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     mono_logger (1.1.0)
     multi_json (1.12.1)
     mustermann (1.0.2)
@@ -346,7 +347,7 @@ GEM
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.3)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
@@ -378,7 +379,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth (= 4.3.1)
-  acts_as_tree
+  acts_as_tree (~> 2.7.1)
   bcrypt (= 3.1.10)
   bootstrap-sass (~> 2.3.2.2)
   brakeman


### PR DESCRIPTION
2.6.1 has a deprecation warning on Rails 5.1+, see
https://github.com/amerine/acts_as_tree/pull/67