### PR TITLE
fix long nodenames are cut

### DIFF
--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -292,7 +292,6 @@ body {
           &.node {
             a {
               word-break: break-all;
-              margin-left: 30px;
             }
           }
         }

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -171,6 +171,8 @@ body {
             display: inline-block;
             width: auto;
             color: lighten($primaryBgColor, 40%);
+            word-break: break-all;
+            line-height: 1.5em;
             &:hover {
               text-decoration: none;
               color: lighten($primaryBgColor, 50%);
@@ -288,12 +290,6 @@ body {
             display: none;
             font-size: 10px;
             padding: 0 0 1em 3em;
-          }
-          &.node {
-            a {
-              word-break: break-all;
-              line-height: 1.5em;
-            }
           }
         }
       }

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -289,6 +289,12 @@ body {
             font-size: 10px;
             padding: 0 0 1em 3em;
           }
+          &.node {
+            a {
+              word-break: break-all;
+              margin-left: 30px;
+            }
+          }
         }
       }
 

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -292,6 +292,7 @@ body {
           &.node {
             a {
               word-break: break-all;
+              line-height: 1.5em;
             }
           }
         }


### PR DESCRIPTION
### Summary

This is a  fix for issue #228 Long Names are Cut when using large node names.
after this fix long node names will break to newlines making it visible to end user.   



### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
