### PR TITLE
Comments must preserve linebreaks and white space

### DIFF
--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -28,6 +28,13 @@
     border-radius: 5px;
     background-color: #f1f3f3;
 
+    .content {
+      padding: 2em;
+      font-family: inherit;
+      border: none;
+      font-size: 1.1em;
+    }
+
     .time {
       color: #888;
       font-size: 12px;

--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -29,10 +29,13 @@
     background-color: #f1f3f3;
 
     .content {
-      padding: 2em;
+      padding: 0px;
+      margin-left: 35px;
+      margin-top: 1em;
       font-family: inherit;
       border: none;
       font-size: 1.1em;
+      background-color: inherit;
     }
 
     .time {

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -31,9 +31,7 @@
             <% end %>
           </div>
 
-          <div class="content">
-            <%= comment.content %>
-          </div>
+          <pre class="content"><%= comment.content %></pre>
 
           <% if can? :update, comment %>
             <%= render 'comments/edit', commentable: commentable, comment: comment %>


### PR DESCRIPTION
This is the problem we want to fix:
![preview-full-comments](https://user-images.githubusercontent.com/85766/42874456-1be71fb8-8a79-11e8-83a3-6a5c0afa3615.gif)
