### PR TITLE
Warden failure app (v2)

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -8,8 +8,7 @@ module Authentication
   end
 
   def access_denied
-    # specify 'main_app' explicitly in case we're inside an engine.
-    redirect_to(main_app.login_path, alert: 'Please sign in first. Access denied.')
+    throw :warden, message: 'Please sign in first. Access denied.'
   end
 
   # Proxy to the authenticated? method on warden

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,7 @@ class SessionsController < ApplicationController
   before_action :ensure_setup,          only: :new
   before_action :ensure_not_setup,      only: [:init, :setup]
   before_action :ensure_valid_password, only: :setup
+  skip_before_action :verify_authenticity_token, only: :failure
 
   # ------------------------------------------- Initial shared password setup
   # Initialise the session, clear any objects that might currently exist and
@@ -31,10 +32,6 @@ class SessionsController < ApplicationController
   end
   # ------------------------------------------ /Initial shared password setup
 
-  def new
-    flash.now[:alert] = warden_message if warden_message.present?
-  end
-
   def create
     warden.authenticate!
     redirect_to_target_or_default root_url
@@ -43,6 +40,17 @@ class SessionsController < ApplicationController
   def destroy
     logout
     redirect_to login_path, notice: 'You have been logged out.'
+  end
+
+  def failure
+    respond_to do |format|
+      format.html do
+        flash[:alert] = warden_message if warden_message.present?
+        redirect_to new_session_path
+      end
+      format.json { head :not_found }
+      format.js { head :not_found }
+    end
   end
 
   protected

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,7 +46,7 @@ class SessionsController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:alert] = warden_message if warden_message.present?
-        redirect_to new_session_path
+        redirect_to login_path
       end
       format.json { head :not_found }
       format.js { head :not_found }

--- a/app/views/activities/_poller.html.erb
+++ b/app/views/activities/_poller.html.erb
@@ -6,6 +6,6 @@
   data-id="<%= params[:id] %>"
   data-last-poll="<%= Time.now.to_i %>"
   data-node-id="<%= @node.try(:id) %>"
-  data-url=<%= main_app.poll_project_activities_path(current_project) %>
+  data-url=<%= main_app.poll_project_activities_path(current_project, format: :js) %>
 >
 </div>

--- a/config/initializers/warden_00_shared_password.rb
+++ b/config/initializers/warden_00_shared_password.rb
@@ -14,7 +14,7 @@ end
 
 Rails.configuration.middleware.use Warden::Manager do |manager|
   manager.default_strategies :shared_password
-  manager.failure_app = ->(env) { SessionsController.action(:new).call(env) }
+  manager.failure_app = ->(env) { SessionsController.action(:failure).call(env) }
 end
 
 # A simple db-backed strategy that uses the User.authenticate() method.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
   # Sign in / sign out
   get '/login'  => 'sessions#new'
   get '/logout' => 'sessions#destroy'
-  match '/timeout' => 'sessions#timeout', via: :all
   resource :session
 
   # ------------------------------------------------------------ Project routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   resources :projects, only: [:show] do
     resources :activities, only: [] do
       collection do
-        get :poll, defaults: { format: :js }
+        get :poll, constraints: { format: /js/ }
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   # Sign in / sign out
   get '/login'  => 'sessions#new'
   get '/logout' => 'sessions#destroy'
+  match '/timeout' => 'sessions#timeout', via: :all
   resource :session
 
   # ------------------------------------------------------------ Project routes
@@ -23,7 +24,7 @@ Rails.application.routes.draw do
   resources :projects, only: [:show] do
     resources :activities, only: [] do
       collection do
-        get :poll, constraints: { format: /js/ }
+        get :poll, defaults: { format: :js }
       end
     end
 

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -355,7 +355,10 @@ describe 'Issues pages' do
           it 'creates an evidence for new nodes and existing nodes too' do
             find('.js-add-evidence').click
             fill_in 'Paste list of nodes', with: "192.168.0.1\r\n192.168.0.2\r\n192.168.0.3"
-            expect { click_button('Save Evidence') }.to change { Evidence.count }.by(3).and change { Node.count }.by(2)
+            expect do
+              click_button('Save Evidence')
+              expect(page).to have_text 'Evidence added for selected nodes.'
+            end.to change { Evidence.count }.by(3).and change { Node.count }.by(2)
 
             # New nodes don't have a parent:
             current_project.nodes.order('created_at ASC').last(2).each do |node|

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'Sessions' do
+  subject { page }
+
+  before do
+    create(
+      :configuration,
+      name: 'admin:password',
+      value: ::BCrypt::Password.create('rspec_pass')
+    )
+  end
+
+  let(:password) { 'rspec_pass' }
+
+  let(:login) do
+    visit login_path
+    fill_in 'login', with: 'rspec_user'
+    fill_in 'password', with: password
+    click_button 'Let me in!'
+  end
+
+  context 'when using the correct password' do
+    it 'users can log in' do
+      login
+
+      expect(current_path).to eq(project_path(Project.find(1)))
+    end
+  end
+
+  context 'when using an incorrect password' do
+    let(:password) { 'wrong_pass'}
+
+    it 'redirect to login with a message' do
+      login
+
+      expect(current_path).to eq(login_path)
+      expect(page).to have_content('Invalid credentials')
+    end
+  end
+
+  context 'when session is expired' do
+    it 'redirect to login with a message' do
+      login
+
+      Timecop.freeze(Time.now + 1.hour) do
+        visit project_path(Project.find(1))
+
+        expect(current_path).to eq(login_path)
+        expect(page).to have_content('Session timed out!')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Spec 

This is another attempt to https://github.com/dradis/dradis-ce/pull/432

When:
- we login with invalid credentials
- we make a POST/PATCH request and the session is expired 
We are redirected to the warden failure app. But since the request triggered in these cases check the csrf token, the failure app raises an error.

In this PR we try to set up a unique warden failure app, that does not check csrf token.
This failure app then just redirect to login for html requests, and for other requests (js/json) just returns 404 (not found)

### How to test
* Switch to `warden-failure-app-2` and confirm you now see a form when trying to login with bad credentials.
* In CE, create a node with subnodes (so when clicking the triangle to unfold the parent node a js request is generated). 
* Alter the app session timeout to be smaller. To do so edit this line: https://github.com/dradis/dradis-ce/blob/master/config/initializers/warden_99_timeout.rb#L30 so it looks like: 
  ` if last_request_at && last_request_at <= 10.seconds.ago`
and restart the server
* Login and visit a node so the attachments dropbox is visible. Wait > 10 seconds so the session expires.
 * When we try to upload an attachment, we should see an error like this:
<img width="286" alt="captura de pantalla 2019-02-21 a las 20 41 39" src="https://user-images.githubusercontent.com/85766/53203792-06a86d00-3622-11e9-933e-004934bd7f28.png">
* When we try to unfold a node in the sidebar we must see:
<img width="189" alt="captura de pantalla 2019-02-21 a las 21 18 51" src="https://user-images.githubusercontent.com/85766/53203834-1b850080-3622-11e9-81ba-16c9f112d53f.png">
    
* Reload the page and assert we see the login form
* Login and visit an issue edit page, but don't save it. Wait > 10 seconds so the session expires and submit the form. We should be redirected to the login page.