### PR TITLE
Extract default tag list to a constant

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -7,6 +7,14 @@
 #   * If they start with ! they define their own colour (e.g. !red needs to be coloured red, !4444dd should be a dark shade of blue).
 #     - We require a 6-digit hex code (no 3-digit shortcut)
 class Tag < ApplicationRecord
+  DEFAULT_TAGS = %w[
+    !9467bd_critical
+    !d62728_high
+    !ff7f0e_medium
+    !6baed6_low
+    !2ca02c_info
+  ].freeze
+  
   # -- Relationships ----------------------------------------------------------
   has_many :taggings, dependent: :destroy
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -14,7 +14,7 @@ class Tag < ApplicationRecord
     !6baed6_low
     !2ca02c_info
   ].freeze
-  
+
   # -- Relationships ----------------------------------------------------------
   has_many :taggings, dependent: :destroy
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,4 @@
 # Create a few default tags.
-[
-  '!9467bd_critical',
-  '!d62728_high',
-  '!ff7f0e_medium',
-  '!6baed6_low',
-  '!2ca02c_info',
-].each do |name|
+Tag::DEFAULT_TAGS.each do |name|
   Tag.create!(name: name)
 end


### PR DESCRIPTION
We may need to get the list of default tags in different places.
In this PR we extract that list to a unique list, and force using that list elsewhere.