### PR TITLE
Notifications table

### DIFF
--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -1,0 +1,7 @@
+module Notifiable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :notifications, as: :notifiable, dependent: :destroy
+  end
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,5 @@
 class Issue < Note
-  include Commentable, Taggable
+  include Commentable, Notifiable, Taggable
 
   # -- Relationships --------------------------------------------------------
   has_many :evidence, dependent: :destroy

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,25 @@
+class Notification < ApplicationRecord
+  # -- Relationships --------------------------------------------------------
+  belongs_to :actor, class_name: 'User'
+  belongs_to :recipient, class_name: 'User'
+  belongs_to :notifiable, polymorphic: true
+
+  # -- Callbacks ------------------------------------------------------------
+
+  # -- Validations ----------------------------------------------------------
+  validates :action, presence: true
+  validates :actor, presence: true, associated: true
+  validates :notifiable, presence: true, associated: true
+  validates :recipient, presence: true, associated: true
+
+  # -- Scopes ---------------------------------------------------------------
+  scope :unread,  -> { where(read_at: nil) }
+  scope :read,    -> { where.not(read_at: nil) }
+
+  # -- Class Methods --------------------------------------------------------
+
+  # -- Instance Methods -----------------------------------------------------
+  def read?
+    self.read_at
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # -- Relationships --------------------------------------------------------
   has_many :activities
   has_many :comments
+  has_many :notifications
 
   # -- Callbacks ------------------------------------------------------------
   # -- Validations ----------------------------------------------------------

--- a/db/migrate/20180612095838_create_notifications.rb
+++ b/db/migrate/20180612095838_create_notifications.rb
@@ -1,0 +1,15 @@
+class CreateNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :notifications do |t|
+      t.string      :action
+      t.datetime    :read_at
+
+      t.references  :notifiable, polymorphic: true, index: true
+
+      t.references  :actor, index: true, foreign_key: { to_table: :user }
+      t.references  :recipient, index: true, foreign_key: { to_table: :user }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180611150236) do
+ActiveRecord::Schema.define(version: 20180612095838) do
 
   create_table "activities", force: :cascade do |t|
     t.string "user", null: false
@@ -88,6 +88,20 @@ ActiveRecord::Schema.define(version: 20180611150236) do
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_notes_on_category_id"
     t.index ["node_id"], name: "index_notes_on_node_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.string "action"
+    t.datetime "read_at"
+    t.string "notifiable_type"
+    t.integer "notifiable_id"
+    t.integer "actor_id"
+    t.integer "recipient_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "index_notifications_on_actor_id"
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Notification do
+  it { should belong_to :actor }
+  it { should belong_to :notifiable }
+  it { should belong_to :recipient }
+
+  it { should validate_presence_of :action }
+  it { should validate_presence_of :actor }
+  it { should validate_presence_of :notifiable }
+  it { should validate_presence_of :recipient }
+end


### PR DESCRIPTION
### Spec
From now on, we may need somewhere to store notifications (as messages that the user may be interested in reading). Example: a comment is created on an issue the current user created.

**Proposed solution**

Propose a table structure + db model that allows us to store notifications in db.
The proposed table must be able to store a notification with info that tells us:

- what item was changed (an issue by now, but keep the door open to any model)
- what action was done on the issue (action)
- who did that (actor)
- who must be notified (recipient)

### How to test
Specs should pass.