### PR TITLE
Add sort to attachments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ v3.12 (XXX)
  - Fixed nodes sidebar header margin
  - Added bold font to improve bold text visibility
  - Fix links display in Textile fields
+ - Sort attachments in alphabetical ASCII order
 
 v3.11 (November 2018)
  - Added comments, subscriptions and notifications to notes

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -94,7 +94,7 @@ class Attachment < File
         node_id = options[:conditions][:node_id].to_s
         raise "Node with ID=#{node_id} does not exist" unless Node.exists?(node_id)
         if (File.exist?( File.join(pwd, node_id)))
-          node_dir = Dir.new(pwd.join(node_id))
+          node_dir = Dir.new(pwd.join(node_id)).sort
           node_dir.each do |attachment|
             next unless (attachment =~ /^(.+)$/) == 0 && !File.directory?(pwd.join(node_id, attachment))
             attachments << Attachment.new(:filename => $1, :node_id => node_id.to_i)
@@ -103,7 +103,7 @@ class Attachment < File
       else
         dir.each do |node|
           next unless node =~ /^\d*$/
-          node_dir = Dir.new(pwd.join(node))
+          node_dir = Dir.new(pwd.join(node)).sort
           node_dir.each do |attachment|
             next unless (attachment =~ /^(.+)$/) == 0 && !File.directory?(pwd.join(node, attachment))
             attachments << Attachment.new(:filename => $1, :node_id => node.to_i)
@@ -128,7 +128,7 @@ class Attachment < File
       raise "You need to supply a node id in the condition parameter" unless options[:conditions] && options[:conditions][:node_id]
       node_id = options[:conditions][:node_id].to_s
       raise "Node with ID=#{node_id} does not exist" unless Node.exists?(node_id)
-      node_dir = Dir.new(pwd.join(node_id))
+      node_dir = Dir.new(pwd.join(node_id)).sort
       node_dir.each do |attachment|
         next unless ((attachment =~ /^(.+)$/) == 0 && $1 == filename)
         attachments << Attachment.new(:filename => $1, :node_id => node_id.to_i)


### PR DESCRIPTION
### Spec
Currently, attachments are ordered arbitrarily in the attachments list in the nodes view.

**Proposed solution**
Use the `sort` method to sort the attachments.

### How to test

1. Visit a node
2. Upload a number of attachments
3. Assert that they are sorted alphabetically