### PR TITLE
in proetect_from_forgery, reset session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,5 +4,5 @@
 class ApplicationController < ActionController::Base
   include Authentication
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :reset_session
 end


### PR DESCRIPTION
We do these 2 checks on our requests:
- check csrf token (applies to POST requests). 
- check for valid user session

When the user session expires, csrf token check also fails, because there is no info to check the incoming csrf token.

So, if we open Dradis, go to a page that sends a POST request (create issue, evidence...) and wait enough time (or delete the cookie manually), we see this error.

protect_from_forgery has the option to reset the session instead of rising an exception, so tried that