### PR TITLE
Add project_id parameter in upload job

### DIFF
--- a/app/jobs/upload_job.rb
+++ b/app/jobs/upload_job.rb
@@ -1,7 +1,7 @@
 class UploadJob < ApplicationJob
   queue_as :dradis_upload
 
-  def perform(default_user_id:, file:, plugin_name:, uid:)
+  def perform(default_user_id:, file:, plugin_name:, project_id:, uid:)
     logger = Log.new(uid: uid)
 
     logger.write { "Job id is #{job_id}." }
@@ -13,7 +13,8 @@ class UploadJob < ApplicationJob
     importer = plugin::Importer.new(
       default_user_id: default_user_id,
       logger: logger,
-      plugin: plugin
+      plugin: plugin,
+      project_id: project_id
     )
 
     importer.import(file: file)


### PR DESCRIPTION
Fixes: #418 

### Spec
The `UploadJob` is missing the `project_id` parameter and it's throwing the `unknown keyword: project_id` error. This PR resolves the issue.

### How to test:

1. Run the app in production or uncomment the if block [here](https://github.com/dradis/dradis-ce/blob/master/app/controllers/upload_controller.rb#L47) to force it to run the background job.
2. Upload a sample project to the app
3. Confirm that the upload was successful.
