### PR TITLE
Nest Issues resource under :project

### DIFF
--- a/app/controllers/concerns/conflict_resolver.rb
+++ b/app/controllers/concerns/conflict_resolver.rb
@@ -1,0 +1,28 @@
+module ConflictResolver
+  extend ActiveSupport::Concern
+
+  protected
+  def check_for_edit_conflicts(record, updated_at_before_save)
+    name = record.model_name.name.downcase
+    if params[name][:original_updated_at].to_i < updated_at_before_save
+      # Even if there have been edit conflicts, the save will still be
+      # successful, which means we're going to *redirect* to another action
+      # (#show), rather than just simply rendering a template - which means
+      # all the current variables and params will be forgotten. But we still
+      # need to pass information about the edit conflicts to the next action,
+      # so we use the flash.
+      #
+      # Only primitive types (String, Array, Hash) can be saved in the flash;
+      # we can't use it to pass a Time objec - so pass the time as a string.
+      flash[:update_conflicts_since] = Time.at(params[name][:original_updated_at].to_i + 1).utc.to_s(:db)
+    end
+  end
+
+  def load_conflicting_revisions(record)
+    if flash[:update_conflicts_since]
+      @conflicting_revisions = record.versions\
+        .order("created_at ASC")\
+        .where("created_at > '#{flash[:update_conflicts_since]}'")
+    end
+  end
+end

--- a/app/controllers/concerns/project_scoped.rb
+++ b/app/controllers/concerns/project_scoped.rb
@@ -18,16 +18,11 @@ module ProjectScoped
   #   https://github.com/airblade/paper_trail#metadata-from-controllers
   #
   def info_for_paper_trail
-    { project_id: @project.id } if project
+    ;
   end
 
   def set_project
-    # authorize! :use, project
-
-    # @nodes = project.nodes.in_tree
-  end
-
-  def project
-    @project ||= OpenStruct.new(id: 1)
+    @nodes   = Node.in_tree
+    @project = Project.new
   end
 end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -1,4 +1,5 @@
 class EvidenceController < NestedNodeResourceController
+  include ConflictResolver
   include MultipleDestroy
 
   before_action :find_or_initialize_evidence, except: [ :index, :create_multiple ]

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -68,7 +68,7 @@ class EvidenceController < NestedNodeResourceController
         )
       end
     end
-    redirect_to issue_path(evidence_params[:issue_id]), notice: 'Evidence added for selected nodes.'
+    redirect_to project_issue_path(@project, evidence_params[:issue_id]), notice: 'Evidence added for selected nodes.'
   end
 
   def edit

--- a/app/controllers/issues/merge_controller.rb
+++ b/app/controllers/issues/merge_controller.rb
@@ -9,7 +9,7 @@ class Issues::MergeController < IssuesController
     end
 
     if @issues.count <= 1
-      redirect_to issues_url,
+      redirect_to projects_issues_url(@project),
         alert: 'You need to select at least two issues to merge.'
     end
   end
@@ -37,9 +37,9 @@ class Issues::MergeController < IssuesController
     respond_to do |format|
       format.html {
         if count > 0
-          redirect_to @issue, notice: "#{count} #{'issue'.pluralize(count)} merged into #{@issue.title}."
+          redirect_to [@project, @issue], notice: "#{count} #{'issue'.pluralize(count)} merged into #{@issue.title}."
         else
-          redirect_to issues_url, alert: "Issues couldn't be merged."
+          redirect_to project_issues_path(@project), alert: "Issues couldn't be merged."
         end
       }
       format.json

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,7 +1,9 @@
-class IssuesController < ProjectScopedController
+class IssuesController < AuthenticatedController
+  include ActivityTracking
   include ContentFromTemplate
   include ConflictResolver
   include MultipleDestroy
+  include ProjectScoped
 
   before_action :find_issuelib
   before_action :find_issues, except: [:destroy]
@@ -57,7 +59,7 @@ class IssuesController < ProjectScopedController
         # taggable IDs)
         tag_issue_from_field_content(@issue)
 
-        format.html { redirect_to @issue, notice: 'Issue added.' }
+        format.html { redirect_to [@project, @issue], notice: 'Issue added.' }
       else
         format.html { render 'new', alert: 'Issue couldn\'t be added.' }
       end
