### PR TITLE
Extract issue tagging to the model

### DIFF
--- a/app/controllers/issues/merge_controller.rb
+++ b/app/controllers/issues/merge_controller.rb
@@ -23,7 +23,7 @@ class Issues::MergeController < IssuesController
         @issue.author ||= current_user.email
         if @issue.save && @issue.update_attributes(issue_params)
           track_created(@issue)
-          tag_issue_from_field_content(@issue)
+          @issue.tag_from_field_content!
         end
       end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -59,9 +59,10 @@ class IssuesController < AuthenticatedController
 
 
         track_created(@issue)
+
         # Only after we save the issue, we can create valid taggings (w/ valid
         # taggable IDs)
-        tag_issue_from_field_content(@issue)
+        @issue.tag_from_field_content!
 
         format.html { redirect_to [current_project, @issue], notice: 'Issue added.' }
       else
@@ -151,18 +152,4 @@ class IssuesController < AuthenticatedController
     params.require(:issue).permit(:tag_list, :text)
   end
 
-  # This method inspect the issues' Tag field and if present tags the issue
-  # accordingly.
-  def tag_issue_from_field_content(issue)
-    # If the Issue already has tags (e.g. from the HTML form), or if it doesn't
-    # have a Tags field, bail.
-    return if @issue.tags.any?
-    return unless issue.fields['Tags'].present?
-
-    # For now we just care about the first tag
-    if (tag_name = issue.fields['Tags'].split(',').first)
-      issue.tag_list = tag_name
-      issue.save
-    end
-  end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -129,4 +129,18 @@ class Issue < Note
     merged
   end
 
+  # This method inspects the issues' Tag field and if present tags the issue
+  # accordingly.
+  def tag_from_field_content!
+    # If the Issue already has tags (e.g. from the HTML form), or if it doesn't
+    # have a Tags field, bail.
+    return if tags.any?
+    return unless fields['Tags'].present?
+
+    # For now we just care about the first tag
+    if (tag_name = fields['Tags'].split(',').first)
+      self.tag_list = tag_name
+      self.save
+    end
+  end
 end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/issues_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/issues_controller.rb
@@ -17,6 +17,7 @@ module Dradis::CE::API
 
         if @issue.save
           track_created(@issue)
+          @issue.tag_from_field_content!
           render status: 201, location: dradis_api.issue_url(@issue)
         else
           render_validation_errors(@issue)

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb
@@ -105,6 +105,19 @@ describe "Issues API" do
         expect(retrieved_issue['text']).to eq valid_params[:issue][:text]
       end
 
+      it "tags the issue from the Tags field" do
+        tag_name = '!2ca02c_info'
+        valid_params[:issue][:text] << "#[Tags]#\n\n#{tag_name}\n\n"
+
+        expect { valid_post }.to change{ current_project.issues.count }.by(1)
+        expect(response.status).to eq(201)
+
+        retrieved_issue = JSON.parse(response.body)
+        database_issue  = current_project.issues.find(retrieved_issue['id'])
+
+        expect(database_issue.tag_list).to eq(tag_name)
+      end
+
       let(:submit_form) { valid_post }
       include_examples "creates an Activity", :create, Issue
 

