### PR TITLE
Enhance mentions display

### DIFF
--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -42,6 +42,12 @@
     form.edit_comment {
       display: none;
     }
+
+    .format_comment {
+      .gravatar {
+        float: none;
+      }
+    }
   }
 }
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -10,6 +10,6 @@ module CommentsHelper
       else
         mention
       end
-    end.html
+    end.html_safe
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,6 +1,6 @@
 module CommentsHelper
   def format_comment(text)
-    simple_format(text).gsub(/@[a-z0-9\-_\.]+/i) do |mention|
+    simple_format(text).gsub(/@[a-z0-9\-_\.@]+/i) do |mention|
       user = User.find_by_email(mention[1..-1])
       if user
         content_tag :span, class: 'format_comment' do

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,11 @@
+module CommentsHelper
+  def format_comment(text)
+    simple_format(text).gsub(/@[a-z0-9\-_\.]+/i) do |mention|
+      user = User.find_by_email(mention[1..-1])
+      content_tag :span do
+        avatar_image(user, size: 30) +
+        content_tag(:strong, user.email)
+      end
+    end.html_safe
+  end
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -2,10 +2,14 @@ module CommentsHelper
   def format_comment(text)
     simple_format(text).gsub(/@[a-z0-9\-_\.]+/i) do |mention|
       user = User.find_by_email(mention[1..-1])
-      content_tag :span do
-        avatar_image(user, size: 30) +
-        content_tag(:strong, user.email)
+      if user
+        content_tag :span, class: 'format_comment' do
+          avatar_image(user, size: 30) +
+          content_tag(:strong, user.email)
+        end
+      else
+        mention
       end
-    end.html_safe
+    end.html
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <div class="content">
-      <%= simple_format(comment.content) %>
+      <%= format_comment(comment.content) %>
     </div>
 
     <% if can? :update, comment %>


### PR DESCRIPTION
When comments have mentions, we are just displaying the Email in the rendered comment, like: `@user@example.com`.

This PR tries to enhance that rendering.

With a view helper, when we are rendering a comment and detect a mention, we search for the user an instead of rendering the string above, we render some improved version of it using the user info (avatar, name with styles, etc...)

<img width="748" alt="improved_mentions_ce" src="https://user-images.githubusercontent.com/85766/47013934-b172c100-d140-11e8-8cb7-2d96428ab764.png">
 