@@ -76,7 +78,7 @@ class IssuesController < ProjectScopedController
         @modified = true
         check_for_edit_conflicts(@issue, updated_at_before_save)
         track_updated(@issue)
-        format.html { redirect_to @issue, notice: 'Issue updated' }
+        format.html { redirect_to project_issue_path(@project, @issue), notice: 'Issue updated' }
       else
         format.html { render 'edit' }
       end
@@ -89,10 +91,10 @@ class IssuesController < ProjectScopedController
     respond_to do |format|
       if @issue.destroy
         track_destroyed(@issue)
-        format.html { redirect_to issues_url, notice: 'Issue deleted.' }
+        format.html { redirect_to project_issues_url(@project), notice: 'Issue deleted.' }
         format.json
       else
-        format.html { redirect_to issues_url, notice: "Error while deleting issue: #{@issue.errors}" }
+        format.html { redirect_to project_issues_url(@project), notice: "Error while deleting issue: #{@issue.errors}" }
         format.json
       end
     end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,5 +1,6 @@
 class IssuesController < ProjectScopedController
   include ContentFromTemplate
+  include ConflictResolver
   include MultipleDestroy
 
   before_action :find_issuelib

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,7 @@
 # This controller exposes the REST operations required to manage the Note
 # resource.
 class NotesController < NestedNodeResourceController
+  include ConflictResolver
   include MultipleDestroy
 
   before_action :find_or_initialize_note, except: [:index, :new, :multiple_destroy]

--- a/app/controllers/project_scoped_controller.rb
+++ b/app/controllers/project_scoped_controller.rb
@@ -22,30 +22,7 @@ class ProjectScopedController < AuthenticatedController
   end
 
   def set_current_project
-    @nodes = Node.in_tree
-  end
-
-  def check_for_edit_conflicts(record, updated_at_before_save)
-    name = record.model_name.name.downcase
-    if params[name][:original_updated_at].to_i < updated_at_before_save
-      # Even if there have been edit conflicts, the save will still be
-      # successful, which means we're going to *redirect* to another action
-      # (#show), rather than just simply rendering a template - which means
-      # all the current variables and params will be forgotten. But we still
-      # need to pass information about the edit conflicts to the next action,
-      # so we use the flash.
-      #
-      # Only primitive types (String, Array, Hash) can be saved in the flash;
-      # we can't use it to pass a Time objec - so pass the time as a string.
-      flash[:update_conflicts_since] = Time.at(params[name][:original_updated_at].to_i + 1).utc.to_s(:db)
-    end
-  end
-
-  def load_conflicting_revisions(record)
-    if flash[:update_conflicts_since]
-      @conflicting_revisions = record.versions\
-        .order("created_at ASC")\
-        .where("created_at > '#{flash[:update_conflicts_since]}'")
-    end
+    @nodes   = Node.in_tree
+    @project = Project.new
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,5 @@
 class ProjectsController < AuthenticatedController
+  before_action :set_project, only: :show
   helper :snowcrash
   layout 'snowcrash'
 
@@ -29,5 +30,10 @@ class ProjectsController < AuthenticatedController
         end
       end
     end
+  end
+
+  private
+  def set_project
+    @project = Project.new
   end
 end

--- a/app/helpers/revisions_helper.rb
+++ b/app/helpers/revisions_helper.rb
@@ -11,7 +11,7 @@ module RevisionsHelper
     # 'Note' before they can reach 'Issue' FIXME - ISSUE/NOTE INHERITANCE
     case record
     when Issue
-      issue_revisions_path(record)
+      project_issue_revisions_path(@project, record)
     when Note
       node_note_revisions_path(record.node, record)
     when Evidence
@@ -24,7 +24,7 @@ module RevisionsHelper
     # 'Note' before they can reach 'Issue' FIXME - ISSUE/NOTE INHERITANCE
     case record
     when Issue
-      issue_revision_path(record, revision)
+      project_issue_revision_path(@project, record, revision)
     when Note
       node_note_revision_path(record.node, record, revision)
     when Evidence

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,10 @@
+class Project
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+
+  def id; 1; end
+
+  def name; 'Dradis CE'; end
+
+  def persisted?; true; end
+end

--- a/app/views/activities/_evidence.html.erb
+++ b/app/views/activities/_evidence.html.erb
@@ -1,7 +1,7 @@
 <% if evidence %>
   <% issue = evidence.issue %>
   <% node  = evidence.node %>
