### PR TITLE
Fix no-comments warning

### DIFF
--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -6,3 +6,5 @@ var submit = $('[data-behavior~=add-comment] input[type=submit]')
 submit.attr('disabled', false).val(submit.data('disable-with'))
 
 $('#<%= dom_id(@comment) %>').find('.actions').addClass('current_user')
+
+$('[data-notice~=no-comments]').hide()


### PR DESCRIPTION
When adding a comment for the first time, the 'no comments' warning stays.
Probably missed this when moving comments to AJAX in https://github.com/dradis/dradis-ce/pull/400