### PR TITLE
Nodes#tree - sort in an IP-meaningful way

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -107,7 +107,7 @@ class NodesController < NestedNodeResourceController
   # Lazy-load the nodes' tree via Ajax calls to this action.
   def tree
     # TODO: Do we want to use :find_or_initialize_node or skip it and :include children?
-    @children = @node.children
+    @children = @node.children.to_a.sort_by!{ |node| node.label.split('.').map(&:to_i) }
     respond_to do |format|
       format.js
     end


### PR DESCRIPTION
This PR causes the nodes loaded via Ajax for the nodes tree to be sorted in an IP-meaningful way.

To test:

1. Create a node
2. Click 'Add subnode' and 'add multiple', then paste the following:

```
127.0.0.10
127.0.0.2
127.0.0.12
127.0.0.11
127.0.1.10
127.0.10.10
127.0.1.1
127.0.1.11
```

Before (left, alpha sorting) and after (right, IP sorting) this PR:

<img width="290" alt="screen shot 2019-01-29 at 13 50 26" src="https://user-images.githubusercontent.com/53006/51909425-e55eb300-23cc-11e9-9d5f-1e5c6edfa0c2.png">
