### PR TITLE
Comments list (in main tab)

### DIFF
--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -1,0 +1,45 @@
+class CommentPresenter < BasePresenter
+  presents :comment
+
+  def avatar_with_link(size)
+    h.link_to(avatar_image(size), 'javascript:void(0)')
+  end
+
+  def created_at_ago
+    h.local_time_ago(comment.created_at)
+  end
+
+  # Interestingly enough we're not linking the email to anything yet as we
+  # don't know what we should link to. For the time being lets just enclose
+  # it in a strong tag.
+  def linked_email
+    if comment.user
+      # h.link_to(activity.user.email, 'javascript:void(0);')
+      h.content_tag :strong, comment.user.email
+    else
+      'a user who has since been deleted'
+    end
+  end
+
+  def render_content
+    comment.content
+    # TODO: render_partial
+  end
+
+  private
+
+  def avatar_image(size)
+    if comment.user
+      h.image_tag(
+        image_path('profile.jpg'),
+        alt: comment.user,
+        class: 'gravatar',
+        data: { fallback_image: image_path('logo_small.png') },
+        title: comment.user,
+        width: size
+      )
+    else
+      h.image_tag 'logo_small.png', width: size, alt: 'This user has been deleted from the system'
+    end
+  end
+end

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -2,7 +2,7 @@ class CommentPresenter < BasePresenter
   presents :comment
 
   def avatar_with_link(size)
-    h.link_to(avatar_image(size), 'javascript:void(0)')
+    h.link_to(avatar_image(size), "##{dom_id(comment)}")
   end
 
   def created_at_ago

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -23,7 +23,6 @@ class CommentPresenter < BasePresenter
 
   def render_content
     comment.content
-    # TODO: render_partial
   end
 
   private
@@ -32,10 +31,10 @@ class CommentPresenter < BasePresenter
     if comment.user
       h.image_tag(
         image_path('profile.jpg'),
-        alt: comment.user,
+        alt: comment.user.email,
         class: 'gravatar',
         data: { fallback_image: image_path('logo_small.png') },
-        title: comment.user,
+        title: comment.user.email,
         width: size
       )
     else

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -1,0 +1,23 @@
+<div class="comment-feed">
+  <% if comments.any? %>
+    <% comments.each do |comment| %>
+      <% present comment do |comment_presenter| %>
+        <%= div_for comment do %>
+          <div class="body">
+            <%= comment_presenter.avatar_with_link(30) %>
+
+            <div>
+              <%= comment_presenter.linked_email %> <%= comment_presenter.created_at_ago %>
+            </div>
+
+            <div class="content">
+              <%= comment_presenter.render_content %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <p class="no-content">There has been no comments yet.</p>
+  <% end %>
+</div>

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -1,0 +1,2 @@
+<h3>Comments</h3>
+<%= render 'comments/feed', comments: @issue.comments %>

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -1,2 +1,2 @@
-<h3>Comments</h3>
+<h3>Comments <span class="badge"><%= @issue.comments.count %></span></h3>
 <%= render 'comments/feed', comments: @issue.comments %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -22,11 +22,10 @@
   </li>
   <li><a href="#evidence-tab" data-toggle="tab"><i class="fa fa-laptop"></i> Evidence <span class="badge"><%= @issue.evidence.count %></span></a></li>
   <li><a href="#activity-tab" data-toggle="tab"><i class="fa fa-refresh"></i> Recent activity</a></li>
-  <li><a href="#comments-tab" data-toggle="tab"><i class="fa fa-comments"></i> Comments <span class="badge"><%= @issue.comments.count %></span></a></li>
 </ul>
 
 <div class="tab-content">
-  <% cache ['issue-information-tab', @issue] do %>
+  <% cache ['issue-information-tab', @issue, @comments ] do %>
     <div class="tab-pane active" id="info-tab">
       <div class="inner note-text-inner">
         <h3>Issue information -
@@ -48,6 +47,10 @@
         <div class="content-textile">
           <%= markup(@issue.text) %>
         </div>
+      </div>
+
+      <div class="inner">
+        <%= render partial: 'comments' %>
       </div>
     </div>
   <% end %>
@@ -72,14 +75,6 @@
     <div class="tab-pane" id="activity-tab">
       <div class="inner">
         <%= render partial: 'activity' %>
