### PR TITLE
Add start of line (^) modifier for bc.. terminals

### DIFF
--- a/lib/html/pipeline/dradis_escape_html_filter.rb
+++ b/lib/html/pipeline/dradis_escape_html_filter.rb
@@ -19,7 +19,7 @@ module HTML
         # Match the text under bc./bc.. and links, following the textile rules
         regex = Regexp.union(
           /(?<=bc\. )(.*?)(?=(\r\n|\n){2})/m,
-          /(?<=bc\.\. )(.*?)(?=(bc\.|bc\.\.|p\.|\z))/m,
+          /(?<=bc\.\. )(.*?)(?=(^bc\.|^bc\.\.|^p\.|\z))/m,
           /&quot;(.*?)&quot;:(?:http|https)\:\/\/.+/
         )
 


### PR DESCRIPTION
### Spec
The regex terminates the `bc..` block even if the new textile block elements are not in a newline.

### How to test:
1. Add an issue with the content:
```
#[Description]#
bc.. (C) Copyright 1985-2001 Microsoft Corp.    
D:\Program Files\microsoft_corp>
printf "Hello World"
```

2. Click on the preview tab.
3. Confirm that the characters are not escaped when displayed.