### PR TITLE
Allows a the contents of a node to be merged with another

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -113,6 +113,16 @@ class NodesController < NestedNodeResourceController
     end
   end
 
+  def merge
+    @other_node = current_project.nodes.find(params[:merge_with_node_id])
+
+    if @node.merge_with!(@other_node)
+      redirect_to project_node_path(current_project, @node), notice: "Successfully merged with #{@other_node.label}"
+    else
+      redirect_to project_node_path(current_project, @node), alert: "Couldn't merge with #{@other_node.label}"
+    end
+  end
+
   private
   def node_params
     params.require(:node).permit(:label, :parent_id, :position, :raw_properties, :type_id)

--- a/app/views/layouts/snowcrash/_breadcrumb.html.erb
+++ b/app/views/layouts/snowcrash/_breadcrumb.html.erb
@@ -14,6 +14,7 @@
       <li><a href="#modal_delete_node" class="text-error" tabindex="-1" data-toggle="modal"><i class="fa fa-trash"></i> Delete</a></li>
       <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
       <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
+      <li><a href="#modal_merge_node" tabindex="-1" data-toggle="modal"><i class="fa fa-compress"></i> Merge</a></li>
     </ul>
   </div>
 </div>
@@ -23,6 +24,7 @@
 <%= render partial: 'nodes/modals/delete' %>
 <%= render partial: 'nodes/modals/rename' %>
 <%= render partial: 'nodes/modals/move' %>
+<%= render partial: 'nodes/modals/merge' %>
 <% end %>
 
 <% if content_for?(:breadcrums) %>

--- a/app/views/nodes/modals/_merge.html.erb
+++ b/app/views/nodes/modals/_merge.html.erb
@@ -1,0 +1,24 @@
+<div id="modal_merge_node" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <%= form_tag [:merge, current_project, @node], class: 'form-horizontal modal-node-selection-form', data: { node_id: @node.id, hidden_field: '#merge_with_node_id' } do %>
+    <%= hidden_field_tag :merge_with_node_id %>
+
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+      <h3 id="myModalLabel">Merge <%= @node.label %> node</h3>
+    </div>
+    <div class="modal-body">
+      <p>What do you want to merge into the <strong><%= @node.label %></strong> node?</p>
+
+      <div class="tree-modal-box">
+        <%= render "layouts/snowcrash/nodes" %>
+      </div>
+      <p id="move-under">
+        Merge with: <strong><span id="current-selection"></span></strong>
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary">Merge</button>
+      <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
 
       member do
         get :tree
+        post :merge
       end
 
       resources :notes, concerns: :multiple_destroy do

--- a/spec/features/node_merging_spec.rb
+++ b/spec/features/node_merging_spec.rb
@@ -16,13 +16,40 @@ describe "merging a node", js: true do
     click_link "Merge"
   end
 
-  example "merging with another node" do
-    within_merge_node_modal do
-      click_link @other_node.label
-      click_button "Merge"
+  example "Clicking merge opens the modal" do
+    expect(page).to have_selector('#modal_merge_node', visible: true)
+  end
+
+  describe "within the merge modal" do
+    it "starts with Merge button disabled" do
+      expect(page).to have_button('Merge', disabled: true)
     end
 
-    expect(current_path).to eq project_node_path(current_project, @node)
+    it "selecting a node makes the Merge button enabled" do
+      within_merge_node_modal do
+        click_link @other_node.label
+      end
+
+      expect(page).to have_button('Merge', disabled: false)
+    end
+
+    it "selecting a node fills in the current selection text" do
+      within_merge_node_modal do
+        click_link @other_node.label
+      end
+
+      expect(find('#current-selection')).to have_content(@other_node.label)
+    end
+
+    it "clicking Merge button performs a merge" do
+      within_merge_node_modal do
+        click_link @other_node.label
+        click_button "Merge"
+      end
+
+      expect(current_path).to eq project_node_path(current_project, @node)
+      expect(page).to have_content("Successfully merged with #{@other_node.label}")
+    end
   end
 
   def within_merge_node_modal

--- a/spec/features/node_merging_spec.rb
+++ b/spec/features/node_merging_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "merging a node", js: true do
+
+  subject { page }
+
+  before do
+    login_to_project_as_user
+
+    @node = create(:node, label: "Node", project: current_project)
+    @other_node = create(:node, label: "Other Node", project: current_project)
+  end
+
+  before do
+    visit project_node_path(@node.project, @node)
+    click_link "Merge"
+  end
+
+  example "merging with another node" do
+    within_merge_node_modal do
+      click_link @other_node.label
+      click_button "Merge"
+    end
+
+    expect(current_path).to eq project_node_path(current_project, @node)
+  end
+
+  def within_merge_node_modal
+    within("#modal_merge_node") { yield }
+  end
+
+  def click_node_toggle_button(node)
+    find("[data-node-id='#{node.id}']").click
+  end
+end


### PR DESCRIPTION
Adds a new button to the Node Show view that allows it to be merged with another node. This is particularly handy if you've accidentally started 2 nodes on the same topic and started to populate both.

To use, first create two nodes and populate them with some data. To perform the merge, navigate to the node that you wish to transfer data _into_. Click the "Merge" button in the at the top of the page. Select the other node you'd like to merge with and then click "Merge" in the dialog box.

The merge will transfer the following items from the selected node, and then delete the other node:
* Attachments
* Notes
* Activity
* Evidence

Pull request includes a feature test for the UI elements and a model test for testing `Node#merge_with!`

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.