### PR TITLE
Add comment charset migration and database config updates

### DIFF
--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -17,8 +17,8 @@ development:
 # If you uncomment this development: block, comment the previous one.
 # development:
 #   adapter: mysql2
-#   encoding: utf8
-#   collation: utf8_bin
+#   encoding: utf8mb4
+#   collation: utf8mb4_unicode_ci
 #   database: dradis_dev
 #   username: root
 #   socket: /tmp/mysql.sock

--- a/db/migrate/20180620124108_use_utf8_mb4_for_comments.rb
+++ b/db/migrate/20180620124108_use_utf8_mb4_for_comments.rb
@@ -1,0 +1,11 @@
+class UseUtf8Mb4ForComments < ActiveRecord::Migration[5.1]
+  def up
+    execute "ALTER TABLE comments CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    execute "ALTER TABLE comments MODIFY content TEXT CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci"
+  end
+
+  def down
+    execute "ALTER TABLE comments CHARSET utf8 COLLATE utf8_bin"
+    execute "ALTER TABLE comments MODIFY content TEXT CHARSET utf8 COLLATE utf8_bin"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180613151829) do
+ActiveRecord::Schema.define(version: 20180620124108) do
 
   create_table "activities", force: :cascade do |t|
     t.string "user", null: false


### PR DESCRIPTION
### Spec
Currently, emojis cannot be saved in the database.

#### Proposed Solution
Update the character set for comments to allow emojis in the database.

### How to test
1. Run rails db:migrate
2. Create a comment with content with your favorite emoji.
3. Assert that it is saved.

