### PR TITLE
Turn PaperTrail off in specs by default

### DIFF
--- a/app/models/recoverable_revision.rb
+++ b/app/models/recoverable_revision.rb
@@ -73,7 +73,7 @@ class RecoverableRevision
 
     # If @object's node was destroyed, assign it to a new node.
     if @object.respond_to?(:node_id) && !Node.exists?(@object.node_id)
-      @object.node = Node.recovered
+      @object.node = project.recovered
     end
 
     # If object is evidence and its issue doesn't exist any more, recover the issue.

--- a/spec/features/issue_trash_recover_spec.rb
+++ b/spec/features/issue_trash_recover_spec.rb
@@ -23,11 +23,13 @@ describe "issue trash" do
 
 
   def edit_and_delete_issue title
-    @issue.update_attribute(
-      :text,
-      "#[Title]#\r\n#{title}\r\n\r\n#[Description]#\r\n\r\n"
-    )
-    @issue.destroy
-    @issue.versions.last.update_attribute(:project_id, current_project.id)
+    with_versioning do
+      @issue.update_attribute(
+        :text,
+        "#[Title]#\r\n#{title}\r\n\r\n#[Description]#\r\n\r\n"
+      )
+      @issue.destroy
+      @issue.versions.last.update_attribute(:project_id, current_project.id)
+    end
   end
 end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -209,8 +209,10 @@ describe 'Issues pages' do
           include_examples 'creates an Activity', :update
 
           it "creates a version with the user's email as 'whodunnit'" do
-            submit_form
-            expect(@issue.reload.versions.last.whodunnit).to eq @logged_in_as.email
+            with_versioning do
+              submit_form
+              expect(@issue.reload.versions.last.whodunnit).to eq @logged_in_as.email
+            end
           end
 
           let(:column) { :text }

--- a/spec/models/recoverable_revision_spec.rb
+++ b/spec/models/recoverable_revision_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe RecoverableRevision do
+  before { PaperTrail.enabled = true }
+  after  { PaperTrail.enabled = false }
 
   describe ".find" do
     it "returns a RecoverableRevision that wraps the PaperTrail::Version with the given ID" do

--- a/spec/presenters/recoverable_revision_presenter_spec.rb
+++ b/spec/presenters/recoverable_revision_presenter_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe RecoverableRevisionPresenter do
+
+  before { PaperTrail.enabled = true }
+  after  { PaperTrail.enabled = false }
+
   class FakeView
     include ActionView::Helpers::TextHelper
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'rspec/rails'
 
 require 'capybara/rspec'
 require 'capybara/poltergeist'
+require 'paper_trail/frameworks/rspec'
 require 'shoulda/matchers'
 
 

--- a/spec/support/edit_conflicts_shared_examples.rb
+++ b/spec/support/edit_conflicts_shared_examples.rb
@@ -22,17 +22,22 @@ shared_examples "a page which handles edit conflicts" do
   end
 
   specify "a regular update doesn't say anything about edit conflicts" do
-    submit_form
-    expect(page).to have_no_content conflict_warning
-    expect(page).to have_no_link(//, href: record_revisions_path(record))
+    with_versioning do
+      submit_form
+      expect(page).to have_no_content conflict_warning
+      expect(page).to have_no_link(//, href: record_revisions_path(record))
+    end
   end
 
   context "when another user has updated the record in the meantime" do
     let(:email_1) { "someone@example.com" }
     before do
+      PaperTrail.enabled = true
       record.update_attributes!(column => "Someone else's changes")
       record.versions.last.update!(whodunnit: email_1)
     end
+
+    after { PaperTrail.enabled = false }
 
     it "saves my changes" do
       submit_form


### PR DESCRIPTION
We realised we were wasting lots of cycles during CI due to PaperTrail creating revisions for everything.

This PR disables PT by default and re-enables it selectively where it makes sense (e.g. testing the Trash, editing conflicts, Revision history view, etc.).