-  <%= presenter.verb %> <%= link_to 'a piece of evidence', [node, evidence] %> for <%= link_to issue.title || "Issue #{issue.id}", evidence.issue %> at <%= link_to node.label, node %>.
+  <%= presenter.verb %> <%= link_to 'a piece of evidence', [node, evidence] %> for <%= link_to issue.title || "Issue #{issue.id}", [@project, evidence.issue] %> at <%= link_to node.label, node %>.
 <% else %>
   <% if activity.action == 'destroy' %>
     deleted a piece of evidence.

--- a/app/views/activities/_issue.html.erb
+++ b/app/views/activities/_issue.html.erb
@@ -2,7 +2,7 @@
   <% if issue.title? %>
     <%= presenter.verb %> the <%= link_to issue.title, [@project, issue] %> issue.
   <% else %>
-    <%= presenter.verb %> <%= link_to "Issue ##{issue.id}", issue %>.
+    <%= presenter.verb %> <%= link_to "Issue ##{issue.id}", [@project, issue] %>.
   <% end %>
 <% else %>
   <% if activity.action == 'destroy' %>

--- a/app/views/activities/_issue.html.erb
+++ b/app/views/activities/_issue.html.erb
@@ -1,6 +1,6 @@
 <% if issue %>
   <% if issue.title? %>
-    <%= presenter.verb %> the <%= link_to issue.title, issue %> issue.
+    <%= presenter.verb %> the <%= link_to issue.title, [@project, issue] %> issue.
   <% else %>
     <%= presenter.verb %> <%= link_to "Issue ##{issue.id}", issue %>.
   <% end %>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -51,7 +51,7 @@
           <h3>
             Issue information -
             <span class="actions">
-            <%= link_to 'Open', issue_path(@issue), class: 'action-link' %> -
+            <%= link_to 'Open', project_issue_path(@project, @issue), class: 'action-link' %> -
             <%= tag_and_name_for(@issue) %>
             </span>
           </h3>

--- a/app/views/issues/_activity.html.erb
+++ b/app/views/issues/_activity.html.erb
@@ -8,7 +8,7 @@
       #%>
     <%= link_to(
           'revision history',
-          issue_revisions_path(@issue),
+          project_issue_revisions_path(@project, @issue),
           class: 'action-link'
     ) if @issue.has_revision_history? %>
   </span>

--- a/app/views/issues/_evidence.html.erb
+++ b/app/views/issues/_evidence.html.erb
@@ -11,7 +11,7 @@
       <% @affected_nodes.each do |node| %>
         <% cache [@issue, node, node.evidence_count, 'evidence-nav'] do %>
           <li>
-            <a href="#evidence_for_<%= dom_id(node) %>" data-toggle="tab" data-path="<%= issue_node_path(@issue, node) %>" data-node="<%= "evidence_for_#{dom_id(node)}" %>">
+            <a href="#evidence_for_<%= dom_id(node) %>" data-toggle="tab" data-path="<%= project_issue_node_path(@project, @issue, node) %>" data-node="<%= "evidence_for_#{dom_id(node)}" %>">
               <i class="fa fa-<%= ['folder-o','laptop'][node.type_id] %>"></i> <%= node.label %> (<%= node.evidence_count %>)
             </a>
           </li>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @issue do |f| %>
+<%= simple_form_for [@project, @issue] do |f| %>
   <%= f.error_notification %>
 
   <%= f.input :text, label: false, input_html: { class: 'textile', data: { preview_url: preview_path, help_url: markup_path } } %>
@@ -11,6 +11,6 @@
 
   <div class="form-actions">
     <%= f.button :submit, nil, class: 'btn btn-primary' %> or
-    <%= link_to 'Cancel', @issue.new_record? ? issues_path : @issue, class: 'cancel-link' %>
+    <%= link_to 'Cancel', @issue.new_record? ? project_issues_path(@project) : [@project, @issue], class: 'cancel-link' %>
   </div>
 <% end %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -6,18 +6,18 @@
 <%= content_tag :div, id: "#{dom_id(issue)}_link", class: item_css.join do %>
 
   <div class="expansion-container">
-    <%= link_to issue, class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
+    <%= link_to [@project, issue], class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
       <%= colored_icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
       <%= issue.title %>
     <% end %>
   </div>
 
   <div class="list-item-actions">
