### PR TITLE
do not vaildate email format

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
 
   validates :email,
-    format: { with: /\A[-a-z0-9_+\.]+\@([-a-z0-9]+\.)+[a-z0-9]{2,4}\z/i },
     length: { maximum: DB_MAX_STRING_LENGTH },
     uniqueness: { allow_blank: false }
 


### PR DESCRIPTION
### Spec
In CE, when trying to log in with a new user, we always get an "Invalid credentials" message.
If the user was already present in the db, we can log in.

### Proposed solution
Once found that the problems was just with new users, I think the error is that when creating the new user it does not vaildate the email.
We did not validate emails before, but we do now. 

The proposed solution is to stop validating email format in CE.

### How to test

1. Log in with an existing user, should work.
2. Log in with a new user. The user should be created an log in should work.