### PR TITLE
remove deprecated FactoryBot syntax

### DIFF
--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :project do
     skip_create
 
-    ignore do
+    transient do
       id 1
     end
   end


### PR DESCRIPTION
'ignore' prints a deprecation warning