-    <%= link_to edit_issue_path(issue), class:'list-item-action-edit' do %>
+    <%= link_to edit_project_issue_path(@project, issue), class:'list-item-action-edit' do %>
       <i class="fa fa-pencil"></i> Edit
     <% end %>
 
-    <%= link_to issue,
+    <%= link_to [@project, issue],
           method: :delete,
           data: { confirm: 'Are you sure?' },
           class: 'list-item-action-delete' do %>

--- a/app/views/issues/_sidebar.html.erb
+++ b/app/views/issues/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="note-list">
-  <%= content_tag :div, id: 'issue_summary_link', class: current_page?(issues_path) ? 'list-item active' : 'list-item' do %>
+  <%= content_tag :div, id: 'issue_summary_link', class: current_page?(project_issues_path(@project)) ? 'list-item active' : 'list-item' do %>
     <div class="expansion-container">
-      <%= link_to issues_path(), class: 'view-toggle-off' do %>
+      <%= link_to project_issues_path(@project), class: 'view-toggle-off' do %>
         <i class="fa fa-bar-chart"></i>
         Summary of issues
       <% end %>
@@ -12,7 +12,7 @@
 <%= render 'shared/sidebar_collection',
   name: 'Issues',
   collection: @issues,
-  new_path: new_issue_path,
+  new_path: new_project_issue_path(@project),
   category_id: nil
 %>
 <%= render 'import_box' %>

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -12,13 +12,13 @@
       <% issues.each do |issue| %>
       <% cache [issue, @columns, issue.affected_count, 'issues-table'] do%>
       <tr>
-        <td class="column-checkbox"><%= check_box_tag dom_id(issue, :checkbox), issue.id, false, class: 'js-multicheck', data: { url: issue_path(issue, format: :json) } %></td>
+        <td class="column-checkbox"><%= check_box_tag dom_id(issue, :checkbox), issue.id, false, class: 'js-multicheck', data: { url: project_issue_path(@project, issue, format: :json) } %></td>
         <% @columns.each do |column| %>
         <td>
           <%=
           case column
           when 'Title'
-            link_to(issue.title, issue)
+            link_to(issue.title, [@project, issue])
           when 'Tags'
             tag_and_name_for(issue)
           when 'Affected'
@@ -37,10 +37,10 @@
         </td>
         <% end  %>
         <td class="column-actions">
-          <%= link_to edit_issue_path(issue), class: '' do %>
+          <%= link_to edit_project_issue_path(@project, issue), class: '' do %>
             <i class="fa fa-pencil"></i> Edit
           <% end %>
-          <%= link_to issue, method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-error' do %>
+          <%= link_to [@project, issue], method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-error' do %>
             <i class="fa fa-trash"></i> Delete
           <% end %>
         </td>

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -19,7 +19,7 @@
       class="btn"
       id="merge-selected"
       title="Merge into one issue"
-      data-url="<%= new_merge_path() %>"
+      data-url="<%= new_project_merge_path(@project) %>"
     >
       <i class="fa fa-compress"></i> Merge
     </a>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -11,9 +11,9 @@
 
     <% if @issues.any? %>
       <div id="issues-table"
-           data-destroy-url="<%= multiple_destroy_issues_path %>"
+           data-destroy-url="<%= multiple_destroy_project_issues_path(@project) %>"
            data-storage-key="project.ce.issue_columns"
-           data-close-console-url="<%= issues_path %>">
+           data-close-console-url="<%= project_issues_path(@project) %>">
         <%= render 'toolbar' %>
         <%= render 'table', issues: @issues %>
       </div>

--- a/app/views/issues/merge/new.html.erb
+++ b/app/views/issues/merge/new.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :breadcrums do %>
   <ul class="breadcrumb">
-    <li><%= link_to 'All issues', issues_path %> <span class="divider">/</span></li>
+    <li><%= link_to 'All issues', project_issues_path(@project) %> <span class="divider">/</span></li>
     <li class="active">Merge issues</li>
   </ul>
 <% end %>
@@ -15,7 +15,7 @@
   <div class="inner note-text-inner">
     <h3>You're merging <%= @issues.count %> Issues into a target Issue</h3>
 
-    <%= form_tag merge_index_path do %>
+    <%= form_tag project_merge_index_path(@project) do %>
       <p>
         Select an existing Issue to merge into, or create a new one.
       </p>
