### PR TITLE
Replace Node.recovered with Project#recovered

### DIFF
--- a/app/controllers/concerns/project_scoped.rb
+++ b/app/controllers/concerns/project_scoped.rb
@@ -21,6 +21,7 @@ module ProjectScoped
   #   https://github.com/airblade/paper_trail#metadata-from-controllers
   #
   def info_for_paper_trail
+    { project_id: current_project.id } if current_project
   end
 
   def set_nodes

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -20,11 +20,11 @@ class RevisionsController < AuthenticatedController
 
   def trash
     # Get all revisions whose event is destroy.
-    @revisions = RecoverableRevision.all
+    @revisions = RecoverableRevision.all(project_id: current_project.id)
   end
 
   def recover
-    revision = RecoverableRevision.find(params[:id])
+    revision = RecoverableRevision.find(id: params[:id], project_id: current_project.id)
     if revision.recover
       track_recovered(revision.object)
       flash[:info] = "#{revision.type} recovered"

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -81,12 +81,6 @@ class Node < ApplicationRecord
     find_or_create_by(label: 'Methodologies', type_id: Node::Types::METHODOLOGY)
   end
 
-  # If an item is recovered from the trash, but we can't reassign it to its
-  # Node because its Node has also been deleted, it will be assigned to this
-  # node:
-  def self.recovered
-    find_or_create_by(label: 'Recovered', type_id: Node::Types::DEFAULT)
-  end
 
   # -- Instance Methods -----------------------------------------------------
   def ancestor_of?(node)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,12 @@ class Project
 
   attr_reader :id, :name
 
+  # -- Class Methods --------------------------------------------------------
+  def find(id)
+    new(id: id)
+  end
+
+  # -- Instance Methods -----------------------------------------------------
   def initialize(id: 1, name: 'Dradis CE', **_attrs)
     @id   = id
     @name = name
@@ -32,4 +38,10 @@ class Project
     @plugin_uploads_node ||= nodes.find_or_create_by(label: ::Configuration.plugin_uploads_node)
   end
 
+  # If an item is recovered from the trash, but we can't reassign it to its
+  # Node because its Node has also been deleted, it will be assigned to this
+  # node:
+  def recovered
+    @recovered ||= nodes.find_or_create_by(label: 'Recovered')
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,7 +7,7 @@ class Project
   attr_reader :id, :name
 
   # -- Class Methods --------------------------------------------------------
-  def find(id)
+  def self.find(id)
     new(id: id)
   end
 

--- a/app/models/recoverable_revision.rb
+++ b/app/models/recoverable_revision.rb
@@ -67,7 +67,7 @@ class RecoverableRevision
     # which should be an issue, convert it to an instance of Issue:
     #
     # FIXME - ISSUE/NOTE INHERITANCE
-    if @object.instance_of?(Note) && @object.node_id == project.issue_library.id
+    if @object.instance_of?(Note) && @object.node_id == Node.issue_library.id
       @object = Issue.new(@object.attributes)
     end
 
@@ -106,6 +106,6 @@ class RecoverableRevision
 
   private
   def project
-    @project ||= Project.find(@object.project_id)
+    @project ||= Project.find(@version.project_id)
   end
 end

--- a/app/models/recoverable_revision.rb
+++ b/app/models/recoverable_revision.rb
@@ -58,7 +58,6 @@ class RecoverableRevision
   end
 
   def recover
-    project = Project.find(id)
     # If we're recovering an issue, revision.reify will return an instance
     # of `Note`, because `revision.reify.item_type == "Note"`. This won't prevent
     # the issue from being recovered correctly (because `revision.reify.node_id
@@ -104,4 +103,9 @@ class RecoverableRevision
     end
   end
 
+
+  private
+  def project
+    @project ||= Project.find(@object.project_id)
+  end
 end

--- a/db/migrate/20161114111520_add_project_id_to_versions.rb
+++ b/db/migrate/20161114111520_add_project_id_to_versions.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToVersions < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :versions, :project, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,7 +124,9 @@ ActiveRecord::Schema.define(version: 20180611150236) do
     t.string "whodunnit"
     t.text "object", limit: 1073741823
     t.datetime "created_at"
+    t.integer "project_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["project_id"], name: "index_versions_on_project_id"
   end
 
 end

--- a/spec/features/issue_trash_recover_spec.rb
+++ b/spec/features/issue_trash_recover_spec.rb
@@ -28,5 +28,6 @@ describe "issue trash" do
       "#[Title]#\r\n#{title}\r\n\r\n#[Description]#\r\n\r\n"
     )
     @issue.destroy
+    @issue.versions.last.update_attribute(:project_id, current_project.id)
   end
 end

--- a/spec/models/recoverable_revision_spec.rb
+++ b/spec/models/recoverable_revision_spec.rb
@@ -7,7 +7,7 @@ describe RecoverableRevision do
       deleted_evidence = create(:evidence)
       deleted_evidence.destroy
       destroy_revision = deleted_evidence.versions.last
-      r_revision = RecoverableRevision.find(destroy_revision)
+      r_revision = RecoverableRevision.find(id:destroy_revision)
       expect(r_revision).to be_a RecoverableRevision
       expect(r_revision.version).to eq destroy_revision
     end
@@ -16,7 +16,7 @@ describe RecoverableRevision do
       evidence        = create(:evidence)
       create_revision = evidence.versions.first
       expect do
-        RecoverableRevision.find(create_revision.id)
+        RecoverableRevision.find(id: create_revision.id)
       end.to raise_error ActiveRecord::RecordNotFound
     end
   end
@@ -78,7 +78,7 @@ describe RecoverableRevision do
     end
 
     it "doesn't return revisions when the item has been recovered" do
-      recoverable = described_class.find(@deleted_note.versions.last.id)
+      recoverable = described_class.find(id: @deleted_note.versions.last.id)
       recoverable.recover
 
       expect(described_class.all.map { |v| v.version.reify }).to match_array(


### PR DESCRIPTION
Now that we're moving away from using set_project_scope in Pro, it doesn't make sense to have a class method on Node called recovered - because this method won't know which project's recovered  to load. So we're changing this method from a class method on Node to an instance method on Project.