### PR TITLE
Bump mysql to 5.1.x from 3.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'json', '1.8.6'
 gem 'nokogiri', '1.8.2'
 
 # MySQL backend
-gem 'mysql2', '0.3.18'
+gem 'mysql2', '~> 0.5.1'
 
 # Textile markup
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     mono_logger (1.1.0)
     multi_json (1.13.1)
     mustermann (1.0.2)
-    mysql2 (0.3.18)
+    mysql2 (0.5.1)
     nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.8.2)
@@ -408,7 +408,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   local_time (>= 2.0.0)
-  mysql2 (= 0.3.18)
+  mysql2 (~> 0.5.1)
   nokogiri (= 1.8.2)
   paper_trail (~> 6.0)
   parslet (~> 1.6.0)


### PR DESCRIPTION
Old mysql2 gem fails to install when the dev libraries are from
libmariadb-client-dev / libmariadb-client-dev-compat.

New mysql2 version compiles with no issues

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
