### PR TITLE
Fix cable connection exception for expired sessions

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -9,7 +9,8 @@ module ApplicationCable
     private
 
     def find_verified_user
-      if verified_user = env['warden'].user
+      verified_user = catch(:warden) { env['warden'].user }
+      if verified_user.is_a?(User)
         verified_user
       else
         reject_unauthorized_connection


### PR DESCRIPTION
I see in the logs:

```
Started GET "/cable" for 127.0.0.1 at 2018-08-06 12:51:00 +0100
Started GET "/cable/" [WebSocket] for 127.0.0.1 at 2018-08-06 12:51:00 +0100
Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 2 LIMIT 1
There was an exception - UncaughtThrowError(uncaught throw :warden)
/.../dradis-ce/config/initializers/warden_99_timeout.rb:33:in `throw'
```

This exception is thrown by the request made by the browser when trying to open the cable connection.
When we get that request, we try to get the user from warden, but warden `throws`a ruby error when the user session has expired.
When opening the connection, we must `catch` that error and provide an early exit.

### How to test
Start the server  (puma)
Open the browser and visit dradis main project page
Remove the dradis cookie form the browser
Without closing the browser, restart the puma server.
The browser will try to reopen the cable connection, but instead of seeing the previous exception, we should see:

```
Started GET "/cable" for 127.0.0.1 at 2018-08-08 11:58:43 +0100
Started GET "/cable/" [WebSocket] for 127.0.0.1 at 2018-08-08 11:58:43 +0100
Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
An unauthorized connection attempt was rejected
Failed to upgrade to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
Finished "/cable/" [WebSocket] for 127.0.0.1 at 2018-08-08 11:58:43 +0100
Finished "/cable/" [WebSocket] for 127.0.0.1 at 2018-08-08 11:58:43 +0100
```