### PR TITLE
Fix NotificationsReader

### DIFF
--- a/app/assets/javascripts/cable/subscriptions/notifications_channel.js.coffee
+++ b/app/assets/javascripts/cable/subscriptions/notifications_channel.js.coffee
@@ -10,4 +10,7 @@ App.cable.subscriptions.create 'NotificationsChannel',
     $(document).off('.notifications')
 
   received: (data)->
-    $('[data-behavior~=notifications-dot]').removeClass('hidden')
+    if data == 'all_read'
+      $('[data-behavior~=notifications-dot]').addClass('hidden')
+    else
+      $('[data-behavior~=notifications-dot]').removeClass('hidden')

--- a/app/controllers/concerns/notifications_reader.rb
+++ b/app/controllers/concerns/notifications_reader.rb
@@ -9,7 +9,7 @@ module NotificationsReader
 
   def read_item_notifications
     commentable = instance_variable_get("@#{controller_name.singularize}")
-    NotificationsReaderJob.perform_now(
+    NotificationsReaderJob.perform_later(
       commentable_id: commentable.id,
       commentable_type: commentable.class.to_s,
       user_id: current_user.id

--- a/app/controllers/concerns/notifications_reader.rb
+++ b/app/controllers/concerns/notifications_reader.rb
@@ -9,7 +9,7 @@ module NotificationsReader
 
   def read_item_notifications
     commentable = instance_variable_get("@#{controller_name.singularize}")
-    NotificationsReaderJob.perform_later(
+    NotificationsReaderJob.perform_now(
       commentable_id: commentable.id,
       commentable_type: commentable.class.to_s,
       user_id: current_user.id

--- a/app/jobs/notifications_reader_job.rb
+++ b/app/jobs/notifications_reader_job.rb
@@ -8,6 +8,10 @@ class NotificationsReaderJob < ApplicationJob
         unread.
         where(recipient_id: user_id).
         mark_all_as_read!
+
+      if Notification.unread.where(recipient_id: user_id).count == 0
+        NotificationsChannel.broadcast_to(User.find(user_id), 'all_read')
+      end
     end
   end
 


### PR DESCRIPTION
### Spec
When we get a notification and we visit it clicking the notifications dropdown link, the notification is marked read, but the red dot alert stays, until we reload the page again.
￼
![red_dot_stays](https://user-images.githubusercontent.com/85766/47228282-bcd22080-d3bc-11e8-8862-eaa49928e4c8.gif)


### Proposed solution
`NotificationsReader` conocern cannot run in the bg.
If we visit the notified resource, we mark it read at visit time, not later.

### How to test
  Even if this is a CE PR, but can only be seen when changing the bg queue to use redis.
  So change it or use a Pro instance if available.
  Then:
  - create a an issue with user A
  - visit the "All issues" the with user A
  - with user B comment on that issue
  - assert that user A get the red dot on the top bell wo/ doing anything
  - visit the issue with user A, assert the red dot disappears