### PR TITLE
Warden - fix :failure_app config

### DIFF
--- a/config/initializers/warden_00_shared_password.rb
+++ b/config/initializers/warden_00_shared_password.rb
@@ -14,7 +14,10 @@ end
 
 Rails.configuration.middleware.use Warden::Manager do |manager|
   manager.default_strategies :shared_password
-  manager.failure_app = ->(env) { SessionsController.action(:new).call(env) }
+  manager.failure_app = ->(env) do
+    env['REQUEST_METHOD'] = 'GET'
+    SessionsController.action(:new).call(env)
+  end
 end
 
 # A simple db-backed strategy that uses the User.authenticate() method.


### PR DESCRIPTION
When providing the wrong credentials, we had a Warden config problem that resulted in an exception thrown instead of the login form being re-rendered.

This PR fixes the warden config to handle bad creds properly.

See:
  https://github.com/wardencommunity/rails_warden/issues/30
