### PR TITLE
Scope h4 margin to main-content only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v3.12 (XXX)
+ - Fixed nodes sidebar header margin
+
 v3.11 (November 2018)
  - Added comments, subscriptions and notifications to notes
  - Added comments, subscriptions and notifications to evidence

--- a/app/assets/stylesheets/snowcrash/modules/nodes.scss
+++ b/app/assets/stylesheets/snowcrash/modules/nodes.scss
@@ -16,7 +16,7 @@ body.nodes {
     }
   }
   &.show {
-    h4 { margin-top: 30px; }
+    .main-content h4 { margin-top: 30px; }
     #scripts-tabs .tab-pane {
       padding-left: 2em;
     }


### PR DESCRIPTION
The Nodes header in the sidebar is misaligned:
![screen shot 2018-11-15 at 8 35 39 pm](https://user-images.githubusercontent.com/1908272/48553273-1410d580-e916-11e8-8f88-0bb8e25f91c5.png)

This PR scopes the `h4` margin, which is used in the node properties body for the headers, to `main-content`.