### PR TITLE
do not use foreign_keys in notification migration + remove unique index

### DIFF
--- a/db/migrate/20180705112109_create_notifications.rb
+++ b/db/migrate/20180705112109_create_notifications.rb
@@ -6,15 +6,10 @@ class CreateNotifications < ActiveRecord::Migration[5.1]
 
       t.references  :notifiable, polymorphic: true, index: true
 
-      t.references  :actor, index: true, foreign_key: { to_table: :users }
-      t.references  :recipient, index: true, foreign_key: { to_table: :users }
+      t.references  :actor, index: true, references: :users
+      t.references  :recipient, index: true, references: :users
 
       t.timestamps
     end
-
-    add_index :notifications,
-              [:notifiable_id, :notifiable_type, :recipient_id],
-              unique: true,
-              name: 'index_notifications_on_notifiable_and_recipient'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,7 +100,6 @@ ActiveRecord::Schema.define(version: 20180705112109) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["actor_id"], name: "index_notifications_on_actor_id"
-    t.index ["notifiable_id", "notifiable_type", "recipient_id"], name: "index_notifications_on_notifiable_and_recipient", unique: true
     t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
     t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
   end


### PR DESCRIPTION
In notifications table we are using foreign keys to point `actor` and `recipient` to the users table.
There is no need for it.

Also, this keeps this new migration compatible for users who have a working dradis (from before rails 5.1) with a `users.id` as `int` instead a `bigint`

Also remove a too restrictive unique index as discussed here https://github.com/dradis/dradis-ce/pull/303#pullrequestreview-138626747