### PR TITLE
csrf error

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -7,7 +7,7 @@
 # Any third-party code (e.g. plugins) should inherit from this class instead of
 # calling the authentication filters directly
 class AuthenticatedController < ApplicationController
-  before_action :login_required
+  prepend_before_action :login_required
   before_action :set_paper_trail_whodunnit
   # before_action :render_onboarding_tour
 

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -7,6 +7,10 @@
 # Any third-party code (e.g. plugins) should inherit from this class instead of
 # calling the authentication filters directly
 class AuthenticatedController < ApplicationController
+  # We are using 'prepend_' here so this is executed before
+  # ApplicationController#protect_from_forgery. If not, when the user session
+  # expires we see an 'Invalid csrf token' exception for requests that require
+  # a csrf token.
   prepend_before_action :login_required
   before_action :set_paper_trail_whodunnit
   # before_action :render_onboarding_tour

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -10,7 +10,8 @@ class AuthenticatedController < ApplicationController
   # We are using 'prepend_' here so this is executed before
   # ApplicationController#protect_from_forgery. If not, when the user session
   # expires we see an 'Invalid csrf token' exception for requests that require
-  # a csrf token.
+  # a csrf token. But it is not a csrf attack, it's just that wo/ session the token
+  # cannot be checked.
   prepend_before_action :login_required
   before_action :set_paper_trail_whodunnit
   # before_action :render_onboarding_tour


### PR DESCRIPTION
We do these 2 checks on our requests:

- check csrf token (applies to POST requests).
- check for valid user session

When the user session expires, csrf token check also fails, because there is no info to check the incoming csrf token.

So, if we open Dradis, go to a page that sends a POST request (create issue, evidence...) and wait enough time (or delete the cookie manually), we see this error.

In this PR we force checking for a valid session before checking the csrf token. 

### How to test:
-  Create an issue and stay on that issue page
-  Delete the session cookie from the browser to simulate a session timeout
-  From the issue page/evidence tab, create evidence using the "Add evidence" link
-  We should be logged out, no error should raise