### PR TITLE
Comments api

### DIFF
--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -13,8 +13,4 @@ module Commentable
       )
     )
   end
-
-  def comments_count
-    self.comments.count
-  end
 end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -13,4 +13,8 @@ module Commentable
       )
     )
   end
+
+  def comments_count
+    self.comments.count
+  end
 end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -22,16 +22,10 @@ module Dradis::CE::API
       private
 
       def set_commentable
-        @commentable =
-          if params[:issue_id]
-           Issue.find(params[:issue_id])
-          elsif params[:note_id]
-            Note.find(params[:note_id])
-          elsif params[:evidence_id]
-            Evidence.find(params[:evidence_id])
-          else
-            raise 'Polymorphic model missing!'
-          end
+        commentable_klasses = %w[issue note evidence]
+        if klass = commentable_klasses.detect { |ck| params[:"#{ck}_id"].present? }
+          @commentable = klass.camelize.constantize.find params[:"#{klass}_id"]
+        end
       end
 
       def set_comment

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -24,7 +24,8 @@ module Dradis::CE::API
       def set_commentable
         commentable_klasses = %w[issue note evidence]
         if klass = commentable_klasses.detect { |ck| params[:"#{ck}_id"].present? }
-          @commentable = klass.camelize.constantize.find params[:"#{klass}_id"]
+          @commentable =
+            current_project.send(klass.pluralize).find(params[:"#{klass}_id"])
         end
       end
 

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -1,0 +1,36 @@
+module Dradis::CE::API
+  module V1
+    class CommentsController < Dradis::CE::API::V1::ProjectScopedController
+      before_action :set_comment, only: [:show, :update, :destroy]
+      before_action :set_commentable, only: [:index, :create]
+
+      def index
+      end
+
+      def show; end
+
+      def create
+      end
+
+      def update
+      end
+
+      def destroy
+      end
+
+      private
+
+      def set_commentable
+        regex = /(?<=\/api\/)([a-z]+)(?=\/)/
+        commentable_type = request.original_fullpath[regex].singularize
+        commentable_class = commentable_type.capitalize.constantize
+
+        @commentable = commentable_class.find(params["#{commentable_type}_id"])
+      end
+
+      def set_comment
+        @comment = Comment.find(params[:id])
+      end
+    end
+  end
+end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -22,11 +22,16 @@ module Dradis::CE::API
       private
 
       def set_commentable
-        regex = /(?<=\/api\/)([a-z]+)(?=\/)/
-        commentable_type = request.original_fullpath[regex].singularize
-        commentable_class = commentable_type.capitalize.constantize
-
-        @commentable = commentable_class.find(params["#{commentable_type}_id"])
+        @commentable =
+          if params[:issue_id]
+           Issue.find(params[:issue_id])
+          elsif params[:note_id]
+            Note.find(params[:note_id])
+          elsif params[:evidence_id]
+            Evidence.find(params[:evidence_id])
+          else
+            raise 'Polymorphic model missing!'
+          end
       end
 
       def set_comment

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -5,6 +5,7 @@ module Dradis::CE::API
       before_action :set_commentable, only: [:index, :create]
 
       def index
+        @comments = @commentable.comments
       end
 
       def show; end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -2,7 +2,7 @@ module Dradis::CE::API
   module V1
     class CommentsController < Dradis::CE::API::V1::ProjectScopedController
       before_action :set_comment, only: [:show, :update, :destroy]
-      before_action :set_commentable, only: [:index, :create]
+      before_action :set_commentable
 
       def index
         @comments = @commentable.comments
@@ -30,7 +30,7 @@ module Dradis::CE::API
       end
 
       def set_comment
-        @comment = Comment.find(params[:id])
+        @comment = @commentable.comments.find(params[:id])
       end
     end
   end

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/comments/_comment.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/comments/_comment.json.jbuilder
@@ -1,0 +1,1 @@
+json.(comment, :id, :content, :user_id, :created_at, :updated_at)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/comments/index.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/comments/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @comments, partial: 'comment', as: :comment

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/comments/show.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/comments/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'comment', comment: @comment

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/evidence/_evidence.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/evidence/_evidence.json.jbuilder
@@ -4,3 +4,5 @@ json.issue do |json|
   json.title evidence.issue.title
   json.url dradis_api.issue_url(evidence.issue_id)
 end
