### PR TITLE
Update the use of Node.in_tree and Node.user_nodes to go through current_project when needed

### DIFF
--- a/app/controllers/concerns/project_scoped.rb
+++ b/app/controllers/concerns/project_scoped.rb
@@ -25,7 +25,7 @@ module ProjectScoped
   end
 
   def set_nodes
-    @nodes = Node.in_tree
+    @nodes = current_project.nodes.in_tree
   end
 
   def set_project

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -20,7 +20,7 @@ class IssuesController < AuthenticatedController
 
     # We can't use the existing @nodes variable as it only contains root-level
     # nodes, and we need the auto-complete to have the full list.
-    @nodes_for_add_evidence = Node.user_nodes.order(:label)
+    @nodes_for_add_evidence = current_project.nodes.user_nodes.order(:label)
 
     @affected_nodes = Node.joins(:evidence)
                         .select('nodes.id, label, type_id, count(evidence.id) as evidence_count, nodes.updated_at')

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -60,7 +60,7 @@ class Search
   end
 
   def nodes
-    @nodes ||= Node.user_nodes
+    @nodes ||= project.nodes.user_nodes
       .where("LOWER(label) LIKE LOWER(:q)", q: "%#{query}%")
       .order(updated_at: :desc)
   end


### PR DESCRIPTION
If we're going to remove the default scopes of `Node` we need to use finders that are adequately scoped.