### PR TITLE
Upgrade to nokogiri 1.8.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'bcrypt',   '3.1.12'
 gem 'json', '1.8.6'
 
 # XML manipulation
-gem 'nokogiri', '1.8.3'
+gem 'nokogiri', '1.8.5'
 
 # MySQL backend
 gem 'mysql2', '~> 0.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     mysql2 (0.5.1)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.3)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -410,7 +410,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   local_time (>= 2.0.0)
   mysql2 (~> 0.5.1)
-  nokogiri (= 1.8.3)
+  nokogiri (= 1.8.5)
   paper_trail (~> 6.0)
   parslet (~> 1.6.0)
   poltergeist


### PR DESCRIPTION
```
Name: nokogiri
Version: 1.8.3
Advisory: CVE-2018-14404
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1785
Title: Nokogiri gem, via libxml2, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.8.5
```