### PR TITLE
Comment activities 2

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
@@ -178,6 +178,8 @@ class @ActivitiesPoller
   @addComment: (commentableId, content) ->
     if commentableId == @modelId
       $('.comment-list').append(content)
+      count = parseInt($('#comment-count').html())
+      $('#comment-count').html(count + 1)
 
   @updateComment: (commentId, commentableId, content) ->
     comment = $("#comment_#{commentId}")
@@ -185,7 +187,10 @@ class @ActivitiesPoller
 
   @deleteComment: (commentId) ->
       comment = $("#comment_#{commentId}")
-      comment.remove() if comment.length
+      if comment.length
+        comment.remove()
+        count = parseInt($('#comment-count').html())
+        $('#comment-count').html(count - 1) if count > 0
 
   # private
 

--- a/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
@@ -173,6 +173,20 @@ class @ActivitiesPoller
       @_showEvidenceDeletedAlert()
 
 
+  # ------ COMMENTS ------
+
+  @addComment: (commentableId, content) ->
+    if commentableId == @modelId
+      $('.comment-list').append(content)
+
+  @updateComment: (commentId, commentableId, content) ->
+    comment = $("#comment_#{commentId}")
+    comment.replaceWith(content)
+
+  @deleteComment: (commentId) ->
+      comment = $("#comment_#{commentId}")
+      comment.remove() if comment.length
+
   # private
 
   @_addLink: (selector, link) ->

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < AuthenticatedController
   include ActionView::RecordIdentifier
+  include ActivityTracking
   include ProjectScoped
 
   load_and_authorize_resource
@@ -7,17 +8,26 @@ class CommentsController < AuthenticatedController
   def create
     @comment = Comment.new(comment_params)
     @comment.user = current_user
-    @comment.save
+    if @comment.save
+      track_created(@comment)
+    end
+
     redirect_to polymorphic_path([@project, @comment.commentable], anchor: dom_id(@comment))
   end
 
   def update
-    @comment.update_attributes(comment_params)
+    if @comment.update_attributes(comment_params)
+      track_updated(@comment)
+    end
+
     redirect_to polymorphic_path([@project, @comment.commentable], anchor: dom_id(@comment))
   end
 
   def destroy
-    @comment.destroy
+    if @comment.destroy
+      track_destroyed(@comment)
+    end
+
     redirect_to [@project, @comment.commentable]
   end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -16,7 +16,7 @@ class IssuesController < AuthenticatedController
   end
 
   def show
-    @activities = @issue.activities.latest
+    @activities = @issue.commentable_activities.latest
 
     # We can't use the existing @nodes variable as it only contains root-level
     # nodes, and we need the auto-complete to have the full list.

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -4,4 +4,10 @@ module Commentable
   included do
     has_many :comments, as: :commentable, dependent: :destroy
   end
+
+  def commentable_activities
+    Activity.where(trackable_type: self.class.to_s, trackable_id: self.id).or(
+      Activity.where(trackable_type: 'Comment', trackable_id: [self.comments.map(&:id)])
+    )
+  end
 end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -6,8 +6,11 @@ module Commentable
   end
 
   def commentable_activities