+json.comments_count evidence.comments_count
+json.comments_url evidence_comments_path(evidence)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/evidence/_evidence.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/evidence/_evidence.json.jbuilder
@@ -4,5 +4,5 @@ json.issue do |json|
   json.title evidence.issue.title
   json.url dradis_api.issue_url(evidence.issue_id)
 end
-json.comments_count evidence.comments_count
+json.comments_count evidence.comments.count
 json.comments_url evidence_comments_path(evidence)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/issues/_issue.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/issues/_issue.json.jbuilder
@@ -1,3 +1,3 @@
 json.(issue, :id, :title, :fields, :text, :created_at, :updated_at)
-json.comments_count issue.comments_count
+json.comments_count issue.comments.count
 json.comments_url issue_comments_path(issue)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/issues/_issue.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/issues/_issue.json.jbuilder
@@ -1,1 +1,3 @@
 json.(issue, :id, :title, :fields, :text, :created_at, :updated_at)
+json.comments_count issue.comments_count
+json.comments_url issue_comments_path(issue)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/notes/_note.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/notes/_note.json.jbuilder
@@ -1,1 +1,3 @@
 json.(note, :id, :category_id, :title, :fields, :text)
+json.comments_count note.comments_count
+json.comments_url note_comments_path(note)

--- a/engines/dradis-api/app/views/dradis/ce/api/v1/notes/_note.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v1/notes/_note.json.jbuilder
@@ -1,3 +1,3 @@
 json.(note, :id, :category_id, :title, :fields, :text)
-json.comments_count note.comments_count
+json.comments_count note.comments.count
 json.comments_url note_comments_path(note)

--- a/engines/dradis-api/config/routes.rb
+++ b/engines/dradis-api/config/routes.rb
@@ -7,14 +7,11 @@ Dradis::CE::API::Engine::routes.draw do
     defaults format: 'json' do
       scope module: :v1, constraints: Dradis::CE::API::RoutingConstraints.new(version: 1, default: true) do
         resources :issues, concerns: :with_comments
-        resources :evidence, only: [], concerns: :with_comments
-        resources :notes, only: [], concerns: :with_comments
-
         resources :comments, only: [:show, :update, :destroy]
 
         resources :nodes do
-          resources :evidence
-          resources :notes
+          resources :evidence, concerns: :with_comments
+          resources :notes, concerns: :with_comments
           constraints(:filename => /.*/) do
             resources :attachments, param: :filename
           end

--- a/engines/dradis-api/config/routes.rb
+++ b/engines/dradis-api/config/routes.rb
@@ -1,8 +1,17 @@
 Dradis::CE::API::Engine::routes.draw do
+  concern :with_comments do
+    resources :comments, only: [:index, :create]
+  end
+
   scope path: :api do
     defaults format: 'json' do
       scope module: :v1, constraints: Dradis::CE::API::RoutingConstraints.new(version: 1, default: true) do
-        resources :issues
+        resources :issues, concerns: :with_comments
+        resources :evidence, only: [], concerns: :with_comments
+        resources :notes, only: [], concerns: :with_comments
+
+        resources :comments, only: [:show, :update, :destroy]
+
         resources :nodes do
           resources :evidence
           resources :notes


### PR DESCRIPTION
Reviewer notes: update the base branch when #372 is merged.

### Spec
We want to have an API endpoint for comments. This task should implement the comments#index API.

**Proposed solution**
We'll pattern the comment API endpoint from basecamp.

First, we add two new attributes to the the commentable items API: comments_count and comments_url. Comments URL will point to the commentable's comment API endpoint. Ex: api/issues/:issue_id/comments.

Second, we add the comments endpoint. Using the comments_url in the first step, it should list the commentable's comments in an array. 

For this task, we should implement the groundwork for the comments API and the comments index.

### How to test

1. Add an issue to the project.
2. Add comments to the issue.
3. Fetch the issue using the API. Assert that the comments_count and comments_url appears.
4. Fetch the issue's comments using the comments_url. Assert that the comments were correctly fetched.