### PR TITLE
Add paper trail whodunnit hooks to api controller

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v3.12 (XXX)
  - Fixed nodes sidebar header margin
  - Added bold font to improve bold text visibility
+ - Added revision history user for API actions
 
 v3.11 (November 2018)
  - Added comments, subscriptions and notifications to notes

--- a/engines/dradis-api/app/controllers/dradis/ce/api/api_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/api_controller.rb
@@ -5,6 +5,8 @@ module Dradis::CE::API
     before_action :api_authentication_required
     before_action :json_required, only: [:create, :update]
 
+    before_action :set_paper_trail_whodunnit
+
     rescue_from ActionController::ParameterMissing do |exception|
       # after_action is not called for exceptions
       skip_set_cookies_header
@@ -19,6 +21,12 @@ module Dradis::CE::API
 
     # No CSRF protection for the wicked!
     protect_from_forgery with: :null_session
+
+    # Set 'whodunnit' in paper trail versions to be the email address of the
+    # current user
+    def user_for_paper_trail
+      current_user.email if current_user
+    end
 
     protected
     # def ssl_configured?


### PR DESCRIPTION
GH Issue: #376 

### Spec
Currently, revision "By" attribute is not being set when using the API.

**Proposed Solution**
Add Paper Trail callback to the api controller

### How to test:

1. Add an issue using the API
2. Update the issue using the API
3. Visit the issue's revision history in the web UI
4. Assert that the "By" column is populated.