### PR TITLE
remove foreign_key: true from AddProjectIdToVersions

### DIFF
--- a/db/migrate/20161114111520_add_project_id_to_versions.rb
+++ b/db/migrate/20161114111520_add_project_id_to_versions.rb
@@ -1,5 +1,5 @@
 class AddProjectIdToVersions < ActiveRecord::Migration[5.0]
   def change
-    add_reference :versions, :project, index: true, foreign_key: true
+    add_reference :versions, :project, index: true
   end
 end


### PR DESCRIPTION
Trying to fix a migration error in mariadb: https://github.com/dradis/dradis-ce/issues/321