### PR TITLE
Bump to dradis-plugins >= 3.10 doesn't require the set_project_scope call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,7 +206,7 @@ end
 #
 
 # Base framework classes required by other plugins
-gem 'dradis-plugins', '~> 3.9', github: 'dradis/dradis-plugins'
+gem 'dradis-plugins', '~> 3.10', github: 'dradis/dradis-plugins'
 
 
 gem 'dradis-api', path: 'engines/dradis-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/dradis/dradis-plugins.git
-  revision: 4405464bf845c54196d7fcfb2cf8efe88adcd8eb
+  revision: dc29467e46cd7f6c4c42bee0c4476c5a860fbefc
   specs:
-    dradis-plugins (3.9.0)
+    dradis-plugins (3.10.0)
 
 GIT
   remote: https://github.com/dradis/dradis-projects.git
@@ -394,7 +394,7 @@ DEPENDENCIES
   database_cleaner
   differ (~> 0.1.2)
   dradis-api!
-  dradis-plugins (~> 3.9)!
+  dradis-plugins (~> 3.10)!
   dradis-projects (~> 3.9)!
   factory_bot_rails
   font-awesome-sass (~> 4.7.0)

--- a/app/controllers/upload_controller.rb
+++ b/app/controllers/upload_controller.rb
@@ -73,6 +73,7 @@ class UploadController < AuthenticatedController
       default_user_id: current_user.id,
       file: attachment.fullpath.to_s,
       plugin_name: @uploader.to_s,
+      project_id: current_project.id,
       uid: params[:item_id].to_i
     )
   end
@@ -84,8 +85,9 @@ class UploadController < AuthenticatedController
     begin
       importer = @uploader::Importer.new(
         default_user_id: current_user.id,
-        logger: job_logger,
-        plugin: @uploader
+        logger:     job_logger,
+        plugin:     @uploader,
+        project_id: current_project.id
       )
 
       importer.import(file: attachment.fullpath)


### PR DESCRIPTION
The code is now in `dradis/dradis-plugins#master` so we should be good. Before release we need to make a .gem file and tweak our Gemfile.