@@ -86,7 +86,7 @@
 
       <div class="form-actions">
         <%= button_tag 'Merge issues', class: 'btn btn-primary' %> or
-        <%= link_to 'Cancel', issues_path, class: 'cancel-link' %>
+        <%= link_to 'Cancel', project_issues_path(@project), class: 'cancel-link' %>
       </div>
     <% end %>
   </div>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -10,7 +10,7 @@
 
 <!-- Main content -->
 <ul class="breadcrumb">
-  <li><%= link_to 'All issues', issues_path() %> <span class="divider">/</span></li>
+  <li><%= link_to 'All issues', project_issues_path(@project) %> <span class="divider">/</span></li>
   <li class="active"><%= (@issue.title? ? @issue.title : "Issue ##{@issue.id}")%></li>
 </ul>
 
@@ -30,11 +30,11 @@
       <div class="inner note-text-inner">
         <h3>Issue information -
           <span class="actions">
-            <%= link_to edit_issue_path(@issue),
+            <%= link_to edit_project_issue_path(@project, @issue),
                   class: 'action-link' do %>
               <i class="fa fa-pencil"></i> Edit
             <% end %>
-            <%= link_to @issue,
+            <%= link_to [@project, @issue],
                   class: 'action-link text-error',
                   data: { confirm: 'Are you sure?' },
                   method: :delete do %>

--- a/app/views/layouts/snowcrash.html.erb
+++ b/app/views/layouts/snowcrash.html.erb
@@ -28,7 +28,7 @@
         <div class="inner">
           <ul id="main-menu">
             <%= content_tag :li, :class => controller_name == 'issues' ? 'active' : '' do %>
-              <%= link_to main_app.issues_path do %>
+              <%= link_to main_app.project_issues_path(@project) do %>
                 <i class="fa fa-bug"></i> <span>All issues</span>
               <% end %>
             <% end %>
@@ -43,7 +43,8 @@
               <% end %>
             <% end %>
           </ul>
