### PR TITLE
allow app prefix wo/ breaking engine url helpers

### DIFF
--- a/app/controllers/methodologies_controller.rb
+++ b/app/controllers/methodologies_controller.rb
@@ -8,7 +8,7 @@ class MethodologiesController < AuthenticatedController
     @methodologies = []
 
     # How ugly is using the :filename to store the note's :id?
-    @methodologies = @methodologylib.notes.map{|n| Methodology.new(filename: n.id, content: n.text)}
+    @methodologies = @methodologylib.notes.map{|n| Methodology.new(filename: n.id.to_s, content: n.text)}
 
     @methodology_templates = Methodology.all
   end

--- a/config.ru
+++ b/config.ru
@@ -2,9 +2,7 @@
 
 require_relative 'config/environment'
 
-map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
-  run Rails.application
-end
+run Rails.application
 
 # Mount the Resque web interface in development. In production is already
 # available through the CIC.

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,13 +23,6 @@ module Dradis
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-
-    # Fix relative URLs for mounted engines.
-    # See:
-    #   https://github.com/activeadmin/activeadmin/issues/101#issuecomment-22273869
-    #
-    # TODO: possibly fixed by Rails 4?
-    routes.default_url_options[:script_name] = ActionController::Base.config.relative_url_root || '/'
   end
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,5 +54,8 @@ Rails.application.configure do
 
   # In development, we want any emails to be opened in the browser
   config.action_mailer.delivery_method = :letter_opener
-end
 
+  if ENV['RAILS_RELATIVE_URL_ROOT']
+    config.assets.prefix = "#{ENV['RAILS_RELATIVE_URL_ROOT']}/assets"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
+if ENV['RAILS_RELATIVE_URL_ROOT']
+  Rails.application.routes.default_scope = ENV['RAILS_RELATIVE_URL_ROOT']
+end
+
 Rails.application.routes.draw do
   # ------------------------------------------------------------ Authentication
   # These routes allow users to set the shared password


### PR DESCRIPTION
We had to force the use of rails `5.1.2` because
our way of deploying rails to a subdirectory (`/pro`) stopped working on `5.1.3`.

### The issue:

We deployed in a subdirectory using `map` in `config.ru`: 

```
map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
  run Rails.application
end
```

and mounted engines in `/`. 

```
initializer 'example.mount_engine' do
  Rails.application.routes.append do
    mount Dradis::Pro::Example::Engine => '/', as: :exmplengine
  end
end
```

then, when using helper urls *from inside the engine*, like:
`examplengine.examplengine_custom__path`

the result missed the subdirectory ('/...` instead of `/pro/...`)

This happens since this commit in rails: https://github.com/rails/rails/commit/cba4e5319430df3a477e658f5025bf44857b2764

This commit is there for rails `5.1.3`, so we forced the use of `5.1.2` to prevent the problem.

There is a rails issue for this, which I tried to push, here: https://github.com/rails/rails/issues/31476
even with a PR to fix it https://github.com/rails/rails/pull/31539/files
But the issue was closed.

### Fix:
I am not sure if the bug above is really  a bug, or using the `map` in `config.ru` in not supported anymore.
I think I've found a nice workaround (or correct way to do this) by using scope in our routes depending on ENV:
```
if ENV['RAILS_RELATIVE_URL_ROOT']
  Rails.application.routes.default_scope = ENV['RAILS_RELATIVE_URL_ROOT']
end
```

### How to test:

**In development:**

- start rails with: `bin/rails` and assert that the engine url helpers work
   Assert that it works from outside the engine and from inside 
   the engine.
   Assert that all assets are working as expected (styles look good), and that all fonts are working 
   (check for font-awesome icons).

- start rails with: ` RAILS_RELATIVE_URL_ROOT="/pro" bin/rails s`
Assert that we must access tha app using `/pro`, and check that everything mentioned in the first point works too.

