### PR TITLE
scope 'find' calls to current_project

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -41,11 +41,11 @@ class EvidenceController < NestedNodeResourceController
 
   def create_multiple
     # validate Issue
-    issue = Issue.find(evidence_params[:issue_id])
+    issue = current_project.issues.find(evidence_params[:issue_id])
 
     if params[:evidence][:node_ids]
       params[:evidence][:node_ids].reject(&:blank?).each do |node_id|
-        node = Node.find(node_id)
+        node = current_project.nodes.find(node_id)
         Evidence.create(
           issue_id: issue.id,
           node_id: node.id,
@@ -55,10 +55,10 @@ class EvidenceController < NestedNodeResourceController
     end
     if params[:evidence][:node_list]
       if params[:evidence][:node_list_parent_id].present?
-        parent = Node.find(params[:evidence][:node_list_parent_id])
+        parent = current_project.nodes.find(params[:evidence][:node_list_parent_id])
       end
       params[:evidence][:node_list].lines.map(&:strip).each do |label|
-        node = Node.create_with(type_id: Node::Types::HOST)
+        node = current_project.nodes.create_with(type_id: Node::Types::HOST)
           .find_or_create_by(label: label)
         node.update_attributes!(parent: parent) if parent
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -140,7 +140,7 @@ class IssuesController < AuthenticatedController
   # Load all the colour tags in the project (those that start with !). If none
   # exist, initialize a set of tags.
   def find_or_initialize_tags
-    @tags = Tag.where('name like ?', '!%')
+    @tags = current_project.tags.where('name like ?', '!%')
   end
 
   def issue_params

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -38,7 +38,7 @@ class NodesController < NestedNodeResourceController
 
   def create_multiple
     if params[:nodes][:parent_id].present?
-      @parent = Node.find(params[:nodes][:parent_id])
+      @parent = current_project.nodes.find(params[:nodes][:parent_id])
     end
 
     list = params[:nodes][:list].lines.map(&:strip).select(&:present?)

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -46,7 +46,7 @@ class NodesController < NestedNodeResourceController
     if list.any?
       Node.transaction do |node|
         list.each do |node_label|
-          node = Node.create!(
+          node = current_project.nodes.create!(
             label: node_label.strip,
             parent: @parent,
             type_id: params[:nodes][:type_id]
@@ -67,7 +67,7 @@ class NodesController < NestedNodeResourceController
   # POST /nodes/sort
   def sort
     params[:nodes].each_with_index do |id, index|
-      Node.update_all({position: index+1}, {id: id})
+      current_project.nodes.update_all({position: index+1}, {id: id})
     end
     head :ok
   end

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -38,7 +38,7 @@ class RevisionsController < AuthenticatedController
   private
   def load_node
     if params[:evidence_id] || params[:note_id]
-      @node = Node.includes(
+      @node = current_project.nodes.includes(
         :notes, :evidence, evidence: [:issue, { issue: :tags }]
       ).find_by_id(params[:node_id])
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,6 +43,10 @@ class Project
     Note.all
   end
 
+  def tags
+    Tag.all
+  end
+
   # Returns or creates the Node that acts as container for all Methodologies in
   # a given project
   def methodology_library

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/project_scoped_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/project_scoped_controller.rb
@@ -1,5 +1,13 @@
 module Dradis::CE::API
   module V1
+    # In Pro the dradispro-api engine overrides 'current_project' by injecting
+    # a module into this controller on startup. Unfortunately it won't work
+    # properly in development because of code reloading; every time you make a
+    # new request, PSController will be reloaded without the module included.
+    #
+    # Workaround: set 'config.cache_classes = true' in config/development.rb
+    # (but don't commit it!) The downside is that you'll now have to restart
+    # the server every time you make a change.)
     class ProjectScopedController < Dradis::CE::API::APIController
       include ActivityTracking
 


### PR DESCRIPTION
While working on removing `set_project_scope` from Pro, I uncovered some more cases where `find` calls are not correctly scoped to the `current_project`. I've fixed them in Pro and pushed to `project-id-scopes` - this PR backports the changes to CE to keep the controller code identical.

Probably best not to merge this one until the `set_project_scope` stuff is done on Pro, in case I find any more changes like this that need to be backported. No sense doing it in more than one PR.