### PR TITLE
Make sure ActivitiesPoller is just initialized once

### DIFF
--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -147,8 +147,9 @@ document.addEventListener "turbolinks:load", ->
       img.src = $this.attr('src')
 
   if ($poller = $("#activities-poller")).length
-    ActivitiesPoller.init($poller)
-    ActivitiesPoller.poll()
+    unless ActivitiesPoller.initialized
+      ActivitiesPoller.init($poller)
+      ActivitiesPoller.poll()
 
   # Disable form buttons after submitting them.
   $('form').submit (ev)->


### PR DESCRIPTION
Since we are using turbolinks we initialize ActivitiesPoller more than once. 

We keep doing it one time on every page visit, as before, but with the problem that the old initialized ActivitiesPoller remains there.

This leads to polling more often than just every 10s.

We already had an unused `initialized` flag in ActivitiesPoller. Using it now to check if it needs to be initialized or not.

### How to test:
Navigate a few pages: main project page, all issues page, an issue page....
Check with the browser console that we keep polling for activities just once every 10 seconds.