### PR TITLE
Restrict auto-generated routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   # Sign in / sign out
   get '/login'  => 'sessions#new'
   get '/logout' => 'sessions#destroy'
-  resource :session
+  resource :session, only: [:new, :create, :destroy]
 
   # ------------------------------------------------------------ Project routes
   concern :multiple_destroy do
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
     resources :revisions, only: [:index, :show]
   end
 
-  resources :methodologies do
+  resources :methodologies, only: [:index, :create, :edit, :update, :destroy] do
     collection { post :preview }
     member do
       get :add
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :nodes do
+  resources :nodes, only: [:create, :show, :edit, :update, :destroy] do
     collection do
       post :sort
       post :create_multiple
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
       get :tree
     end
 
-    resources :notes, concerns: :multiple_destroy do
+    resources :notes, only: [:new, :create, :show, :edit, :update, :destroy], concerns: :multiple_destroy do
       resources :revisions, only: [:index, :show]
     end
 
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
     end
 
     constraints(:filename => /.*/) do
-      resources :attachments, param: :filename
+      resources :attachments, only: [:index, :create, :show, :update, :destroy], param: :filename
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
       resources :revisions, only: [:index, :show]
     end
 
-    resources :evidence, except: :index, concerns: :multiple_destroy do
+    resources :evidence, only: [:new, :create, :show, :edit, :update, :destroy], concerns: :multiple_destroy do
       resources :revisions, only: [:index, :show]
     end
 


### PR DESCRIPTION
There are a couple of routes that are being auto-generated but they do not actually exist at the controller level.

The removed routes are:
```
            edit_session GET    /session/edit(.:format)                                       sessions#edit
                 session GET    /session(.:format)                                            sessions#show
                         PATCH  /session(.:format)                                            sessions#update
                         PUT    /session(.:format)                                            sessions#update
         new_methodology GET    /methodologies/new(.:format)                                  methodologies#new
             methodology GET    /methodologies/:id(.:format)                                  methodologies#show
              node_notes GET    /nodes/:node_id/notes(.:format)                               notes#index
     new_node_attachment GET    /nodes/:node_id/attachments/new(.:format)                     attachments#new
    edit_node_attachment GET    /nodes/:node_id/attachments/:filename/edit(.:format)          attachments#edit {:filename=>/.*/}
                   nodes GET    /nodes(.:format)                                              nodes#index
                new_node GET    /nodes/new(.:format)                                          nodes#new
```

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
