### PR TITLE
Subscribe/Unscubscribe links

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -32,6 +32,11 @@ class IssuesController < AuthenticatedController
     @first_evidence  = Evidence.where(node: @first_node, issue: @issue)
 
     load_conflicting_revisions(@issue)
+
+    @subscription = Subscription.find_by(
+                      user: current_user,
+                      subscribable_type: @issue.class.to_s,
+                      subscribable_id: @issue.id)
   end
 
   def new

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,28 @@
+class SubscriptionsController < AuthenticatedController
+  include ProjectScoped
+
+  def create
+    subscription = Subscription.new(subscription_params)
+    subscription.user = current_user
+    subscription.save
+
+    redirect_to [@project, subscription.subscribable], notice: 'Subscribed!'
+  end
+
+  def destroy
+    subscription = Subscription.find_by(
+      user: current_user,
+      subscribable_type: subscription_params[:subscribable_type],
+      subscribable_id: subscription_params[:subscribable_id]
+    )
+    subscription.destroy
+
+    redirect_to [@project, subscription.subscribable], notice: 'Unsubscribed!'
+  end
+
+  private
+
+  def subscription_params
+    params.require(:subscription).permit(:subscribable_type, :subscribable_id)
+  end
+end

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -25,7 +25,7 @@
 </ul>
 
 <div class="tab-content">
-  <% cache ['issue-information-tab', @issue] do %>
+  <% cache ['issue-information-tab', @issue, @subscription] do %>
     <div class="tab-pane active" id="info-tab">
       <div class="inner note-text-inner">
         <h3>Issue information -
@@ -40,6 +40,34 @@
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %> -
+            <% if @subscription %>
+              <%= link_to \
+                    project_subscription_path(
+                      @project,
+                      @subscription,
+                      subscription: {
+                        subscribable_type: @issue.class.to_s,
+                        subscribable_id: @issue.id
+                      }
+                    ),
+                    class: 'action-link text-error',
+                      method: :delete do %>
+                  <i class="fa fa-bell-slash"></i> Unsubscribe
+              <% end %>
+            <% else %>
+              <%= link_to \
+                    project_subscriptions_path(
+                      @project,
+                      subscription: {
+                        subscribable_type: @issue.class.to_s,
+                        subscribable_id: @issue.id
+                      }
+                    ),
+                    class: 'action-link',
+                    method: :post do %>
+                <i class="fa fa-bell"></i> Subscribe
+              <% end %>
+            <% end %> - 
             <%= render partial: 'send_to_menu' %>
             <%= tag_and_name_for(@issue) %>
           </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
       resources :nodes, only: [:show], controller: 'issues/nodes'
       resources :revisions, only: [:index, :show]
     end
+    resources :subscriptions, only: [:create, :destroy]
   end
 
   resources :activities, only: [] do

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -293,7 +293,7 @@ describe 'Issues pages' do
         it_behaves_like 'a page with an activity feed'
 
         let(:subscribable) { @issue }
-        it_behaves_like 'a page sith subscribe/unsunscribe links'
+        it_behaves_like 'a page sith subscribe/unsubscribe links'
 
         describe "clicking 'delete'" do
           before { visit project_issue_path(@project, @issue) }

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -292,6 +292,9 @@ describe 'Issues pages' do
         let(:trackable) { @issue }
         it_behaves_like 'a page with an activity feed'
 
+        let(:subscribable) { @issue }
+        it_behaves_like 'a page sith subscribe/unsunscribe links'
+
         describe "clicking 'delete'" do
           before { visit project_issue_path(@project, @issue) }
 

--- a/spec/support/subscription_shared_examples.rb
+++ b/spec/support/subscription_shared_examples.rb
@@ -1,6 +1,6 @@
 # Define the following let variables before using these examples:
 #   subscribable: an instance of the subscribable model
-shared_examples 'a page sith subscribe/unsunscribe links' do
+shared_examples 'a page sith subscribe/unsubscribe links' do
   it 'subscribes and unsubscribes with the provided links' do
     click_link 'Subscribe'
     expect(page).to have_text 'Subscribed!'

--- a/spec/support/subscription_shared_examples.rb
+++ b/spec/support/subscription_shared_examples.rb
@@ -1,0 +1,25 @@
+# Define the following let variables before using these examples:
+#   subscribable: an instance of the subscribable model
+shared_examples 'a page sith subscribe/unsunscribe links' do
+  it 'subscribes and unsubscribes with the provided links' do
+    click_link 'Subscribe'
+    expect(page).to have_text 'Subscribed!'
+    expect(
+      Subscription.find_by(
+        user: @logged_in_as,
+        subscribable_type: subscribable.class.to_s,
+        subscribable_id: subscribable.id
+      )
+    ).not_to be nil
+
+    click_link 'Unsubscribe'
+    expect(page).to have_text 'Unsubscribed!'
+    expect(
+      Subscription.find_by(
+        user: @logged_in_as,
+        subscribable_type: subscribable.class.to_s,
+        subscribable_id: subscribable.id
+      )
+    ).to be nil
+  end
+end


### PR DESCRIPTION
### Spec
The user should be able to manually subscribe or unscubscribe to/from a subscribable item. 

**Proposed solution**
Add links to the subscription resource from a subscribable show page, so the user can edit her subscription for that item.

### How to test

- Visit an issue   
- Assert there is a link to subscribe to that issue.
- Subscribe and check subscriptions table on the db for a new record
- Unsubscribe and check in db the corresponding record is deleted