### PR TITLE
Fix issues with comment polling

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
@@ -177,6 +177,7 @@ class @ActivitiesPoller
 
   @addComment: (commentableId, content) ->
     if commentableId == @modelId
+      $('#no-comments-notice').hide()
       $('.comment-list').append(content)
       count = parseInt($('#comment-count').html())
       $('#comment-count').html(count + 1)
@@ -186,11 +187,13 @@ class @ActivitiesPoller
     comment.replaceWith(content)
 
   @deleteComment: (commentId) ->
-      comment = $("#comment_#{commentId}")
-      if comment.length
-        comment.remove()
-        count = parseInt($('#comment-count').html())
-        $('#comment-count').html(count - 1) if count > 0
+    comment = $("#comment_#{commentId}")
+    if comment.length
+      comment.remove()
+      count = parseInt($('#comment-count').html())
+      $('#comment-count').html(count - 1) if count > 0
+      if !$('.comments-list .comment:not(#no-comments-notice').length
+        $('#no-comments-notice').show()
 
   # private
 

--- a/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
@@ -179,7 +179,7 @@ class @ActivitiesPoller
     # Make sure comment isn't already on the page, e.g. if they
     # loaded/refreshed the page just after the comment was posted:
     if commentableId == @modelId && !$("#comment_#{commentId}").length
-      $('#no-comments-notice').hide()
+      $('[data-notice~=no-comments]').hide()
       $('.comment-list').append(content)
       count = parseInt($('#comment-count').html())
       $('#comment-count').html(count + 1)
@@ -195,7 +195,7 @@ class @ActivitiesPoller
       count = parseInt($('#comment-count').html())
       $('#comment-count').html(count - 1) if count > 0
       if !$('.comments-list .comment:not(#no-comments-notice').length
-        $('#no-comments-notice').show()
+        $('[data-notice~=no-comments]').show()
 
   # private
 

--- a/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/activities/poller.js.coffee
@@ -176,7 +176,9 @@ class @ActivitiesPoller
   # ------ COMMENTS ------
 
   @addComment: (commentableId, content) ->
-    if commentableId == @modelId
+    # Make sure comment isn't already on the page, e.g. if they
+    # loaded/refreshed the page just after the comment was posted:
+    if commentableId == @modelId && !$("#comment_#{commentId}").length
       $('#no-comments-notice').hide()
       $('.comment-list').append(content)
       count = parseInt($('#comment-count').html())

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -3,7 +3,7 @@
   <div class="comment-list">
     <%= render(commentable.comments.includes(:user)) if commentable.comments.any? %>
 
-    <div id="no-comments-notice" class="comment"
+    <div data-notice="no-comments" class="comment"
       <% if commentable.comments.any? %>
         style="display: none;" <%# may be un-hidden later by JS %>
       <% end %>

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -1,11 +1,15 @@
 <h3>Comments <span class="badge" id="comment-count"><%= commentable.comments.count %></span></h3>
 <div class="comment-feed">
   <div class="comment-list">
-    <% if commentable.comments.any? %>
-    <%= render(commentable.comments.includes(:user)) %>
-    <% else %>
-    <div class="comment">There have been no comments yet.</div>
-    <% end %>
+    <%= render(commentable.comments.includes(:user)) if commentable.comments.any? %>
+
+    <div id="no-comments-notice" class="comment"
+      <% if commentable.comments.any? %>
+        style="display: none;" <%# may be un-hidden later by JS %>
+      <% end %>
+    >
+      There have been no comments yet.
+    </div>
   </div>
 
   <%= render 'comments/new', commentable: commentable %>


### PR DESCRIPTION
To test:

Bug 1:

1. Open an issue with no comments in two separate tabs/browsers as two different users.
1. As one user, make a comment.
1. Go to the other tab and don't refresh the page; wait for the poller to grab the comment and display it.
1. Confirm that the "there have been no comments yet" text disappears.
1. As the first user, delete the comment.
1. As the second user, again without refreshing, wait for the poller to remove the deleted comment from the page.
1. Confirm that the "there have been no comments yet" text appears again.

Bug 1:

1. Open an issue in two separate tabs/browsers as two different users.
1. As one user, make a comment.
1. Quickly switch to the other tab and refresh the page. The new comment should be visible.
1. Wait 10 seconds or so for the poller to make its next poll. (If you want to be extra certain you can check the Network tab in the Chrome inspector to see exactly when polling occurs.)
1. Confirm that the new comment doesn't get added to the page a second time. (If you're not sure what I mean, follow these instructions on a different branch to see the bug in action!)