### PR TITLE
use foreign keys in references to users.id

### DIFF
--- a/db/migrate/20180611150236_create_comments.rb
+++ b/db/migrate/20180611150236_create_comments.rb
@@ -4,7 +4,7 @@ class CreateComments < ActiveRecord::Migration[5.1]
       t.text :content
 
       t.references :commentable, polymorphic: true, index: true
-      t.references :user, index: true
+      t.references :user, index: true, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20180613151829_create_subscriptions.rb
+++ b/db/migrate/20180613151829_create_subscriptions.rb
@@ -2,7 +2,7 @@ class CreateSubscriptions < ActiveRecord::Migration[5.1]
   def change
     create_table :subscriptions do |t|
       t.references :subscribable, polymorphic: true
-      t.references :user, index: true
+      t.references :user, index: true, foreign_key: true
     end
 
     add_index :subscriptions,

--- a/db/migrate/20180705112109_create_notifications.rb
+++ b/db/migrate/20180705112109_create_notifications.rb
@@ -6,8 +6,8 @@ class CreateNotifications < ActiveRecord::Migration[5.1]
 
       t.references  :notifiable, polymorphic: true, index: true
 
-      t.references  :actor, index: true, references: :users
-      t.references  :recipient, index: true, references: :users
+      t.references  :actor, index: true, foreign_key: { to_table: :users }
+      t.references  :recipient, index: true, foreign_key: { to_table: :users }
 
       t.timestamps
     end


### PR DESCRIPTION
Revert https://github.com/dradis/dradis-ce/commit/ed18f71939eca53dc9a803a5a9a8e68763eb2a83, we do want to use foreign keys

Also, there are two more cases in `subscriptions` and `comments` table where we can use a similar foreign key