-          <%= render "layouts/snowcrash/nodes" %>
+
+          <%= render 'layouts/snowcrash/nodes' %>
 
           <%# need to include this modal here, because not all pages have
             breadcrumbs (e.g. Project#show). Can't move it inside _nodes,

--- a/app/views/projects/_issue_summary.html.erb
+++ b/app/views/projects/_issue_summary.html.erb
@@ -9,8 +9,8 @@
         <h2 style="color: <%= tag.color %>"><%= tag.display_name %></h2>
         <ul class="issue-list drop-target" data-tag="<%= tag.name %>">
           <% for issue in @issues_by_tag[tag.name] %>
-            <%= content_tag_for :li, issue, data: {url: issue_path(issue, format: :json)} do %>
-              <%= link_to issue.title, issue %>
+            <%= content_tag_for :li, issue, data: { url: project_issue_path(@project, issue, format: :json) } do %>
+              <%= link_to issue.title, [@project, issue] %>
             <% end %>
           <% end %>
         </ul>
@@ -22,8 +22,8 @@
       <h2>Unassigned</h2>
       <ul class="issue-list drop-target">
           <% for issue in @issues_by_tag[:unassigned] %>
-            <%= content_tag_for :li, issue, data: {url: issue_path(issue, format: :json)} do %>
-              <%= link_to issue.title, issue %>
+            <%= content_tag_for :li, issue, data: { url: project_issue_path(@project, issue, format: :json) } do %>
+              <%= link_to issue.title, [@project, issue] %>
             <% end %>
           <% end %>
       </ul>
@@ -32,7 +32,7 @@
   <% else %>
     <p class="no-content">There are no issues in this project yet.</p>
     <div>
-      <%= link_to issues_path(), class: 'btn btn-large btn-primary' do %>
+      <%= link_to project_issues_path(@project), class: 'btn btn-large btn-primary' do %>
         <i class="fa fa-plus"></i> Add new issue
       <% end %> or <%= link_to upload_manager_path() do %><i class="fa fa-cloud-upload fa-lg"></i> Upload output from tool<% end %>
     </div>

--- a/app/views/search/results/_evidence.html.erb
+++ b/app/views/search/results/_evidence.html.erb
@@ -4,7 +4,7 @@
 <%= link_to title, node_evidence_path(row.node_id, row), class: "search-match-title" %>
 
 <div class="result-details">
-  <p><span>Issue:</span> <%= link_to row.issue.title, issue_path(row.issue) %></p>
+  <p><span>Issue:</span> <%= link_to row.issue.title, project_issue_path(@project, row.issue) %></p>
   <p><span>Node:</span> <%= link_to row.node.label, node_path(row.node) %></p>
   <p><span>Last updated:</span> <%= local_time_ago(row.updated_at) %></p>
 </div>

--- a/app/views/search/results/_issue.html.erb
+++ b/app/views/search/results/_issue.html.erb
@@ -1,7 +1,7 @@
 <span class="fa fa-bug"></span>
 
 <% title = row.title? ? row.title : "Issue ##{row.id}" %>
-<%= link_to title, issue_path(row), class: "search-match-title" %>
+<%= link_to title, project_issue_path(@project, row), class: "search-match-title" %>
 
 <p class="result-details">Last updated: <%= local_time_ago(row.updated_at) %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,15 @@ Rails.application.routes.draw do
 
   resources :projects, only: [:show] do
     resources :comments
+    resources :issues, concerns: :multiple_destroy do
+      collection do
+        post :import
+        resources :merge, only: [:new, :create], controller: 'issues/merge'
+      end
+
+      resources :nodes, only: [:show], controller: 'issues/nodes'
+      resources :revisions, only: [:index, :show]
+    end
   end
 
   resources :activities, only: [] do
@@ -30,16 +39,6 @@ Rails.application.routes.draw do
 
   resources :console, only: [] do
     collection { get :status }
-  end
-
-  resources :issues, concerns: :multiple_destroy do
-    collection do
-      post :import
-      resources :merge, only: [:new, :create], controller: 'issues/merge'
-    end
-
-    resources :nodes, only: [:show], controller: 'issues/nodes'
-    resources :revisions, only: [:index, :show]
   end
 
   resources :methodologies do

--- a/spec/features/issue_pages/table_spec.rb
+++ b/spec/features/issue_pages/table_spec.rb
@@ -8,7 +8,7 @@ describe 'issue pages' do
       login_to_project_as_user
 
       @issue = create(:issue, text: "#[Title]#\nIssue1\n\n#[Risk]#\nHigh\n\n#[Description]#\nn/a")
-      visit issues_path
+      visit project_issues_path(@project)
     end
 
     let(:columns) { ['Title', 'Created', 'Created by', 'Updated'] }

--- a/spec/features/issue_pages/table_toolbar_spec.rb
+++ b/spec/features/issue_pages/table_toolbar_spec.rb
@@ -17,7 +17,7 @@ describe 'issue table' do
       login_to_project_as_user
       Tag.create!(name: '!6baed6_low')
       @issues = items
-      visit issues_path
+      visit project_issues_path(@project)
     end
 
     it_behaves_like 'an index table toolbar'

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -5,7 +5,7 @@ describe 'Issues pages' do
 
   it 'should require authenticated users' do
     Configuration.create(name: 'admin:password', value: 'rspec_pass')
-    visit issues_path
+    visit project_issues_path(project_id: 1)
     expect(current_path).to eq(login_path)
     expect(page).to have_content('Access denied.')
   end
@@ -23,13 +23,13 @@ describe 'Issues pages' do
       describe 'index page' do
 
         it 'presents a link to add new issue' do
-          visit issues_path
-          expect(page).to have_xpath("//a[@href='#{new_issue_path()}']")
+          visit project_issues_path(@project)
+          expect(page).to have_xpath("//a[@href='#{new_project_issue_path(@project)}']")
         end
 
         it 'shows an *empty list* message if none have been assigned' do
-          visit issues_path
-          expect(current_path).to eq(issues_path)
+          visit project_issues_path(@project)
+          expect(current_path).to eq(project_issues_path(@project))
           expect(page).to have_content('nothing yet')
         end
 
@@ -43,8 +43,8 @@ describe 'Issues pages' do
             )
           end
 
-          visit issues_path
-          expect(current_path).to eq(issues_path)
+          visit project_issues_path(@project)
+          expect(current_path).to eq(project_issues_path(@project))
           list.each do |title|
             expect(page).to have_content(title)
           end
@@ -59,7 +59,7 @@ describe 'Issues pages' do
           create(:evidence)
           create(:evidence)
 
