### PR TITLE
Move Import Issues to the top of the issues sidebar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v3.12 (XXX)
  - Added bold font to improve bold text visibility
  - Fix links display in Textile fields
  - Sort attachments in alphabetical ASCII order
+ - Move Import Issues box above issues list
 
 v3.11 (November 2018)
  - Added comments, subscriptions and notifications to notes

--- a/app/views/issues/_sidebar.html.erb
+++ b/app/views/issues/_sidebar.html.erb
@@ -9,10 +9,11 @@
   <% end %>
 </div>
 
+<%= render 'import_box' %>
+
 <%= render 'shared/sidebar_collection',
   name: 'Issues',
   collection: @issues,
   new_path: new_project_issue_path(current_project),
   category_id: nil
 %>
-<%= render 'import_box' %>


### PR DESCRIPTION
### Summary
Currently, if there is a long list of Issues, you have to scroll all the way to the bottom of the page to access the "Import Issues" section: 
<img width="290" alt="screen shot 2019-01-03 at 11 44 26 am" src="https://user-images.githubusercontent.com/11186655/50652779-2ccc5d80-0f4d-11e9-8c6d-6223b7ca4e67.png">

This PR moves "Import Issues" above the list of Issues for quick and easy access, even in large projects: 
<img width="289" alt="screen shot 2019-01-03 at 11 45 24 am" src="https://user-images.githubusercontent.com/11186655/50652799-3d7cd380-0f4d-11e9-9df3-969e36cd3e9f.png">

Should this be a CE change instead or also? The files are similar: https://github.com/dradis/dradis-ce/blob/513fbcb3bfa352d7fc0ee521bc44421688d1432b/app/views/issues/_sidebar.html.erb#L18

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.