### PR TITLE
Add current_user to issues cache key

### DIFF
--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -25,7 +25,7 @@
 </ul>
 
 <div class="tab-content">
-  <% cache ['issue-information-tab', @issue, @issue.comments, @issue.subscriptions] do %>
+  <% cache ['issue-information-tab', @issue, @issue.comments, @issue.subscriptions, current_user] do %>
     <div class="tab-pane active" id="info-tab">
       <div class="inner note-text-inner">
         <h3>Issue information -


### PR DESCRIPTION
Currently, the show page does not update when logging with a new user due to caching. We want to re-cache the view when a new `current_user` is set.