### PR TITLE
Search tags using downcase name

### DIFF
--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -17,7 +17,7 @@ module Taggable
 
   def tag_list=(names)
     self.tags = names.split(",").map do |n|
-      Tag.where(name: n.strip.downcase).first_or_create!
+      Tag.where(name: Tag.normalize(n)).first_or_create!
     end
   end
 end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -17,7 +17,7 @@ module Taggable
 
   def tag_list=(names)
     self.tags = names.split(",").map do |n|
-      Tag.where(name: n.strip).first_or_create!
+      Tag.where(name: n.strip.downcase).first_or_create!
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,7 +28,9 @@ class Tag < ApplicationRecord
 
 
   # -- Class Methods ----------------------------------------------------------
-
+  def self.normalize(name)
+    name.strip.downcase
+  end
 
   # -- Instance Methods -------------------------------------------------------
 
@@ -56,6 +58,6 @@ class Tag < ApplicationRecord
 
   private
   def normalize_name
-    self[:name] = self.name.downcase
+    self[:name] = self.normalize(self.name)
   end
 end


### PR DESCRIPTION
When we create tags, first we search if the tag exist:
https://github.com/dradis/dradis-ce/blob/master/app/models/concerns/taggable.rb#L20
`Tag.where(name: n.strip).first_or_create!`

When we save the tag, the we force the name to be downcase:
https://github.com/dradis/dradis-ce/blob/master/app/models/tag.rb#L22
https://github.com/dradis/dradis-ce/blob/master/app/models/tag.rb#L58
```
before_save :normalize_name

private
def normalize_name
  self[:name] = self.name.downcase
end
```

If we are using a db that differentiates between upcase and downcase (sqlite), when searching for the tab, if we use upcase, the tab is not going to be found. Then when inserting it our unique name validation will fail, since its is case insensitive:
https://github.com/dradis/dradis-ce/blob/master/app/models/tag.rb#L25 

In this PR we make sure that when searching the tag by name we use downcase strings.

### How to test:
Create an issue with this content:

```
#[Title]#
Test critical From Tags

#[Tags]#
!9467bd_critical
```

Then another one with upcase tab:
```
#[Title]#
Test Critical From Tags

#[Tags]#
!9467bd_Critical
```

No error should be raised, both issues should be created an tagged.