-    Activity.where(trackable_type: self.class.to_s, trackable_id: self.id).or(
-      Activity.where(trackable_type: 'Comment', trackable_id: [self.comments.map(&:id)])
+    self.activities.or(
+      Activity.where(
+        trackable_type: 'Comment',
+        trackable_id: self.comments.pluck(:id)
+      )
     )
   end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -47,9 +47,7 @@ class ActivityPresenter < BasePresenter
   # but this may change if we add activities whose action is an irregular
   # verb.
   def verb
-    if activity.trackable_type == 'Comment' && activity.action == 'create'
-      'added'
-    elsif activity.action == 'destroy'
+    if activity.action == 'destroy'
       'deleted'
     else
       activity.action.sub(/e?\z/, 'ed')

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -47,7 +47,9 @@ class ActivityPresenter < BasePresenter
   # but this may change if we add activities whose action is an irregular
   # verb.
   def verb
-    if activity.action == 'destroy'
+    if activity.trackable_type == 'Comment' && activity.action == 'create'
+      'added'
+    elsif activity.action == 'destroy'
       'deleted'
     else
       activity.action.sub(/e?\z/, 'ed')

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -12,6 +12,8 @@ class ActivityPresenter < BasePresenter
   def icon
     icon_css = %w{activity-icon fa}
     icon_css << case activity.trackable_type
+                when 'Comment'
+                  'fa-comment'
                 when 'Evidence'
                   'fa-flag'
                 when 'Issue'

--- a/app/views/activities/_comment.html.erb
+++ b/app/views/activities/_comment.html.erb
@@ -3,7 +3,7 @@
   <% if comment.commentable.title? %>
     <% title = comment.commentable.title %>
   <% end %>
-  <%= presenter.verb %> a comment on <%= link_to title, polymorphic_path([@project, comment.commentable], anchor: dom_id(comment)) %>.
+  <%= presenter.verb %> a <%= link_to 'comment', polymorphic_path([@project, comment.commentable], anchor: dom_id(comment)) %> on <%= link_to title, polymorphic_path([@project, comment.commentable]) %>.
 <% else %>
   <% if activity.action == 'destroy' %>
     deleted a comment.

--- a/app/views/activities/_comment.html.erb
+++ b/app/views/activities/_comment.html.erb
@@ -1,0 +1,13 @@
+<% if comment %>
+  <% title = "#{comment.commentable.class.to_s.capitalize} ##{comment.commentable.id}" %>
+  <% if comment.commentable.title? %>
+    <% title = comment.commentable.title %>
+  <% end %>
+  <%= presenter.verb %> a comment on <%= link_to title, polymorphic_path([@project, comment.commentable], anchor: dom_id(comment)) %>.
+<% else %>
+  <% if activity.action == 'destroy' %>
+    deleted a comment.
+  <% else %>
+    <%= presenter.verb %> a comment which has since been deleted.
+  <% end %>
+<% end %>

--- a/app/views/activities/poll.js.erb
+++ b/app/views/activities/poll.js.erb
@@ -1,5 +1,25 @@
 <% @activities.each do |activity| %>
 
+  <%# Comment activities %>
+  <% if activity.trackable_type == 'Comment' %>
+
+    <% if activity.action == 'destroy' || activity.trackable.nil? %>
+      ActivitiesPoller.deleteComment(<%= activity.trackable_id %>)
+    <% elsif %w[create update].include?(activity.action) %>
+      <% comment = activity.trackable %>
+
+      var commentId = <%= comment.id %>,
+          commentableId = <%= comment.commentable.id %>,
+          template      = '<%= j render(comment) %>';
+
+      <% if activity.action == 'create' %>
+        ActivitiesPoller.addComment(commentableId, template)
+      <% elsif activity.action == 'update' %>
+        ActivitiesPoller.updateComment(commentId, commentableId, template)
+      <% end %>
+    <% end %>
+  <% end # if activity.trackable_type == "Comment" %>
+
   <%# Evidence activities %>
   <% if activity.trackable_type == 'Evidence' %>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,38 @@
+<%= div_for comment do %>
+  <div class="body">
+    <%= link_to(avatar_image(comment.user, size: 30), "##{dom_id(comment)}") %>
+
+    <div>
+      <% if comment.user %>
+        <strong><%= comment.user.email %></strong>
+      <% else %>
+        a user who has since been deleted
+      <% end %>
+
+      <span class="time"><%= local_time_ago(comment.created_at) %></span>
+
+      <% if can? :update, comment %>
+        <div class="actions">
+          <%= link_to 'javascript:void(0)',
+                      data: {toggle_comment: "on"} do %>
+            <i class="fa fa-pencil"></i> Edit
+          <% end %>
+          <%= link_to [@project, comment],
+                      method: :delete,
+                      data: { confirm: 'Are you sure?' },
+                      class: 'text-error' do %>
+            <i class="fa fa-trash"></i> Delete
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="content">
+      <%= comment.content %>
+    </div>
+
+    <% if can? :update, comment %>
+      <%= render 'comments/edit', comment: comment %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -1,49 +1,8 @@
 <h3>Comments <span class="badge"><%= commentable.comments.count %></span></h3>
 <div class="comment-feed">
-  <% if commentable.comments.any? %>
-    <% commentable.comments.each do |comment| %>
-      <%= div_for comment do %>
-        <div class="body">
-          <%= link_to(avatar_image(comment.user, size: 30), "##{dom_id(comment)}") %>
-
-          <div>
-            <% if comment.user %>
-              <strong><%= comment.user.email %></strong>
-            <% else %>
-              a user who has since been deleted
-            <% end %>
-
-            <span class="time"><%= local_time_ago(comment.created_at) %></span>
-
-            <% if can? :update, comment %>
-              <div class="actions">
-                <%= link_to 'javascript:void(0)',
-                            data: {toggle_comment: "on"} do %>
-                  <i class="fa fa-pencil"></i> Edit
-                <% end %>
-                <%= link_to [@project, comment],
-                            method: :delete,
-                            data: { confirm: 'Are you sure?' },
-                            class: 'text-error' do %>
-                  <i class="fa fa-trash"></i> Delete
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-
-          <div class="content">
-            <%= comment.content %>
-          </div>
-
-          <% if can? :update, comment %>
-            <%= render 'comments/edit', commentable: commentable, comment: comment %>
-          <% end %>
-        </div>
-      <% end %>
-    <% end %>
-  <% else %>
-    <p class="no-content">There have been no comments yet.</p>
-  <% end %>
+  <div class="comment-list">
+    <%= render commentable.comments || "There have been no comments yet." %>
+  </div>
 
   <%= render 'comments/new', commentable: commentable %>
 </div>

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -1,7 +1,7 @@
-<h3>Comments <span class="badge"><%= commentable.comments.count %></span></h3>
+<h3>Comments <span class="badge" id="comment-count"><%= commentable.comments.count %></span></h3>
 <div class="comment-feed">
   <div class="comment-list">
-    <%= render commentable.comments || "There have been no comments yet." %>
+    <%= render(commentable.comments) || "There have been no comments yet." %>
   </div>
 
   <%= render 'comments/new', commentable: commentable %>

--- a/spec/features/comment_pages/polling_spec.rb
+++ b/spec/features/comment_pages/polling_spec.rb
@@ -34,6 +34,20 @@ describe 'comment pages', js: true do
       end
     end
 
+    describe 'and someone else deletes a comment' do
+      before do
+        @comment.destroy
+        track_destroyed(@comment, @other_user)
+        call_poller
+      end
+
+      it 'removes the deleted comment' do
+        within('.comment-list') do
+          expect(page).not_to have_selector("#comment_#{@comment.id}")
+        end
+      end
+    end
+
   end
 
   before do

--- a/spec/features/comment_pages/polling_spec.rb
+++ b/spec/features/comment_pages/polling_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'comment pages', js: true do
+  include ActivityMacros
+
+  subject { page }
+
+  shared_examples 'a commentable page with poller' do
+    describe 'and someone else adds a comment' do
+      before do
+        @new_comment = create(:comment, commentable: @commentable, user: @other_user)
+        track_created(@new_comment, @other_user)
+        call_poller
+      end
+
+      it 'displays the new comment' do
+        within('.comment-list') do
+          expect(page).to have_selector("#comment_#{@new_comment.id}") # , visible: :all)
+        end
+      end
+    end
+
+    describe 'and someone else updates a comment' do
+      before do
+        @comment.update_attributes(content: 'content updated')
+        track_updated(@comment, @other_user)
+        call_poller
+      end
+
+      it 'displays the updated comment' do
+        within('.comment-list') do
+          expect(page).to have_text('content updated')
+        end
+      end
+    end
+
+  end
+
+  before do
+    login_to_project_as_user
+    @other_user = create(:user)
+  end
+
+  describe 'when I am viewing an Issue' do
+    before do
+      @commentable = create(:issue)
+      @comment = create(:comment, commentable: @commentable, user: @other_user)
+      visit project_issue_path(@project, @commentable)
+    end
+
+    it_behaves_like 'a commentable page with poller'
+  end
+end

--- a/spec/features/comment_pages/polling_spec.rb
+++ b/spec/features/comment_pages/polling_spec.rb
@@ -17,6 +17,8 @@ describe 'comment pages', js: true do
         within('.comment-list') do
           expect(page).to have_selector("#comment_#{@new_comment.id}") # , visible: :all)
         end
+
+        expect(find('#comment-count').text.to_i).to eq(2)
       end
     end
 
@@ -45,6 +47,8 @@ describe 'comment pages', js: true do
         within('.comment-list') do
           expect(page).not_to have_selector("#comment_#{@comment.id}")
         end
+
+        expect(find('#comment-count').text.to_i).to eq(0)
       end
     end
 

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -296,8 +296,11 @@ describe 'Issues pages' do
         let(:trackable) { @issue }
         it_behaves_like 'a page with an activity feed'
 
-        let(:commentable) { @issue }
-        it_behaves_like "a page with a comments feed"
+        describe 'comments', js: true do
+          let(:commentable) { @issue }
+          it_behaves_like "a page with a comments feed"
+          it_behaves_like "a commentable page with poller"
+        end
 
         describe "clicking 'delete'" do
           before { visit project_issue_path(@project, @issue) }

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -332,7 +332,7 @@ describe 'Issues pages' do
 
           it 'filters nodes' do
             find('.js-add-evidence').click
-	    expect(all('#existing-node-list label').count).to be @project.nodes.user_nodes.count
+            expect(all('#existing-node-list label').count).to be Node.user_nodes.count
 
             # find('#evidence_node').native.send_key('192.')
             fill_in 'evidence_node', with: '192\.'

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -296,11 +296,8 @@ describe 'Issues pages' do
         let(:trackable) { @issue }
         it_behaves_like 'a page with an activity feed'
 
-        describe 'comments', js: true do
-          let(:commentable) { @issue }
-          it_behaves_like "a page with a comments feed"
-          it_behaves_like "a commentable page with poller"
-        end
+        let(:commentable) { @issue }
+        it_behaves_like 'a page with a comments feed'        
 
         describe "clicking 'delete'" do
           before { visit project_issue_path(@project, @issue) }

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -297,7 +297,7 @@ describe 'Issues pages' do
         it_behaves_like 'a page with an activity feed'
 
         let(:commentable) { @issue }
-        it_behaves_like 'a page with a comments feed'        
+        it_behaves_like 'a page with a comments feed'
 
         describe "clicking 'delete'" do
           before { visit project_issue_path(@project, @issue) }
@@ -334,8 +334,8 @@ describe 'Issues pages' do
             find('.js-add-evidence').click
             expect(all('#existing-node-list label').count).to be Node.user_nodes.count
 
-            # find('#evidence_node').native.send_key('192')
-            fill_in 'evidence_node', with: '192'
+            # find('#evidence_node').native.send_key('192.')
+            fill_in 'evidence_node', with: '192\.'
 
             expect(all('#existing-node-list label').count).to eq 1
           end

--- a/spec/support/comment_shared_examples.rb
+++ b/spec/support/comment_shared_examples.rb
@@ -1,6 +1,6 @@
 # Define the following let variables before using these examples:
 #
-#   create_comments : a block which creates the activities AND IS CALLED
+#   create_comments : a block which creates the comments AND IS CALLED
 #                     BEFORE THE PAGE LOADS
 #   commentable: the model which the 'show' page is about
 shared_examples 'a page with a comments feed' do

--- a/spec/support/comment_shared_examples.rb
+++ b/spec/support/comment_shared_examples.rb
@@ -24,46 +24,70 @@ shared_examples 'a page with a comments feed' do
     end
   end
 
-  it 'allows adding a comment' do
-    within 'form#new_comment' do
-      fill_in 'comment_content', with: 'test comment'
-      click_button 'Add comment'
+  describe 'add comment' do
+    let(:submit_form) do
+      within 'form#new_comment' do
+        fill_in 'comment_content', with: 'test comment'
+        click_button 'Add comment'
+      end
     end
 
-    expect(page).to have_text 'test comment'
-  end
+    it 'allows adding a comment' do
+      submit_form
 
-  it 'allows updating a comment from the same user' do
-    id = @comments[0].id
-    within "div#comment_#{id}" do
-      fill_in 'comment_content', with: 'test comment edited'
-      click_button 'Update comment'
+      expect(page).to have_text 'test comment'
     end
 
-    expect(page).to have_text 'test comment edited'
+    include_examples 'creates an Activity', :create, Comment
   end
 
-  it 'does not allow to edit comments from other users' do
-    id = @comments[1].id
-    within "div#comment_#{id}" do
-      expect(page).not_to have_link 'Edit'
-      expect(page).not_to have_css "form#edit_comment_#{id}"
+  describe 'update comment' do
+    let(:model) { @comments[0] }
+    let(:submit_form) do
+      within "div#comment_#{model.id}" do
+        fill_in 'comment_content', with: 'test comment edited'
+        click_button 'Update comment'
+      end
+    end
+
+    it 'allows updating a comment from the same user' do
+      submit_form
+
+      expect(page).to have_text 'test comment edited'
+    end
+
+    include_examples 'creates an Activity', :update
+
+    it 'does not allow to edit comments from other users' do
+      id = @comments[1].id
+      within "div#comment_#{id}" do
+        expect(page).not_to have_link 'Edit'
+        expect(page).not_to have_css "form#edit_comment_#{id}"
+      end
     end
   end
 
-  it 'allows deleting a comment from the same user' do
-    id = @comments[0].id
-    within "div#comment_#{id}" do
-      click_link 'Delete'
+  describe 'delete comment' do
+    let(:model) { @comments[0] }
+    let (:submit_form) do
+      within "div#comment_#{model.id}" do
+        click_link 'Delete'
+      end
     end
 
-    expect(page).not_to have_comment(@comments[0])
-  end
+    it 'allows deleting a comment from the same user' do
+      submit_form
 
-  it 'does not allow deleting a comment from another user' do
-    id = @comments[1].id
-    within "div#comment_#{id}" do
-      expect(page).not_to have_link('Delete')
+      expect(page).not_to have_comment(@comments[0])
+    end
+
+    include_examples 'creates an Activity', :destroy
+
+    it 'does not allow deleting a comment from another user' do
+      id = @comments[1].id
+      within "div#comment_#{id}" do
+        expect(page).not_to have_link('Delete')
+      end
     end
   end
 end


### PR DESCRIPTION
### Spec
Add activity tracking to comments, as we have it for other resources

**Proposed solution**
~~Try to use different approach: use callbacks in the model that trigger a bg task to create the corresponding activity.~~

We are going to use the old way (track activity from controller), ~~and try to move to actioncable for the required page changes.~~

### How to test

- Comment on an Issue
- The main page, assert we can see the activity.
- Edit + delete the issue, check those activities too
- With another browser/user, visit the same issue and create/update/delete a comment. Assert that in the first browser wee see those changes.