--- a/spec/features/issue_pages/merge_spec.rb
+++ b/spec/features/issue_pages/merge_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe 'issue pages' do
+  describe 'merge page', js: true do
+    before do
+      login_to_project_as_user
+
+      # create 2 issues
+      create(:issue, node: current_project.issue_library)
+      create(:issue, node: current_project.issue_library)
+
+      visit project_issues_path(current_project)
+
+      # click > 1 issue checkboxes
+      page.all('input.js-multicheck').each(&:click)
+
+      # click the merge button
+      find('#merge-selected').click
+    end
+
+    it 'merges issues into an existing one' do
+      expect(page).to have_content "You're merging 2 Issues into a target Issue"
+
+      click_button 'Merge issues'
+
+      expect(page).to have_content('1 issue merged into ')
+    end
+
+    context "merge issues into a new one" do
+      it 'creates a new issue' do
+        expect(page).to have_content "You're merging 2 Issues into a target Issue"
+
+        # new issue form should not be visible yet
+        expect(page).to have_selector('#new_issue', visible: false)
+
+        choose('Merge into a new issue')
+
+        # new issue form should be visible now
+        expect(page).to have_selector('#new_issue', visible: true)
+
+        # click button like this because the button may be moving down
+        # due to bootstrap accordion unfold transition
+        find_button('Merge issues').trigger('click') # click_button "Merge issues"
+
+        expect(page).to have_content('2 issues merged into ')
+
+        # We start with 2, but merge into a single one
+        expect(Issue.count).to eq(1)
+        expect(Issue.last.author).to eq(@logged_in_as.email)
+      end
+
+      it 'tags the new issue based on the #[Tags]#' do
+        expect(page).to have_content "You're merging 2 Issues into a target Issue"
+
+        # new issue form should not be visible yet
+        expect(page).to have_selector('#new_issue', visible: false)
+
+        choose('Merge into a new issue')
+
+        # new issue form should be visible now
+        expect(page).to have_selector('#new_issue', visible: true)
+
+        tag_name = '!2ca02c_info'
+        fill_in :issue_text, with: "#[Title]#\nMerged issue\n\n#[Tags]#\n#{tag_name}\n\n"
+
+        # click button like this because the button may be moving down
+        # due to bootstrap accordion unfold transition
+        find_button('Merge issues').trigger('click') # click_button "Merge issues"
+
+        expect(page).to have_content('2 issues merged into Merged issue')
+        expect(Issue.last.reload.tag_list).to eq(tag_name)
+      end
+    end
+
+    let(:submit_form) {
+      click_button 'Merge issues'
+    }
+    include_examples 'deleted item is listed in Trash', :issue
+  end
+end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -48,56 +48,6 @@ describe 'Issues pages' do
 
       end
 
-      describe 'merge page', js: true do
-
-        before do
-          # create 2 issues
-          create(:issue, node: current_project.issue_library)
-          create(:issue, node: current_project.issue_library)
-
-          visit project_issues_path(current_project)
-
-          # click > 1 issue checkboxes
-          page.all('input.js-multicheck').each(&:click)
-
-          # click the merge button
-          find('#merge-selected').click
-        end
-
-        it 'merges issues into an existing one' do
-          expect(page).to have_content "You're merging 2 Issues into a target Issue"
-
-          click_button 'Merge issues'
-
-          expect(page).to have_content('1 issue merged into ')
-        end
-
-        it 'merges issues into a new one' do
-          expect(page).to have_content "You're merging 2 Issues into a target Issue"
-
-          # new issue form should not be visible yet
-          expect(page).to have_selector('#new_issue', visible: false)
-
-          choose('Merge into a new issue')
-
-          # new issue form should be visible now
-          expect(page).to have_selector('#new_issue', visible: true)
-
-          # click button like this because the button may be moving down
-          # due to bootstrap accordion unfold transition
-          find_button('Merge issues').trigger('click') # click_button "Merge issues"
-
-          expect(page).to have_content('2 issues merged into ')
-
-          expect(Issue.last.author).to eq(@logged_in_as.email)
-        end
-
-        let(:submit_form) {
-          click_button 'Merge issues'
-        }
-        include_examples 'deleted item is listed in Trash', :issue
-      end
-
       describe 'new page' do
         let(:submit_form) { click_button 'Create Issue' }
 


### PR DESCRIPTION
There are 4 ways to add an issue (where the content is user-controller and not scanner-provided):

    1. Through the browser, add issue
    2. Through the browser, import from IssueLib
    3. Through the browser, merge issue
    4. Through the API

Before this PR, 1, 2, and 3 would inspect the contents of the Issue and if a `#[Tags]#` field was present, the issue would be tagged accordingly.

This PR extends that behaviour to 4.