### PR TITLE
Fix issue evidence tab cache

### DIFF
--- a/app/views/issues/_add_evidence.html.erb
+++ b/app/views/issues/_add_evidence.html.erb
@@ -4,7 +4,8 @@
     url: project_create_multiple_evidence_path(current_project),
     html: { id: 'add-evidences' }
   ) do |f| %>
-    <% cache [@issue, @nodes_for_add_evidence, NoteTemplate.all] do %>
+    <% note_templates = NoteTemplate.all %>
+    <% cache [@issue, @nodes_for_add_evidence, note_templates: note_templates ] do %>
       <div class="form-inputs">
         <%= f.hidden_field :issue_id, value: @issue.id %>
         <%= f.hidden_field :node_id %>
@@ -13,7 +14,7 @@
           <div class="span4">
             <%= f.label :new_evidence_content %>
             <%= f.collection_select :content,
-             NoteTemplate.all,
+             note_templates,
              :content,
              :name,
              include_blank: 'Empty (no template)'

--- a/app/views/issues/_add_evidence.html.erb
+++ b/app/views/issues/_add_evidence.html.erb
@@ -4,56 +4,57 @@
     url: project_create_multiple_evidence_path(current_project),
     html: { id: 'add-evidences' }
   ) do |f| %>
-    <div class="form-inputs">
-      <%= f.hidden_field :issue_id, value: @issue.id %>
-      <%= f.hidden_field :node_id %>
+    <% cache [@issue, @nodes_for_add_evidence, NoteTemplate.all] do %>
+      <div class="form-inputs">
+        <%= f.hidden_field :issue_id, value: @issue.id %>
+        <%= f.hidden_field :node_id %>
 
-      <!-- <div class="clearfix"></div> -->
-      <div class="row-fluid">
-        <div class="span4">
-          <%= f.label :new_evidence_content %>
-          <%= f.collection_select :content,
-           NoteTemplate.all,
-           :content,
-           :name,
-           include_blank: 'Empty (no template)'
-          %>
-          <pre id="template-content"></pre>
-        </div>
-        <div class="span4">
-          <%= f.label 'Add to existing nodes', for: :evidence_node %>
-          <%= f.text_field :node, placeholder: 'Type here to filter list...' %>
-
-          <div id="existing-node-list">
-            <%= f.collection_check_boxes(:node_ids, @nodes_for_add_evidence, :id, :label) do |b|
-              b.label(class: "checkbox") { b.check_box + b.text}
-            end %>
+        <div class="row-fluid">
+          <div class="span4">
+            <%= f.label :new_evidence_content %>
+            <%= f.collection_select :content,
+             NoteTemplate.all,
+             :content,
+             :name,
+             include_blank: 'Empty (no template)'
+            %>
+            <pre id="template-content"></pre>
           </div>
-        </div>
-        <div class="span4">
-          <label for="evidence_node_list">Paste list of nodes
-            <i
-              class="fa fa-question-circle"
-              data-toggle="tooltip"
-              data-html="true"
-              title="<ul><li>If a node from the list already exist in the project evidence will be added to it.</li><li>If a node doesn't exist it will be created and then evidence will be added.</li></ul>"></i>
-          </label>
-          <%= f.text_area :node_list, rows: 10, placeholder: 'One node per line.' %>
+          <div class="span4">
+            <%= f.label 'Add to existing nodes', for: :evidence_node %>
+            <%= f.text_field :node, placeholder: 'Type here to filter list...' %>
 
-          <%= f.label 'Create new nodes under', for: :evidence_node_list_parent_id %>
-          <%= f.collection_select(
-            :node_list_parent_id,
-            @nodes_for_add_evidence,
-            :id,
-            :label,
-            include_blank: "The root of the tree"
-          ) %>
+            <div id="existing-node-list">
+              <%= f.collection_check_boxes(:node_ids, @nodes_for_add_evidence, :id, :label) do |b|
+                b.label(class: "checkbox") { b.check_box + b.text}
+              end %>
+            </div>
+          </div>
+          <div class="span4">
+            <label for="evidence_node_list">Paste list of nodes
+              <i
+                class="fa fa-question-circle"
+                data-toggle="tooltip"
+                data-html="true"
+                title="<ul><li>If a node from the list already exist in the project evidence will be added to it.</li><li>If a node doesn't exist it will be created and then evidence will be added.</li></ul>"></i>
+            </label>
+            <%= f.text_area :node_list, rows: 10, placeholder: 'One node per line.' %>
+
+            <%= f.label 'Create new nodes under', for: :evidence_node_list_parent_id %>
+            <%= f.collection_select(
+              :node_list_parent_id,
+              @nodes_for_add_evidence,
+              :id,
+              :label,
+              include_blank: "The root of the tree"
+            ) %>
+          </div>
+          <div class="clearfix"></div>
         </div>
-        <div class="clearfix"></div>
       </div>
-    </div>
-    <div class="form-actions">
-      <%= f.submit class: 'btn btn-default btn btn-primary' %>
-    </div>
+      <div class="form-actions">
+        <%= f.submit class: 'btn btn-default btn btn-primary' %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/issues/_add_evidence.html.erb
+++ b/app/views/issues/_add_evidence.html.erb
@@ -4,8 +4,7 @@
     url: project_create_multiple_evidence_path(current_project),
     html: { id: 'add-evidences' }
   ) do |f| %>
