### PR TITLE
Add updated_at to subscriptions table

### DIFF
--- a/db/migrate/20180613151829_create_subscriptions.rb
+++ b/db/migrate/20180613151829_create_subscriptions.rb
@@ -3,6 +3,8 @@ class CreateSubscriptions < ActiveRecord::Migration[5.1]
     create_table :subscriptions do |t|
       t.references :subscribable, polymorphic: true
       t.references :user, index: true, foreign_key: true
+
+      t.timestamps
     end
 
     add_index :subscriptions,


### PR DESCRIPTION
When cache is on, noticed that subscriptions table needs the `updated_at` column, since subscriptions are used in cache keys