-          visit issues_path
+          visit project_issues_path(@project)
 
           # click > 1 issue checkboxes
           page.all('input.js-multicheck').each(&:click)
@@ -107,7 +107,7 @@ describe 'Issues pages' do
 
         context 'submitting the form with valid information' do
           before do
-            visit new_issue_path
+            visit new_project_issue_path(@project)
             fill_in :issue_text,
               with: "#[Title]#\nRspec issue\n\n#[Description]#\nNew description\n\n"
           end
@@ -115,7 +115,7 @@ describe 'Issues pages' do
           it 'creates a new Issue under the Issue library with the right Category and Author'  do
             expect { submit_form }.to change { Issue.count }.by(1)
             issue = Issue.last
-            expect(current_path).to eq(issue_path(issue))
+            expect(current_path).to eq(project_issue_path(@project, issue))
             expect(page).to have_content('Rspec issue')
 
             expect(issue.category).to eq(Category.issue)
@@ -128,7 +128,7 @@ describe 'Issues pages' do
 
         context 'submitting the form with invalid information' do
           before do
-            visit new_issue_path
+            visit new_project_issue_path(@project)
             fill_in :issue_text, with: 'a' * 65536
           end
 
@@ -151,7 +151,7 @@ describe 'Issues pages' do
             allow(NoteTemplate).to receive(:pwd).and_return(template_path)
 
             template_content = File.read(template_path.join('simple_note.txt'))
-            visit new_issue_path(template: 'simple_note')
+            visit new_project_issue_path(@project, template: 'simple_note')
 
             expect(find_field('issue[text]').value).to include(template_content)
           end
@@ -160,7 +160,7 @@ describe 'Issues pages' do
         context 'when the issue has a Tags field' do
           it 'tags the issue with the corresponding tag if only one is present' do
             tag_field = '!f89406_private'
-            visit new_issue_path
+            visit new_project_issue_path(@project)
             fill_in :issue_text,
               with: "#[Title]#\nRspec issue\n\n#[Tags]#\n#{tag_field}\n\n"
 
@@ -172,7 +172,7 @@ describe 'Issues pages' do
 
           it 'tags the issue with the first tag if more than one are present' do
             tag_field = '!f89406_private, !468847_public'
-            visit new_issue_path
+            visit new_project_issue_path(@project)
             fill_in :issue_text,
               with: "#[Title]#\nRspec issue\n\n#[Tags]#\n#{tag_field}\n\n"
 
@@ -190,7 +190,7 @@ describe 'Issues pages' do
         before do
           @node  = create(:node)
           @issue = create(:issue, node: @node, updated_at: 2.seconds.ago)
-          visit edit_issue_path(@issue)
+          visit edit_project_issue_path(@project, @issue)
         end
 
         describe 'submitting the form with valid information' do
@@ -202,7 +202,7 @@ describe 'Issues pages' do
           it 'updates and shows the issue' do
             submit_form
             expect(@issue.reload.text).to eq new_content
-            expect(current_path).to eq issue_path(@issue)
+            expect(current_path).to eq project_issue_path(@project, @issue)
           end
 
           let(:model) { @issue }
@@ -247,7 +247,7 @@ describe 'Issues pages' do
           # has the right class:
           @issue = Issue.find(@issue.id)
           extra_setup
-          visit issue_path(@issue)
+          visit project_issue_path(@project, @issue)
         end
 
         let(:extra_setup) { create_activities }
@@ -293,7 +293,7 @@ describe 'Issues pages' do
         it_behaves_like 'a page with an activity feed'
 
         describe "clicking 'delete'" do
-          before { visit issue_path(@issue) }
+          before { visit project_issue_path(@project, @issue) }
 
           let(:submit_form) { within('.note-text-inner') { click_link 'Delete' } }
 
@@ -313,7 +313,7 @@ describe 'Issues pages' do
         describe 'add evidence', js: true do
           before do
             @node = Node.create!(label: '192.168.0.1')
-            visit issue_path(@issue)
+            visit project_issue_path(@project, @issue)
             click_link('Evidence')
           end
 

--- a/spec/features/user_navigates_to_entity_type_on_search_spec.rb
+++ b/spec/features/user_navigates_to_entity_type_on_search_spec.rb
@@ -32,7 +32,7 @@ describe "User navigates to entity page from search" do
 
       page.find(".search-match-title").click
 
