### PR TITLE
Try to fix issues_spec.rb (1 case)

### DIFF
--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -383,6 +383,7 @@ describe 'Issues pages' do
             fill_in 'Paste list of nodes', with: "#{@node.label}\r\naaaa"
             expect do
               click_button('Save Evidence')
+              expect(page).to have_text 'Evidence added for selected nodes.'
             end.to change { enqueued_activity_tracking_jobs.size }.by(3)
 
             jobs = enqueued_activity_tracking_jobs.last(3)


### PR DESCRIPTION
I noticed a random fail in our `issues_spec.rb` file.
The expected bg jobs had not been enqueued.
When tried to reproduce in CI with the same seed could not reproduce it.

But maybe if I force capybara to wait for the request answer before checking the queue this can be fixed.