-      </div>
-    </div>
-  <% end %>
-
-  <% cache ['issue-comments-tab', @issue, @comments] do %>
-    <div class="tab-pane" id="comments-tab">
-      <div class="inner">
-        <%= render partial: 'comments' %>
       </div>
     </div>
   <% end %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -22,6 +22,7 @@
   </li>
   <li><a href="#evidence-tab" data-toggle="tab"><i class="fa fa-laptop"></i> Evidence <span class="badge"><%= @issue.evidence.count %></span></a></li>
   <li><a href="#activity-tab" data-toggle="tab"><i class="fa fa-refresh"></i> Recent activity</a></li>
+  <li><a href="#comments-tab" data-toggle="tab"><i class="fa fa-comments"></i> Comments <span class="badge"><%= @issue.comments.count %></span></a></li>
 </ul>
 
 <div class="tab-content">
@@ -71,6 +72,14 @@
     <div class="tab-pane" id="activity-tab">
       <div class="inner">
         <%= render partial: 'activity' %>
+      </div>
+    </div>
+  <% end %>
+
+  <% cache ['issue-comments-tab', @issue, @comments] do %>
+    <div class="tab-pane" id="comments-tab">
+      <div class="inner">
+        <%= render partial: 'comments' %>
       </div>
     </div>
   <% end %>

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    commentable { |comment| comment.association :issue }
+    sequence(:content) { |n| "Comment #{n}" }
+    association :user
+  end
+end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -252,8 +252,12 @@ describe "Issues pages" do
           visit issue_path(@issue)
         end
 
-        let(:extra_setup) { create_activities }
+        let(:extra_setup) do
+          create_activities
+          create_comments
+        end
         let(:create_activities) { nil }
+        let(:create_comments) { nil }
 
         context "when there are host nodes with evidence" do
           let(:extra_setup) do
@@ -293,6 +297,9 @@ describe "Issues pages" do
 
         let(:trackable) { @issue }
         it_behaves_like "a page with an activity feed"
+
+        let(:commentable) { @issue }
+        it_behaves_like "a page with a comments feed"
 
         describe "clicking 'delete'" do
           before { visit issue_path(@issue) }

--- a/spec/support/comment_macros.rb
+++ b/spec/support/comment_macros.rb
@@ -1,0 +1,13 @@
+module CommentMacros
+  extend ActiveSupport::Concern
+
+  include ActionView::RecordIdentifier
+  
+  def comment_feed
+    '.comment-feed'
+  end
+
+  def have_comment(comment)
+    have_selector "##{dom_id(comment)}"
+  end
+end

--- a/spec/support/comment_shared_examples.rb
+++ b/spec/support/comment_shared_examples.rb
@@ -1,0 +1,28 @@
+# Define the following let variables before using these examples:
+#
+#   create_comments : a block which creates the activities AND IS CALLED
+#                     BEFORE THE PAGE LOADS
+#   commentable: the model which the 'show' page is about
+shared_examples 'a page with a comments feed' do
+
+  describe 'when the model has comments' do
+    include CommentMacros
+
+    let(:create_comments) do
+      @comments = [
+        create(:comment, commentable: commentable),
+        create(:comment, commentable: commentable)
+      ]
+      other_instance = create(commentable.class.to_s.underscore)
+      @other_comment = create(:comment, commentable: other_instance)
+    end
+
+    it 'lists them in the content feed' do
+      within comment_feed do
+        should have_comment(@comments[0])
+        should have_comment(@comments[1])
+        should_not have_comment(@other_comment)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Spec
We are adding comments to some items: issues, evidence, notes (maybe nodes?).

The first thing we need is a place to be able to read the comments related to the commentable item

When I see an item that allows comments, I want to see a comments tab, so I can check comments

**Proposed solution**
Add comments to the bottom of the main tab.

Make a quick proposal of the UX (html or not) to be shared with the rest of the team asap working on this.

The comments create, update, delete actions are not part of this task.
Adding a comments count is not part of this task.

We should use a partial to share the view among all items that may have comments.

### How to test
* Use the rails console to add a fe comments to an issue. Maybe like this:    
  `Comment.create(commentable: Issue.first, user: User.first, content: "hello")`
* Visit the item, assert the comments looks nice.