### PR TITLE
Try to fix attachments spec

### DIFF
--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -42,18 +42,17 @@ describe "Attachments API" do
   context "as authenticated user" do
     include_context "authenticated API user"
 
-    def empty_attachments
-      node_attachments = Attachment.pwd.join(node.id.to_s)
-      until Dir["#{node_attachments}/*"].count == 0 do
-        FileUtils.rm_rf(Attachment.pwd.join(node.id.to_s))
+    before(:each) do
+      node_attachments_folder = Attachment.pwd.join(node.id.to_s)
+      until Dir["#{node_attachments_folder}/*"].count == 0 do
+        FileUtils.rm_rf(node_attachments_folder)
       end
     end
 
-    around do |example|
-      # assert the attachments folder is empty before and after each spec
-      empty_attachments
-      example.run
-      empty_attachments
+    after(:all) do
+      Dir["#{Attachment.pwd}/*"].each do |folder|
+        FileUtils.rm_rf(folder)
+      end
     end
 
     describe "GET /api/nodes/:node_id/attachments" do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -50,7 +50,7 @@ describe "Attachments API" do
     end
 
     around do |example|
-      # assert the atachments folder is empty before and after the spec
+      # assert the attachments folder is empty before and after each spec
       empty_attachments
       example.run
       empty_attachments

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -42,11 +42,18 @@ describe "Attachments API" do
   context "as authenticated user" do
     include_context "authenticated API user"
 
-    after do
+    def empty_attachments
       node_attachments = Attachment.pwd.join(node.id.to_s)
       until Dir["#{node_attachments}/*"].count == 0 do
         FileUtils.rm_rf(Attachment.pwd.join(node.id.to_s))
       end
+    end
+
+    around do |example|
+      # assert the atachments folder is empty before and after the spec
+      empty_attachments
+      example.run
+      empty_attachments
     end
 
     describe "GET /api/nodes/:node_id/attachments" do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -43,16 +43,11 @@ describe "Attachments API" do
     include_context "authenticated API user"
 
     before(:each) do
-      node_attachments_folder = Attachment.pwd.join(node.id.to_s)
-      until Dir["#{node_attachments_folder}/*"].count == 0 do
-        FileUtils.rm_rf(node_attachments_folder)
-      end
+      FileUtils.rm_rf Dir[Attachment.pwd.join('*')] until Dir[Attachment.pwd.join('*')].count == 0
     end
 
     after(:all) do
-      Dir["#{Attachment.pwd}/*"].each do |folder|
-        FileUtils.rm_rf(folder)
-      end
+      FileUtils.rm_rf Dir[Attachment.pwd.join('*')]
     end
 
     describe "GET /api/nodes/:node_id/attachments" do


### PR DESCRIPTION
There is a spec failing randomly:

```
Failures:

1) Attachments API as authenticated user POST /api/nodes/:node_id/attachments returns 422 when no file saved
Failure/Error: expect(File.exist?(Attachment.pwd.join(node.id.to_s))).to be false

  expected false
       got true
# ./engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb:147:in `block (4 levels) in <top (required)>'

Finished in 10 minutes 44 seconds (files took 9.18 seconds to load)
1610 examples, 1 failure, 72 pending

Failed examples:

rspec ./engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb:142 # Attachments API as authenticated user POST /api/nodes/:node_id/attachments returns 422 when no file saved
```

With this change we try to assert that every spec always find an empty attachments folder.