### PR TITLE
Comments must preserve line breaks

### DIFF
--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -28,6 +28,10 @@
     border-radius: 5px;
     background-color: #f1f3f3;
 
+    .content {
+      margin-left: 20px;
+    }
+
     .time {
       color: #888;
       font-size: 12px;

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -28,7 +28,7 @@
     </div>
 
     <div class="content">
-      <%= comment.content %>
+      <%= simple_format(comment.content) %>
     </div>
 
     <% if can? :update, comment %>


### PR DESCRIPTION
Rebuilding https://github.com/dradis/dradis-ce/pull/307

This is the problem we want to fix:
![preview-full-comments](https://user-images.githubusercontent.com/85766/42874456-1be71fb8-8a79-11e8-83a3-6a5c0afa3615.gif)
