### PR TITLE
Issues#show view hook

### DIFF
--- a/app/assets/javascripts/snowcrash.js
+++ b/app/assets/javascripts/snowcrash.js
@@ -24,6 +24,7 @@
 //= require snowcrash/plugins/jquery.treenav
 
 //= require snowcrash/behaviors
+//= require snowcrash/engines
 //= require snowcrash/keyboard_shortcuts
 
 //= require snowcrash/modules/comments

--- a/app/assets/javascripts/snowcrash/engines.js.erb
+++ b/app/assets/javascripts/snowcrash/engines.js.erb
@@ -1,0 +1,11 @@
+<%
+Dradis::Plugins::with_feature(:addon).sort_by(&:plugin_description).each do |plugin|
+  begin
+    plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
+    %>
+    <%= require_asset "#{plugin_path}/manifests/snowcrash.js" %>
+    <%
+  rescue Sprockets::FileNotFound;
+  end
+end
+%>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,15 @@ module ApplicationHelper # :nodoc:
     result = textile_pipeline.call(text)
     result[:output].to_s.html_safe
   end
+
+  def render_view_hooks(partial, locals: {})
+    Dradis::Plugins::with_feature(:addon).sort_by(&:plugin_description).each do |plugin|
+      begin
+        plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
+        concat(render("#{plugin_path}/#{partial}", locals))
+      rescue ActionView::MissingTemplate
+      end
+    end
+    ;nil
+  end
 end

--- a/app/views/issues/_import_box.html.erb
+++ b/app/views/issues/_import_box.html.erb
@@ -2,7 +2,7 @@
   <div class="header-inner">
     <div class="options">
       <div class="dropdown">
-        <%= link_to raw('<i class="fa fa-chevron-down"></i>'), 'javascript:void(0)', class: 'import-toggle', data: {toggle: 'collapse', target: '.import-box'} %>
+        <%= link_to raw('<i class="fa fa-chevron-down"></i>'), 'javascript:void(0)', class: 'import-toggle', data: { toggle: 'collapse', target: '.import-box' } %>
       </div>
     </div>
     <h3>Import issues</h3>
@@ -18,7 +18,7 @@
       <% Dradis::Plugins::Import::Filters[plugin.plugin_name].each do |label, klass| %>
         <% next if label == :find_one_by_field %>
 
-        <%= form_tag import_project_issues_path, class: 'form-search' do %>
+        <%= form_tag main_app.import_project_issues_path, class: 'form-search' do %>
           <%= hidden_field_tag :scope, plugin.plugin_name %>
           <%= hidden_field_tag :filter, label %>
 

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -6,18 +6,18 @@
 <%= content_tag :div, id: "#{dom_id(issue)}_link", class: item_css.join do %>
 
   <div class="expansion-container">
-    <%= link_to [current_project, issue], class: 'view-toggle-off', data: {target: "##{dom_id(issue)}_content"} do %>
+    <%= link_to main_app.project_issue_path(current_project, issue), class: 'view-toggle-off', data: { target: "##{dom_id(issue)}_content" } do %>
       <%= colored_icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
       <%= issue.title %>
     <% end %>
   </div>
 
   <div class="list-item-actions">
-    <%= link_to edit_project_issue_path(current_project, issue), class:'list-item-action-edit' do %>
+    <%= link_to main_app.edit_project_issue_path(current_project, issue), class:'list-item-action-edit' do %>
       <i class="fa fa-pencil"></i> Edit
     <% end %>
 
-    <%= link_to [current_project, issue],
+    <%= link_to main_app.project_issue_path(current_project, issue),
           method: :delete,
           data: { confirm: 'Are you sure?' },
           class: 'list-item-action-delete' do %>

--- a/app/views/issues/_sidebar.html.erb
+++ b/app/views/issues/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="note-list">
-  <%= content_tag :div, id: 'issue_summary_link', class: current_page?(project_issues_path(current_project)) ? 'list-item active' : 'list-item' do %>
+  <%= content_tag :div, id: 'issue_summary_link', class: current_page?(main_app.project_issues_path(current_project)) ? 'list-item active' : 'list-item' do %>
     <div class="expansion-container">
-      <%= link_to project_issues_path(current_project), class: 'view-toggle-off' do %>
+      <%= link_to main_app.project_issues_path(current_project), class: 'view-toggle-off' do %>
         <i class="fa fa-bar-chart"></i>
         Summary of issues
       <% end %>
@@ -12,7 +12,7 @@
 <%= render 'shared/sidebar_collection',
   name: 'Issues',
   collection: @issues,
-  new_path: new_project_issue_path(current_project),
+  new_path: main_app.new_project_issue_path(current_project),
   category_id: nil
 %>
 <%= render 'import_box' %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -22,6 +22,7 @@
   </li>
   <li><a href="#evidence-tab" data-toggle="tab"><i class="fa fa-laptop"></i> Evidence <span class="badge"><%= @issue.evidence.count %></span></a></li>
   <li><a href="#activity-tab" data-toggle="tab"><i class="fa fa-refresh"></i> Recent activity</a></li>
+  <%= render_view_hooks 'issues/show-tabs' %>
 </ul>
 
 <div class="tab-content">
@@ -72,4 +73,6 @@
       </div>
     </div>
   <% end %>
+
+  <%= render_view_hooks 'issues/show-content' %>
 </div>

--- a/app/views/layouts/snowcrash/_navbar.html.erb
+++ b/app/views/layouts/snowcrash/_navbar.html.erb
@@ -18,7 +18,7 @@
             <%= link_to main_app.project_notifications_path(current_project), class: 'dropdown-toggle', data: { behavior: 'notifications-dropdown', toggle: 'dropdown' }, remote: true do %>
               <i class="fa fa-bell fa-lg"></i><b class="caret"></b><i class="notifications-dot hidden" data-behavior="notifications-dot"></i>
             <% end %>
-            <div class="dropdown-menu" data-url="<%= project_notifications_path(current_project) %>"></div>
+            <div class="dropdown-menu" data-url="<%= main_app.project_notifications_path(current_project) %>"></div>
           </li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-question fa-lg"></i><b class="caret"></b></a>


### PR DESCRIPTION
This PR brings view hooks to Snowcrash, it allows add-ons to hook into different views in the app to extend what you get out of the box.

Apart from the basic building blocks for view hooks, this PR adds the first two hooks in Issues#show to allow add-ons to add new tabs to the Issues#show view.