### PR TITLE
Make issues sidebar scrollable

### DIFF
--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -441,6 +441,11 @@ body {
           }
         }
 
+        .scrollable {
+          overflow-y: auto;
+          height: 500px;
+        }
+
         // there are links in the secondary-navbar that are outside a .list-item
         // and we them with the right color.
         a {

--- a/app/views/issues/_sidebar.html.erb
+++ b/app/views/issues/_sidebar.html.erb
@@ -9,10 +9,11 @@
   <% end %>
 </div>
 
+<%= render 'import_box' %>
+
 <%= render 'shared/sidebar_collection',
   name: 'Issues',
   collection: @issues,
   new_path: new_issue_path,
   category_id: nil
 %>
-<%= render 'import_box' %>

--- a/app/views/shared/_sidebar_collection.html.erb
+++ b/app/views/shared/_sidebar_collection.html.erb
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<div id="<%= name.downcase %>" class="note-list">
+<div id="<%= name.downcase %>" class="note-list scrollable">
   <% if collection.any? %>
     <%= render partial: collection.first.to_partial_path, collection: collection %>
   <% end %>


### PR DESCRIPTION
In the issues page, the sidebar that contains all of the issues is not scrollable.
This arises some usability problems. For example:

1. Create enough issues that the list goes off the bottom of the page.
2. Scroll down to the bottom of the page to find the import section.
3. Click the arrow to expand it
4. The search boxes are now off the bottom of the page so scroll down again to see them
5. Enter a search term
6. Scroll back up to the top of the window to see the results
7. Add a result
8. Scroll back down to the bottom of the page to find the new entry which is added as the last entry in the list.

i.e: too much scrolling up and down.

This PR does 2 things that may solve the problems commented above:
* Makes the issues sidebar scrollable
* Places the import box above the issues list in the sidebar

![issues_scroll](https://user-images.githubusercontent.com/85766/40513937-3392b78a-5f9f-11e8-884e-1d686eff10fe.gif)

Thoughts?