-    <% note_templates = NoteTemplate.all %>
-    <% cache [@issue, @nodes_for_add_evidence, note_templates: note_templates ] do %>
+    <% cache [@issue, @nodes_for_add_evidence ] do %>
       <div class="form-inputs">
         <%= f.hidden_field :issue_id, value: @issue.id %>
         <%= f.hidden_field :node_id %>
@@ -14,7 +13,7 @@
           <div class="span4">
             <%= f.label :new_evidence_content %>
             <%= f.collection_select :content,
-             note_templates,
+             NoteTemplate.all,
              :content,
              :name,
              include_blank: 'Empty (no template)'

--- a/app/views/issues/_evidence.html.erb
+++ b/app/views/issues/_evidence.html.erb
@@ -1,37 +1,43 @@
 <h3>Evidence information - <span class="actions"><a href="javascript:void(0)" class="action-link js-add-evidence">Add new</a></span></h3>
-<% cache [@issue, @nodes_for_add_evidence, session.id] do %>
-  <%= render 'issues/add_evidence'%>
-<% end %>
+<%= render 'issues/add_evidence'%>
 
-<% if @issue.affected.empty? %>
-  <p>None so far.</p>
-<% else %>
-  <div class="tabbable tabs-left" id="evidence-tabs">
-    <ul class="nav nav-tabs" id="evidence-host-list">
-      <% @affected_nodes.each do |node| %>
-        <% cache [@issue, node, node.evidence_count, 'evidence-nav'] do %>
-          <li>
-            <a href="#evidence_for_<%= dom_id(node) %>" data-toggle="tab" data-path="<%= project_issue_node_path(current_project, @issue, node) %>" data-node="<%= "evidence_for_#{dom_id(node)}" %>">
-              <i class="fa fa-<%= ['folder-o','laptop'][node.type_id] %>"></i> <%= node.label %> (<%= node.evidence_count %>)
-            </a>
-          </li>
-        <% end %>
-      <% end %>
-    </ul>
-    <div class="tab-content">
-      <% @affected_nodes.each do |node| %>
-        <%= content_tag :div, class: 'tab-pane evidence-content', id: "evidence_for_#{dom_id(node)}" do %>
-          <% if node == @first_node %>
-            <%=
-              render partial: 'issues/nodes/evidence',
-                locals: {
-                  node: node,
-                  instances: @first_evidence
-                }
-            %>
+<%# We need:
+  #   - @issue                  - in case @issue.evidence is empty (there are
+  #                               two issues with empty evidence)
+  #   - @issue.evidence         - to make sure the tabs are updated with
+  #                               changes.
+  # %>
+<% cache ['issue-evidence-tab', @issue, @issue.evidence] do %>
+  <% if @issue.affected.empty? %>
+    <p>None so far.</p>
+  <% else %>
+    <div class="tabbable tabs-left" id="evidence-tabs">
+      <ul class="nav nav-tabs" id="evidence-host-list">
+        <% @affected_nodes.each do |node| %>
+          <% cache [@issue, node, node.evidence_count, 'evidence-nav'] do %>
+            <li>
+              <a href="#evidence_for_<%= dom_id(node) %>" data-toggle="tab" data-path="<%= project_issue_node_path(current_project, @issue, node) %>" data-node="<%= "evidence_for_#{dom_id(node)}" %>">
+                <i class="fa fa-<%= ['folder-o','laptop'][node.type_id] %>"></i> <%= node.label %> (<%= node.evidence_count %>)
+              </a>
+            </li>
           <% end %>
         <% end %>
-      <% end %>
+      </ul>
+      <div class="tab-content">
+        <% @affected_nodes.each do |node| %>
+          <%= content_tag :div, class: 'tab-pane evidence-content', id: "evidence_for_#{dom_id(node)}" do %>
+            <% if node == @first_node %>
+              <%=
+                render partial: 'issues/nodes/evidence',
+                  locals: {
+                    node: node,
+                    instances: @first_evidence
+                  }
+              %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -58,21 +58,11 @@
     </div>
   <% end %>
 
-  <%# We need:
-    #   - @issue                  - in case @issue.evidence is empty (there are
-    #                               two issues with empty evidence)
-    #   - @issue.evidence         - to make sure the tabs are updated with
-    #                               changes.
-    #   - @nodes_for_add_evidence - to make sure the Add Evidence form is
-    #                               refreshed when the list of node changes.
-    # %>
-  <% cache ['issue-evidence-tab', @issue, @issue.evidence, @nodes_for_add_evidence, session.id] do %>
-    <div class="tab-pane" id="evidence-tab">
-      <div class="inner">
-        <%= render partial: 'evidence' %>
-      </div>
+  <div class="tab-pane" id="evidence-tab">
+    <div class="inner">
+      <%= render partial: 'evidence' %>
     </div>
-  <% end %>
+  </div>
 
   <% cache ['issue-activity-tab', @issue, @activities] do %>
     <div class="tab-pane" id="activity-tab">


### PR DESCRIPTION
**NOTE: It seems like we are modifying a lot in this PR, but it is bc the indentation. Some  `<% cache %>` helpers have been edited and moved, and indentation has been changed too.**

## Spec
We are caching a form: the issues evidence tab add multiple evidence form.
This causes CSRF errors when logging out and logging in again.

## Proposed solution:
Just cache the parts of the form that can be cached

This should allow us to revert: https://github.com/dradis/dradis-ce/pull/398

## How to test

- Enable cache
- Visit an issue
- Using the evidence tab, add an evidence
- Log out
- Log in and visit the same issue
- Add another evidence using the evidence tab. No error should be raised.