### PR TITLE
bug fix: 'create multiple node' modal not closing

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -57,11 +57,11 @@ class NodesController < NestedNodeResourceController
     end
 
     flash[:notice] = "Successfully created #{list.length} node#{'s' if list.many?}"
-    if @parent
-      redirect_to project_node_path(current_project, @parent)
-    else
-      project_path(current_project)
-    end
+    redirect_to (if @parent
+                   project_node_path(current_project, @parent)
+                 else
+                   project_path(current_project)
+                 end)
   end
 
   # POST /nodes/sort

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -80,6 +80,9 @@ describe "node pages" do
           "node_2",
           "node with trailing whitespace",
         ])
+
+        # redirects to project root:
+        expect(page).to have_selector 'h1', text: 'PROJECT SUMMARY'
       end
 
       example "adding multiple root host nodes" do
@@ -162,6 +165,9 @@ describe "node pages" do
           "node_2",
           "node with trailing whitespace",
         ])
+
+        # redirects to parent node's page
+        expect(page).to have_selector 'ul.breadcrumb > li.active', text: node.label
       end
 
       example "adding multiple nodes - submitting a blank textarea" do


### PR DESCRIPTION
the bug occurred when adding multiple root nodes - the 'redirect_to' was
missing so the server responded with 'no content'