### PR TITLE
Ignore vagrant local files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 /Gemfile.plugins
 /Gemfile.codeship
 
+# Vagrant
+.vagrant/
+
 # Random
 .DS_Store
 *.swp


### PR DESCRIPTION
The files placed at the .vagrant directory are relative to the host OS
and should not be committed to the git repository.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
