### PR TITLE
Use dynamic attribute in factories instead of static

### DIFF
--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :activity, aliases: [:create_activity] do
-    action 'create'
+    action { 'create' }
     sequence(:user) { |n| "rspec-user-#{n}" }
     trackable { |activity| activity.association :node }
 
     factory :update_activity do
-      action 'update'
+      action { 'update' }
     end
 
     factory :delete_activity do
-      action 'destroy'
+      action { 'destroy' }
     end
   end
 end

--- a/spec/factories/configurations.rb
+++ b/spec/factories/configurations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :configuration do
     sequence(:name) { |n| "configuration#{n}" }
-    value "Factory-generated value"
+    value { "Factory-generated value" }
   end
 end

--- a/spec/factories/evidence.rb
+++ b/spec/factories/evidence.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :evidence do
-    content "#[EvidenceBlock1]#\nThis particular instance is terrible!\n\n"
-    author "factory_bot"
+    content { "#[EvidenceBlock1]#\nThis particular instance is terrible!\n\n" }
+    author { "factory_bot" }
     association :issue
     association :node
   end

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :issue do
     sequence(:text){ |n| "#[Title]#\nRspec multiple Apache bugs #{n}\n\n#[Description]#\nFoo" }
-    author "factory_bot"
+    author { "factory_bot" }
     category { Category.issue }
     node { Project.new.issue_library }
   end

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :node do
-    label "Node-#{Time.now.to_i}"
-    parent_id nil
+    label { "Node-#{Time.now.to_i}" }
+    parent_id { nil }
 
     trait :with_project do
     end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :note do
-    text "Note text at #{Time.now}"
-    author "factory-girl"
+    text { "Note text at #{Time.now}" }
+    author { "factory-girl" }
     association :category
     association :node
   end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     notifiable { |notification| notification.association :issue }
     association :actor, factory: :user
     association :recipient, factory: :user
-    action :create
+    action { :create }
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     skip_create
 
     transient do
-      id 1
+      id { 1 }
     end
   end
 end


### PR DESCRIPTION
Fix deprecation warning on factory bot
```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

field { "my_field" }
```

More info: https://robots.thoughtbot.com/deprecating-static-attributes-in-factory_bot-4-11