### PR TITLE
Fix 2 bugs with the UI on issues#index

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -8,13 +8,15 @@ class IssuesTable extends ItemsTable
     that = this
     $target = $(event.target)
     tagColumnIndex = @columnIndices['tags']
+    tagColIsHidden = !$('th[data-column=tags]').is(':visible')
     event.preventDefault()
 
     $(@selectedItemsSelector).each ->
       $this = $(this)
 
       $row = $this.parent().parent()
-      $($row.find('td')[tagColumnIndex]).replaceWith("<td class=\"loading\">Loading...</td>")
+      $tagTD = $row.find('td').eq(tagColumnIndex)
+      $tagTD.removeClass().addClass('loading').text('Loading...')
 
       url   = $this.data('url')
       data  = {}
@@ -28,7 +30,9 @@ class IssuesTable extends ItemsTable
           $this.prop('checked', false)
           item_id = $this.val()
 
-          $($row.find('td')[tagColumnIndex]).replaceWith(data.tag_cell)
+          $newTagTD = $(data.tag_cell)
+          $newTagTD.hide() if tagColIsHidden
+          $tagTD.replaceWith($newTagTD)
           $("##{that.itemName}_#{item_id}").replaceWith(data["#{that.itemName}_link"])
           if $(that.selectedItemsSelector).length == 0
             that.resetToolbar()

--- a/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/table.js.coffee
@@ -33,7 +33,8 @@ class IssuesTable extends ItemsTable
           $newTagTD = $(data.tag_cell)
           $newTagTD.hide() if tagColIsHidden
           $tagTD.replaceWith($newTagTD)
-          $("##{that.itemName}_#{item_id}").replaceWith(data["#{that.itemName}_link"])
+          # Update the link in the sidebar:
+          $("##{that.itemName}_#{item_id}_link").replaceWith(data["#{that.itemName}_link"])
           if $(that.selectedItemsSelector).length == 0
             that.resetToolbar()
 

--- a/spec/support/items_table_examples.rb
+++ b/spec/support/items_table_examples.rb
@@ -1,7 +1,7 @@
 # A let variable  'columns' and a variable 'custom_columns' should be defined
 #
 #     let(:columns) { ['Title', 'Created', ...] }
-#     let(:columns) { ['Description', 'Extra', ...] }
+#     let(:custom_columns) { ['Description', 'Extra', ...] }
 #
 shared_examples "an index table" do |item_type|
   it 'displays column controls desired columns' do


### PR DESCRIPTION
Bug 1: if you update an issue's tag while the "tags" column is hidden, bad things happen:

![issue-tag](https://user-images.githubusercontent.com/2656485/44336028-07dbc000-a46e-11e8-88ba-1bb4235807f1.gif)

Fix: update the JS so it hides the updated "tag" cell if necessary.

Bug 2: updating an issue's tag doesn't change the tag colour in the sidebar. This is caused by an incorrect jQuery selector string and is a one-line fix.

To test:
- Open a project, create some issues, and go to the "all issues" page
- Hide the "Tags" column with the button at the top
- Select an issue, click the Tag button that appears at the top, and change the tag
- Confirm that the table itself is not changed, but the tag icon next to the issue in the sidebar updates to the new colour.
- Without reloading the page, show the "Tags" column again and confirm that the updated tag is displayed.