### PR TITLE
Replace Node.plugin_*_node with Project#plugin_*_node

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -81,17 +81,6 @@ class Node < ApplicationRecord
     find_or_create_by(label: 'Methodologies', type_id: Node::Types::METHODOLOGY)
   end
 
-  # When Upload plugins create new nodes, they'll do so under this parent node
-  def self.plugin_parent_node
-    find_or_create_by(label: ::Configuration.plugin_parent_node)
-  end
-
-  # Security scanner output files uploaded via the Upload Manager use this node
-  # as container
-  def self.plugin_uploads_node
-    find_or_create_by(label: ::Configuration.plugin_uploads_node)
-  end
-
   # If an item is recovered from the trash, but we can't reassign it to its
   # Node because its Node has also been deleted, it will be assigned to this
   # node:

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,4 +16,20 @@ class Project
   def nodes
     Node.all
   end
+
+  def notes
+    Note.all
+  end
+
+  # When Upload plugins create new nodes, they'll do so under this parent node
+  def plugin_parent_node
+    @plugin_parent_node ||= nodes.find_or_create_by(label: ::Configuration.plugin_parent_node)
+  end
+
+  # Security scanner output files uploaded via the Upload Manager use this node
+  # as container
+  def plugin_uploads_node
+    @plugin_uploads_node ||= nodes.find_or_create_by(label: ::Configuration.plugin_uploads_node)
+  end
+
 end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/nodes_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/nodes_spec.rb
@@ -71,7 +71,7 @@ describe "Nodes API" do
     end
 
     describe "POST /api/nodes" do
-      let!(:parent_node_id) { Node.plugin_parent_node.id }
+      let!(:parent_node_id) { Project.new.plugin_parent_node.id }
       let(:valid_post) do
         post "/api/nodes", params: valid_params.to_json, env: @env.merge("CONTENT_TYPE" => 'application/json')
       end


### PR DESCRIPTION
Now that we're moving away from using set_project_scope in Pro, it doesn't make sense to have a class method on Node called plugin_uploads_node / plugin_parent_node - because this method won't know which project's uploads / parent node to load. So we're changing this method from a class method on Node to an instance method on Project.