### PR TITLE
Match revision history table header to column contents

### DIFF
--- a/app/views/revisions/show.html.erb
+++ b/app/views/revisions/show.html.erb
@@ -72,8 +72,8 @@
       <% @revisions.each do |revision| %>
         <tr <%= raw "class='active'" if revision == @revision %>>
           <% present(revision, RevisionPresenter) do |revision_presenter| %>
-            <td><%= revision_presenter.created_at_ago %></td>
             <td><%= revision_presenter.action %></td>
+            <td><%= revision_presenter.created_at_ago %></td>
             <td><%= revision_presenter.whodunnit %></td>
             <td>
               <% unless revision == @revisions.last %>


### PR DESCRIPTION
### Summary

A simple UI update. Currently, the table headers don't match the column contents in the revision history table: 

<img width="966" alt="screen shot 2018-05-15 at 11 34 26 am" src="https://user-images.githubusercontent.com/11186655/40070535-f91ec7e6-5833-11e8-907d-b52459eac4ca.png">


This PR updates the header so that it matches: 

<img width="969" alt="screen shot 2018-05-15 at 11 32 56 am" src="https://user-images.githubusercontent.com/11186655/40070468-c6e71c4c-5833-11e8-856d-0f7b9f70078b.png">



> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.