### PR TITLE
Bump to dradis-projects >= 3.10 doesn't require the set_project_scope call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -212,7 +212,7 @@ gem 'dradis-plugins', '~> 3.10', github: 'dradis/dradis-plugins'
 gem 'dradis-api', path: 'engines/dradis-api'
 
 # Import / export project data
-gem 'dradis-projects', '~> 3.9', github: 'dradis/dradis-projects'
+gem 'dradis-projects', '~> 3.10', github: 'dradis/dradis-projects'
 
 plugins_file = 'Gemfile.plugins'
 if File.exists?(plugins_file)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GIT
 
 GIT
   remote: https://github.com/dradis/dradis-projects.git
-  revision: 2a56756753c446b878b2e954f66ee376127a6088
+  revision: 48d6fbfb8998fd5475c9303b42ff2ae41b999696
   specs:
-    dradis-projects (3.9.0)
+    dradis-projects (3.10.0)
       dradis-plugins (~> 3.7)
       rubyzip (~> 1.2.1)
 
@@ -395,7 +395,7 @@ DEPENDENCIES
   differ (~> 0.1.2)
   dradis-api!
   dradis-plugins (~> 3.10)!
-  dradis-projects (~> 3.9)!
+  dradis-projects (~> 3.10)!
   factory_bot_rails
   font-awesome-sass (~> 4.7.0)
   foreman


### PR DESCRIPTION
The code is now in dradis/dradis-projects#master so we should be good. Before release we need to make a .gem file and tweak our Gemfile.