### PR TITLE
Use Ajax in comments

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/comments.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/comments.js.coffee
@@ -1,18 +1,12 @@
 document.addEventListener "turbolinks:load", ->
 
-  # hide/show comment editable textarea
-  $("[data-toggle-comment]").click ->
+  # hide comment editable textarea when clicking cancel
+  $('.comment').on('click', "[data-behavior~=cancel-comment]", ->
     element = $(this)
     comment = element.closest(".comment")
-    content = comment.find(".content")
-    update  = comment.find(".edit_comment")
-    value   = element.data('toggle-comment')
-    if value == "on"
-      content.hide()
-      update.show()
-    else if value == "off"
-      content.show()
-      update.hide()
+    comment.find(".content").show()
+    comment.find("form").hide()
+  )
 
   if $('[data-behavior~=mentionable]').length
     # initialize mentions (https://github.com/zurb/tribute)

--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -38,10 +38,6 @@
         visibility: visible;
       }
     }
-
-    form.edit_comment {
-      display: none;
-    }
   }
 }
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,4 @@
 class CommentsController < AuthenticatedController
-  include ActionView::RecordIdentifier
   include ActivityTracking
   include ProjectScoped
 
@@ -11,37 +10,23 @@ class CommentsController < AuthenticatedController
     if @comment.save
       track_created(@comment)
     end
-
-    redirect_to_comment(@comment)
   end
 
   def update
     if @comment.update_attributes(comment_params)
       track_updated(@comment)
     end
-
-    redirect_to_comment(@comment)
   end
 
   def destroy
     if @comment.destroy
       track_destroyed(@comment)
     end
-
-    redirect_to_comment(@comment)
   end
 
   private
 
   def comment_params
     params.require(:comment).permit(:content, :commentable_type, :commentable_id)
-  end
-
-  def redirect_to_comment(comment)
-    if comment.persisted? && !request.referrer.nil?
-      request.env['HTTP_REFERER'] += "##{dom_id(comment)}"
-    end
-
-    redirect_back fallback_location: project_path(current_project)
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -15,13 +15,13 @@
 
       <% if can? :update, comment %>
         <div class="actions">
-          <%= link_to 'javascript:void(0)',
-                      data: {toggle_comment: "on"} do %>
+          <%= link_to edit_project_comment_path(current_project, comment), remote: true do %>
             <i class="fa fa-pencil"></i> Edit
           <% end %>
           <%= link_to [current_project, comment],
                       method: :delete,
                       data: { confirm: 'Are you sure?' },
+                      remote: true,
                       class: 'text-error' do %>
             <i class="fa fa-trash"></i> Delete
           <% end %>
@@ -32,9 +32,5 @@
     <div class="content">
       <%= simple_format(h(comment.content)) %>
     </div>
-
-    <% if can? :update, comment %>
-      <%= render 'comments/edit', comment: comment %>
-    <% end %>
   </div>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_for [current_project, comment] do |f| %>
+<%= form_with model: [current_project, @comment] do |f| %>
   <%= f.text_area :content,
-                  value: comment.content,
+                  value: @comment.content,
                   rows: 5,
                   required: 'required',
                   data: { behavior: 'mentionable' } %>
@@ -8,5 +8,5 @@
   <%= link_to 'Cancel',
               'javascript:void(0)',
               class: 'cancel-link',
-              data: {toggle_comment: "off"} %>
+              data: {behavior: "cancel-comment"} %>
 <% end %>

--- a/app/views/comments/_new.html.erb
+++ b/app/views/comments/_new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [current_project, Comment.new(commentable: commentable)] do |f| %>
+<%= form_with model: [current_project, Comment.new(commentable: commentable)], data: { behavior: 'add-comment'} do |f| %>
   <%= f.label "Add a comment" %>
   <%= avatar_image(current_user, size: 30) %>
   <%= f.text_area :content,

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,0 +1,4 @@
+$(".comment-list").append("<%= j render(@comment) %>")
+$('[data-behavior~=add-comment] textarea').val('')
+var submit = $('[data-behavior~=add-comment] input[type=submit]')
+submit.attr('disabled', false).val(submit.data('disable-with'))

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -1,0 +1,4 @@
+$("#<%= dom_id(@comment) %>").remove()
+<% if @comment.commentable.comments.empty? %>
+  $('[data-notice~=no-comments]').show()
+<% end %>

--- a/app/views/comments/edit.js.erb
+++ b/app/views/comments/edit.js.erb
@@ -1,0 +1,4 @@
+<% if can? :update, @comment %>
+  $('#<%= dom_id(@comment) %> .content').hide();
+  $('#<%= dom_id(@comment) %> .body').append("<%= j render 'form' %>");
+<% end %>

--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,0 +1,3 @@
+$('#<%= dom_id(@comment) %> form').hide();
+$('#<%= dom_id(@comment) %> .content').html("<%= simple_format(h(@comment.content)) %>");
+$('#<%= dom_id(@comment) %> .content').show();


### PR DESCRIPTION
### Spec

We are using cache in our comments feed.
But as comments are implemented now, this means that we may be caching the comments edit and create forms we we are not very careful with cache keys: https://github.com/dradis/dradis-ce/pull/397 
In this PR we intend to remove forms from any cache fragment rendering them via ajax.

For consistency we are moving all comment CRUD actions to Ajax 

### How to test
Add, Edit and Delete one ore more comments.
Assert everything keeps working.