### PR TITLE
Create a project_path() route so we can nest other top-level resources

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,4 @@
+class CommentsController < AuthenticatedController
+  include ProjectScoped
+end
+

--- a/app/controllers/concerns/project_scoped.rb
+++ b/app/controllers/concerns/project_scoped.rb
@@ -1,0 +1,33 @@
+module ProjectScoped
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_project
+
+    helper :snowcrash
+    layout 'snowcrash'
+  end
+
+  protected
+  # Internal: Sets saves the current :project_id as PaperTrail::Version metadata
+  # this is going to allow us to speed up recovery of Versions scoped to the
+  # current project.
+  #
+  # See also:
+  #
+  #   https://github.com/airblade/paper_trail#metadata-from-controllers
+  #
+  def info_for_paper_trail
+    { project_id: @project.id } if project
+  end
+
+  def set_project
+    # authorize! :use, project
+
+    # @nodes = project.nodes.in_tree
+  end
+
+  def project
+    @project ||= OpenStruct.new(id: 1)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@ class HomeController < ProjectScopedController
   skip_before_action :set_current_project, only: [:markup_help, :textilize]
 
   def index
-    redirect_to summary_path
+    redirect_to project_path(id: 1)
   end
 
   # Returns the markup cheatsheet that is used by the jQuery.Textile plugin Help

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -31,7 +31,7 @@ class NodesController < NestedNodeResourceController
       if parent && parent.user_node?
         redirect_to parent, alert: @node.errors.full_messages.join('; ')
       else
-        redirect_to summary_path, alert: @node.errors.full_messages.join('; ')
+        redirect_to project_path(id: 1), alert: @node.errors.full_messages.join('; ')
       end
     end
   end
@@ -57,7 +57,7 @@ class NodesController < NestedNodeResourceController
     end
 
     flash[:notice] = "Successfully created #{list.length} node#{'s' if list.many?}"
-    redirect_to @parent ? node_path(@parent) : summary_path
+    redirect_to @parent ? node_path(@parent) : project_path(id: 1)
   end
 
   # POST /nodes/sort
@@ -96,7 +96,7 @@ class NodesController < NestedNodeResourceController
     if parent
       redirect_to parent
     else
-      redirect_to summary_path
+      redirect_to project_path(id: 1)
     end
   end
 

--- a/app/views/layouts/snowcrash/_navbar.html.erb
+++ b/app/views/layouts/snowcrash/_navbar.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </a>
-      <%= link_to 'Dradis CE', main_app.summary_path, class: 'brand' %>
+      <%= link_to 'Dradis CE', main_app.project_path(id: 1), class: 'brand' %>
       <div class="navbar-collapse" id="bs-navbar-collapse">
         <ul class="nav pull-right">
           <li><%= link_to main_app.search_path, id: 'js-search-form-toggle' do %><i class="fa fa-search fa-lg"></i><% end %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   end
 
   resources :projects, only: [:show] do
-
+    resources :comments
   end
 
   resources :activities, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/summary' => 'projects#show'
+  resources :projects, only: [:show] do
+
+  end
 
   resources :activities, only: [] do
     collection do

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -8,7 +8,7 @@ describe "node pages" do
   describe "creating new nodes" do
     context "when a project has no nodes defined yet" do
       it "says so in the sidebar" do
-        visit summary_path(@project)
+        visit project_path(id: @project.id)
         within ".main-sidebar" do
           should have_selector ".no-nodes", text: "No nodes defined yet"
         end
@@ -17,7 +17,7 @@ describe "node pages" do
 
     describe "clicking the '+' button in the 'Nodes' sidebar", js: true do
       before do
-        visit summary_path
+        visit project_path(id: @project.id)
         find(".add-subnode > a").click
       end
 
@@ -198,7 +198,7 @@ describe "node pages" do
       let(:submit_form) do
         within "#modal_delete_node" do
           click_link "Delete"
-          expect(current_path).to eq summary_path
+          expect(current_path).to eq project_path(id: @project.id)
         end
       end
 


### PR DESCRIPTION
Initial changes to allow nesting of resources inside projects to allow for one-project-per-tab URLs