### PR TITLE
Fix blockcode escape

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v3.11 (November 2018)
+ - Fix blockcode characters displaying incorrectly
+
 v3.10 (August 2018)
  - Add comments for issues
  - Add notifications for comments

--- a/lib/html/pipeline/dradis_escape_html_filter.rb
+++ b/lib/html/pipeline/dradis_escape_html_filter.rb
@@ -14,7 +14,18 @@ module HTML
     # This filter does not write any additional information to the context hash.
     class DradisEscapeHTMLFilter < TextFilter
       def call
-        ERB::Util.html_escape(@text)
+        text = ERB::Util.html_escape(@text)
+
+        # Match the text between bc. and bc.. following the textile rules
+        regex = Regexp.union(
+          /(?<=bc. )(.*?)(?=(\r\n|\n){2})/m,
+          /(?<=bc.. )(.*?)(?=(bc\.|bc\.\.|p\.|\z))/m
+        )
+
+        # Un-escape the matched strings
+        text.gsub(regex) do |bc|
+          CGI::unescapeHTML(bc)
+        end
       end
     end
   end


### PR DESCRIPTION
### Spec
Currently, the DradisHTMLEscapeFilter is messing up the Textile display of the characters in the blockcode. This is because it escapes the string to be html-safe including the ones enclosed in a blockcode.

**Proposed Solution**
Update the filter to unescape the blockcode characters.

How to test:
1. Add the folllowing issue to a project:
```
bc.. [
  {
    "issue": {
      "Title": "Test Issue 1",
      "Description": "Lorem Ipsum"
    }
  },
  {
    "issue": {
      "Title": "Test Issue 2",
      "Description": "Lorem Ipsum"
    }
  }
]
```
2. Assert that the UI displays the characters correctly.