### PR TITLE
Commentable path

### DIFF
--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -13,4 +13,8 @@ module Commentable
       )
     )
   end
+
+  def path
+    [project, self]
+  end
 end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -10,6 +10,7 @@ class Evidence < ApplicationRecord
   belongs_to :node, touch: true
   has_many :activities, as: :trackable
 
+  delegate :project, :project=, to: :node
 
   # -- Callbacks ------------------------------------------------------------
 
@@ -34,4 +35,7 @@ class Evidence < ApplicationRecord
     }
   end
 
+  def path
+    [project, node, self]
+  end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -138,4 +138,10 @@ class Issue < Note
     merged
   end
 
+  # FIXME - ISSUE/NOTE INHERITANCE
+  # `Issue` should not need to overwrite the `Commentable` concern `path` method
+  # if not inheriting from `Note`, that overwrites it
+  def path
+    [project, self]
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -59,4 +59,8 @@ class Note < ApplicationRecord
   def field_or_text(field_name)
     fields.fetch(field_name, text.truncate(20))
   end
+
+  def path
+    [project, node, self]
+  end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -5,26 +5,6 @@ class ActivityPresenter < BasePresenter
     h.link_to(avatar_image(size), 'javascript:void(0)')
   end
 
-  def comment_path(anchor: false)
-    # FIXME - ISSUE/NOTE INHERITANCE
-    # Would like to use only `commentable.respond_to?(:node)` here, but
-    # that would return a wrong path for issues
-    comment         = activity.trackable
-    commentable     = comment.commentable
-    path_to_comment =
-      if commentable.respond_to?(:node) && !commentable.is_a?(Issue)
-        [current_project, commentable.node, commentable]
-      else
-        [current_project, commentable]
-      end
-
-    anchor = dom_id(comment) if anchor
-    polymorphic_path(
-      path_to_comment,
-      anchor: anchor
-    )
-  end
-
   def created_at_ago
     h.local_time_ago(activity.created_at)
   end

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -5,26 +5,6 @@ class NotificationPresenter < BasePresenter
     h.link_to(avatar_image(size), 'javascript:void(0)')
   end
 
-  def comment_path(anchor: false)
-    # FIXME - ISSUE/NOTE INHERITANCE
-    # Would like to use only `commentable.respond_to?(:node)` here, but
-    # that would return a wrong path for issues
-    comment         = notification.notifiable
-    commentable     = comment.commentable
-    path_to_comment =
-      if commentable.respond_to?(:node) && !commentable.is_a?(Issue)
-        [current_project, commentable.node, commentable]
-      else
-        [current_project, commentable]
-      end
-
-    anchor = dom_id(comment) if anchor
-    polymorphic_path(
-      path_to_comment,
-      anchor: anchor
-    )
-  end
-
   def created_at_ago
     h.local_time_ago(notification.created_at)
   end

--- a/app/views/activities/_comment.html.erb
+++ b/app/views/activities/_comment.html.erb
@@ -1,9 +1,10 @@
 <% if comment %>
-  <% title = "#{comment.commentable.class.to_s.capitalize} ##{comment.commentable.id}" %>
-  <% if comment.commentable.title? %>
-    <% title = comment.commentable.title %>
-  <% end %>
-  <%= presenter.verb %> a <%= link_to 'comment', presenter.comment_path(anchor: dom_id(comment)) %> on <%= link_to title, presenter.comment_path %>.
+  <%
+    commentable = comment.commentable
+    title = "#{commentable.class.to_s.capitalize} ##{commentable.id}"
+    title = commentable.title if commentable.title?
+  %>
+  <%= presenter.verb %> a <%= link_to 'comment', polymorphic_path(commentable.path, anchor: dom_id(comment)) %> on <%= link_to title, polymorphic_path(commentable.path) %>.
 <% else %>
   <% if activity.action == 'destroy' %>
     deleted a comment.

--- a/app/views/notifications/_comment.html.erb
+++ b/app/views/notifications/_comment.html.erb
@@ -1,9 +1,9 @@
 <% commentable = comment.commentable %>
 <% if commentable.title? %>
   commented on the
-  <%= link_to commentable.title, presenter.comment_path(anchor: true) %>
+  <%= link_to commentable.title, polymorphic_path(commentable.path, anchor: dom_id(comment)) %>
   <%= comment.commentable_type %>
 <% else %>
   commented on
-  <%= link_to "#{comment.commentable_type} ##{commentable.id}", presenter.comment_path(anchor: true) %>.
+  <%= link_to "#{comment.commentable_type} ##{commentable.id}", polymorphic_path(commentable.path, anchor: dom_id(comment)) %>.
 <% end %>

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -17,7 +17,7 @@ module Dradis::CE::API
         @comment.user = current_user
         if @comment.save
           track_created(@comment)
-          render status: 201, location: main_app.polymorphic_path(@commentable.path, anchor: dom_id(@comment))
+          render status: 201, location: polymorphic_url(@commentable.path.drop(1).append(@comment))
         else
           render_validation_errors(@comment)
         end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/comments_controller.rb
@@ -1,6 +1,8 @@
 module Dradis::CE::API
   module V1
     class CommentsController < Dradis::CE::API::V1::ProjectScopedController
+      include ActionView::RecordIdentifier
+
       before_action :set_comment, only: [:show, :update, :destroy]
       before_action :set_commentable, only: [:index, :create]
 
@@ -15,7 +17,7 @@ module Dradis::CE::API
         @comment.user = current_user
         if @comment.save
           track_created(@comment)
-          render status: 201, location: @commentable
+          render status: 201, location: main_app.polymorphic_path(@commentable.path, anchor: dom_id(@comment))
         else
           render_validation_errors(@comment)
         end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/comments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/comments_spec.rb
@@ -129,7 +129,7 @@ describe 'Comments API' do
               expect(retrieved_comment[attr.to_s]).to eq value
             end
             expect(response.location).to eq(
-              dradis_api.issue_url(issue.id)
+              dradis_api.issue_comment_url(issue, retrieved_comment['id'])
             )
           end
         end


### PR DESCRIPTION
We noticed during the API implementation, that we may need to know the full url for a comment not only in our views.

Before we had an ugly method under our activity/notification presenter to handle that.

In this PR those methods are removed.

The `Commentable` model concern introduces a default `path` method that returns an array with the nested resources needed to build the url for that commentable.

Every commentable model may or not overwrite that default method.

The PR points to the API branch to keep the context of the discussion.