### PR TITLE
Fix comments form cache

### DIFF
--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -20,7 +20,7 @@
 
 
 <div class="tab-content">
-  <% cache ['evidence-evidence-tab', @evidence, @evidence.comments, @evidence.subscriptions, current_user] do %>
+  <% cache ['evidence-evidence-tab', @evidence, @evidence.comments, @evidence.subscriptions, session.id] do %>
     <div class="tab-pane active" id="evidence-tab">
       <div class="inner note-text-inner">
         <h3>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -66,7 +66,7 @@
     #   - @nodes_for_add_evidence - to make sure the Add Evidence form is
     #                               refreshed when the list of node changes.
     # %>
-  <% cache ['issue-evidence-tab', @issue, @issue.evidence, @nodes_for_add_evidence] do %>
+  <% cache ['issue-evidence-tab', @issue, @issue.evidence, @nodes_for_add_evidence, session.id] do %>
     <div class="tab-pane" id="evidence-tab">
       <div class="inner">
         <%= render partial: 'evidence' %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -25,7 +25,7 @@
 </ul>
 
 <div class="tab-content">
-  <% cache ['issue-information-tab', @issue, @issue.comments, @issue.subscriptions, current_user] do %>
+  <% cache ['issue-information-tab', @issue, @issue.comments, @issue.subscriptions, session.id] do %>
     <div class="tab-pane active" id="info-tab">
       <div class="inner note-text-inner">
         <h3>Issue information -

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -11,7 +11,7 @@
 
 
 <div class="tab-content">
-  <% cache ['note-information-tab', @note, @note.comments, @note.subscriptions, current_user] do %>
+  <% cache ['note-information-tab', @note, @note.comments, @note.subscriptions, session.id] do %>
     <div class="tab-pane active" id="info-tab">
       <div id="<%= dom_id(@note) %>" class="inner note-text-inner">
         <h3>Content for this note -


### PR DESCRIPTION
### Spec
We found a bug on the way we are using cache for comment forms.
We are caching the form, even the csrf token.
So if we logout and login again the token is the cached one and the form does not work.

This is fix tries to invalidate the cache by session.
This leaves us closer to where we were before (we were invalidating the cache for different users), may be a bit worse sine on a new session the cached pages will not be there.

The real fix here will probably be moving the comments create and edit forms to Ajax.

### How to test
- enable cache
- visit issues#show (so the page is cached)
- logout + login
- visit the same page
- try to comment and assert that it works
- try also with evidence#show and notes#show