### PR TITLE
Issues#show - always show Send to, make into a trigger link

### DIFF
--- a/app/views/issues/_send_to_menu.html.erb
+++ b/app/views/issues/_send_to_menu.html.erb
@@ -1,16 +1,22 @@
-<% sync_plugins = Dradis::Plugins::with_feature(:issue_sync) %>
-<% if sync_plugins.any? %>
 <span class="dropdown">
   <a class="dropdown-toggle action-link" data-name="issues" data-toggle="dropdown" href="javascript:void(0)">
     Send to...
   </a>
   <ul class="dropdown-menu" role="menu">
-  <% Dradis::Plugins::with_feature(:issue_sync).each do |plugin| %>
-    <%=
-      plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
-      render partial: "#{plugin_path}/issues/send_to_menu"
-    %>
+  <% sync_plugins = Dradis::Plugins::with_feature(:issue_sync) %>
+  <% if sync_plugins.any? %>
+    <% sync_plugins.each do |plugin| %>
+      <%=
+        plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
+        render partial: "#{plugin_path}/issues/send_to_menu"
+      %>
+    <% end %>
+  <% end %>
+  <% unless defined?(Dradis::Pro) && sync_plugins.include?(Dradis::Pro::Issuelib::Engine) %>
+    <% if sync_plugins.any? %>
+    <li class="divider"></li>
+    <% end %>
+    <li><a href="javascript:void(0)" class="js-try-pro" data-term="issuelib" data-url="http://drad.is/l/try-pro-issuelib"><i class="fa fa-book"></i> Built-in IssueLibrary</a></li>
   <% end %>
   </ul>
 </span> - 
-<% end %>


### PR DESCRIPTION
This PR changes the `Send to...` menu so it's always shown. A trigger link for the built-in IssueLibrary is added if the add-on isn't loaded yet.