### PR TITLE
Use case insensitive regex for tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,7 +28,7 @@ class Tag < ApplicationRecord
   #  * If the tag name contains color details, they are stripped
   #  * The result is titleized
   def display_name()
-    if self.name =~ /\A!([abcdef\d]{6})(_([[:word:]]+))?\z/
+    if self.name =~ /\A!([0-9A-Fa-f]{6})(_([[:word:]]+))?\z/
       if $3
         out = $3
       else
@@ -43,7 +43,7 @@ class Tag < ApplicationRecord
   # Strips the tag's name and returns the color details if present
   # if no color information is found, returns a default value of #ccc
   def color()
-    name[/\A(![abcdef\d]{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || "#ccc"
+    name[/\A(![0-9A-Fa-f]{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || "#ccc"
   end
 
   private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,7 +28,7 @@ class Tag < ApplicationRecord
   #  * If the tag name contains color details, they are stripped
   #  * The result is titleized
   def display_name()
-    if self.name =~ /\A!([0-9A-Fa-f]{6})(_([[:word:]]+))?\z/
+    if self.name =~ /\A!(\h{6})(_([[:word:]]+))?\z/
       if $3
         out = $3
       else
@@ -43,7 +43,7 @@ class Tag < ApplicationRecord
   # Strips the tag's name and returns the color details if present
   # if no color information is found, returns a default value of #ccc
   def color()
-    name[/\A(![0-9A-Fa-f]{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || "#ccc"
+    name[/\A(!\h{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || "#ccc"
   end
 
   private


### PR DESCRIPTION
Tag names in the IssueLibrary or in custom tags need to have characters in lowercase in order to render correctly e.g.
```
!7030a0_Critical instead of !7030A0_Critical 
!c00000_High instead of !C00000_High
!ffc000_Medium instead of !FFC000_Medium
```