### PR TITLE
allowing full emails in mentions

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -50,7 +50,7 @@ class Comment < ApplicationRecord
     @mentions = nil if content_changed?
     @mentions ||= begin
       mentioned_users = []
-      HTML::Pipeline::MentionFilter.mentioned_logins_in(content) do |match, login, is_mentioned|
+      HTML::Pipeline::MentionFilter.mentioned_logins_in(content, /[a-z0-9][a-z0-9\-@\.]*/) do |match, login, is_mentioned|
         if (mentioned_user = User.find_by_email(login))
           mentioned_users << mentioned_user
         end


### PR DESCRIPTION
In comment mentions we need a unique user name with no spaces so we can put it after the `@`, ln then whit html pipeline get the user from that string.

Until now we are using the email, since it is the only human readable unique string that identifies the user.

But noticed that when using full emails html pipeline breaks the string in the second `@` of the mention (thinks it is another mention or something), and thus the user is not found.

But html pipeline itself allows to pass a custom regex to detect the user string: https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/%40mention_filter.rb#L14

In this PR we use that to allow complete emails in mentions

### How to test:

- Create a user with a real email as email.
- Mention that user in comments.
- Assert the mention works.