-      expect(page.current_path).to eq issue_path(issue)
+      expect(page.current_path).to eq project_issue_path(@project, issue)
     end
 
     it 'of evidence opens to node page' do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -16,7 +16,6 @@ module ControllerMacros
 
   def login_to_project_as_user
     login_as_user
-    @project    = OpenStruct.new
-    @project.id = 1
+    @project = Project.new
   end
 end

--- a/spec/support/edit_conflicts_shared_examples.rb
+++ b/spec/support/edit_conflicts_shared_examples.rb
@@ -6,7 +6,7 @@ shared_examples "a page which handles edit conflicts" do
   def record_path(record)
     case record
     when Issue
-      issue_path(record)
+      project_issue_path(@project, record)
     when Note
       node_note_path(@node, record)
     when Evidence

--- a/vendor/assets/javascripts/jquery.textile.js
+++ b/vendor/assets/javascripts/jquery.textile.js
@@ -28,6 +28,7 @@
         // HTML templates
         tpl: {
           wrap: '<div class="textile-wrap"><ul class="textile-toolbar"></ul><div class="textile-inner"></div></div>',
+          form: '<div class="textile-form">Form view</div>',
           preview: '<div class="textile-preview loading-indicator">Loading...</div>',
           help: '<div class="textile-help loading-indicator">Loading...</div>'
         }
@@ -73,8 +74,15 @@
       this.$element.css('width', '100%');
       this.$element.attr('rows', 20);
 
+      // add Form to container and hide
+      this.options.$form = $(this.options.tpl.form);
+      this.options.$form.css('min-height', this.$element.css('height'));
+      $('.textile-inner', this.options.$wrap).append(this.options.$form);
+      this.options.$form.hide();
+
       // add Preview to container and hide
       this.options.$preview = $(this.options.tpl.preview);
+      this.options.$preview.css('min-height', this.$element.css('height'));
       $('.textile-inner', this.options.$wrap).append(this.options.$preview);
       this.options.$preview.hide();
 
@@ -92,6 +100,11 @@
       // Write
       button = $('<a class="btn-write active" href="javascript:void(null);"><span>Write</span></a>');
       button.click( $.proxy( function(evt) { this._onBtnWrite(evt); }, this));
+      $('.textile-toolbar', this.options.$wrap).append( $('<li>').append(button) );
+
+      // Form
+      button = $('<a class="btn-form" href="javascript:void(null);"><span>Form</span></a>');
+      button.click( $.proxy( function(evt) { this._onBtnForm(evt); }, this));
       $('.textile-toolbar', this.options.$wrap).append( $('<li>').append(button) );
 
       // Preview
@@ -143,9 +156,24 @@
       $('.textile-toolbar .btn-write', scope).addClass('active');
 
       // Show Write pane
+      this.options.$form.hide();
       this.options.$preview.hide();
       this.options.$help.hide();
+
       this.$element.show();
+    },
+    _onBtnForm: function() {
+      // Activate toolbar button
+      var scope = this.options.$wrap;
+      $('.textile-toolbar a', scope).removeClass('active');
+      $('.textile-toolbar .btn-form', scope).addClass('active');
+
+      // Show Form pane
+      this.options.$preview.hide();
+      this.options.$help.hide();
+      this.$element.hide();
+
+      this.options.$form.show();
     },
     _onBtnPreview: function() {
       // Activate toolbar button
@@ -155,8 +183,9 @@
 
       // Show Preview pane
       this.$element.hide();
-
+      this.options.$form.hide();
       this.options.$help.hide();
+
       this.options.$preview.show();
 
       // If the text hasn't changed, do nothing.
@@ -222,6 +251,7 @@
 
       // Show Help pane
       this.$element.hide();
+      this.options.$form.hide();
       this.options.$preview.hide();
       this.options.$help.show();
 
@@ -241,6 +271,7 @@
       var height = $(window).height() - hfix;
 
       this.options.$wrap.width($(window).width()-20);
+      this.options.$form.height(height);
       this.options.$preview.height(height);
       this.$element.height(height-10);
     }


### PR DESCRIPTION
This PR brings the Issue resource under :project_id so we can have multiple tabs referencing issues of different projects in Pro.

Some of the functionality in the original `ProjectScopedController` has been split into several controller concerns (`ConflictResolver`, `ProjectScoped`).