### PR TITLE
Use the direct link for the training page

### DIFF
--- a/app/views/layouts/snowcrash/_navbar.html.erb
+++ b/app/views/layouts/snowcrash/_navbar.html.erb
@@ -23,7 +23,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-question fa-lg"></i><b class="caret"></b></a>
             <ul class="dropdown-menu">
-              <li><a href="javascript:void(0)" class="js-try-pro" data-term="training-course" data-url="http://drad.is/l/try-pro-course">Free training course</a></li>
+              <li><a href="javascript:void(0)" class="js-try-pro" data-term="training-course" data-url="https://dradisframework.com/academy/dradis-course/?utm_source=ce&utm_medium=app&utm_campaign=try-pro&utm_term=training-course">Free training course</a></li>
               <li class="divider"></li>
               <li><a href="javascript:void(0)" class="js-try-pro" data-term="contact-support">Contact support</a></li>
               <li><a href="https://evening-hamlet-4416.herokuapp.com/" target="_blank">Chat on Slack</a></li>


### PR DESCRIPTION
Currently, the `Free training course` link is not working because of [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content) issues. To fix this, we use the direct link for the course which uses HTTPS.