### PR TITLE
Use explicit arguments for link helper + mini fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v3.12 (XXX)
  - Added bold font to improve bold text visibility
  - Fix links display in Textile fields
  - Sort attachments in alphabetical ASCII order
+ - Fix methodology checklist edit error
 
 v3.11 (November 2018)
  - Added comments, subscriptions and notifications to notes

--- a/app/views/methodologies/edit.html.erb
+++ b/app/views/methodologies/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row-fluid">
   <div class="span6">
-    <%= simple_form_for [current_project, @methodology], { url: project_methodology_path(current_project, @methodology), method: :put, html: { class: 'form-vertical' } } do |f| %>
+    <%= simple_form_for [current_project, @methodology], { url: project_methodology_path(project_id: current_project.id, methodology_id: @methodology.id), method: :put, html: { class: 'form-vertical' } } do |f| %>
       <%= f.error_notification %>
 
       <%= f.input :content, as: :text, input_html: { data: { preview: preview_project_methodologies_path(current_project) }, rows: 30, style: 'width:100%' } %>
@@ -22,7 +22,7 @@
     <div class="inner">
       <h2 id="preview_name"><%= @methodology.name %></h2>
       <div id="preview_content" class="well">
-        <%= parse_project_methodology_content(current_project, @methodology) %>
+        <%= parse_methodology_content(@methodology) %>
       </div>
     </div>
   </div>

--- a/app/views/methodologies/index.html.erb
+++ b/app/views/methodologies/index.html.erb
@@ -18,7 +18,7 @@
           <ul class="dropdown-menu">
             <% if @methodology_templates.any? %>
               <% for methodology in @methodology_templates do %>
-              <li><%= link_to methodology.name, add_project_methodology_path(current_project, methodology) %></li>
+              <li><%= link_to methodology.filename, add_project_methodology_path(current_project, methodology) %></li>
               <% end %>
             <% else %>
             <li class="disabled"><a href="javascript:void(0)">(no methodology templates defined)</a></li>

--- a/app/views/methodologies/index.html.erb
+++ b/app/views/methodologies/index.html.erb
@@ -18,7 +18,7 @@
           <ul class="dropdown-menu">
             <% if @methodology_templates.any? %>
               <% for methodology in @methodology_templates do %>
-              <li><%= link_to methodology.filename, add_project_methodology_path(current_project, methodology) %></li>
+              <li><%= link_to methodology.name, add_project_methodology_path(current_project, methodology) %></li>
               <% end %>
             <% else %>
             <li class="disabled"><a href="javascript:void(0)">(no methodology templates defined)</a></li>


### PR DESCRIPTION
Fixes: #409 

`project_methodology_path(current_project, @methodology)` is throwing an error as it cannot process the non-standard methodology object. We use explicit arguments for the helper method.

### How to test:
1. Create a methodology
2. Edit a checklist
3. Assert that you can successfully update the checklist