### PR TITLE
Pass the project_id to the export options

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -23,6 +23,7 @@ class ExportController < AuthenticatedController
     # redirecting, so we'll put them in the session.
     # *Warning* can't store too much data here.
     session[:export_manager] = {
+      project_id: current_project.id,
       template: @template_file
     }
 


### PR DESCRIPTION
Currently, exporting controllers for the other plugins have no reference to the CE project. We're storing the `project_id` to the session to be passed in the export controllers, as we do in Pro.