### PR TITLE
When flash messages present, add turbolinks disable cache meta

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ v3.12 (XXX)
  - Fixed nodes sidebar header margin
  - Added bold font to improve bold text visibility
  - Fix links display in Textile fields
+ - Disable turbolinks cache when displaying flash messages
 
 v3.11 (November 2018)
  - Added comments, subscriptions and notifications to notes

--- a/app/views/layouts/snowcrash.html.erb
+++ b/app/views/layouts/snowcrash.html.erb
@@ -11,6 +11,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <% if flash.any? %>
+    <meta name="turbolinks-cache-control" content="no-cache">
+  <% end %>
 
   <%= favicon_link_tag %>
 

--- a/app/views/layouts/snowcrash.html.erb
+++ b/app/views/layouts/snowcrash.html.erb
@@ -12,6 +12,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <% if flash.any? %>
+    <% # when flash messages present, disable turbolinks cache to avoid
+       # the message appear and disappear in the next page load %>
     <meta name="turbolinks-cache-control" content="no-cache">
   <% end %>
   <%= render 'comments/mentionable_users' if @mentionable_users %>


### PR DESCRIPTION
Create 2 issues.
Update one of them, so the "Issue updated" message is displayed.
Click on the sidebar to go to the other issue.
Click on the sidebar to visit the first issue again. Note that the "Issue updated" message is displayed for a second, then disappears when the page is really loaded.

This is due to the turbo links cache: https://github.com/turbolinks/turbolinks#understanding-caching

And the proposed solution consists on adding a `meta` when flash objects are present.



