### PR TITLE
Use current_project instead of node.project

### DIFF
--- a/app/views/issues/nodes/_evidence.html.erb
+++ b/app/views/issues/nodes/_evidence.html.erb
@@ -3,9 +3,9 @@
   <%= content_tag :section, class: 'evidence-for-host' do %>
     <% if node.evidence_count == 1 %>
       <h3>
-        Evidence for <%= link_to node.label, project_node_path(node.project, node) %> -
+        Evidence for <%= link_to node.label, project_node_path(current_project, node) %> -
         <span class="actions">
-          <%= link_to edit_project_node_evidence_path(node.project, node, evidence, back_to: :issue), class: 'action-link' do %>
+          <%= link_to edit_project_node_evidence_path(current_project, node, evidence, back_to: :issue), class: 'action-link' do %>
             <i class="fa fa-pencil"></i> Edit
           <% end %>
           <%= link_to [current_project, node, evidence],
@@ -31,9 +31,10 @@
           <% instances.each_with_index do |instance, i| %>
             <div class="tab-pane<%= ' active' if i==0 %>" id="node_<%= node.id %>_instance_<%= instance.id %>">
               <h3>
-                Instance #<%= i+1 %> for <%= link_to node.label, project_node_path(node.project, node) %> -
+                Instance #<%= i+1 %> for <%= link_to node.label, project_node_path(current_project, node) %> -
                 <span class="actions">
-                  <%= link_to edit_project_node_evidence_path(node.project, node, instance, back_to: :issue), class: 'action-link' do %>
+                  <% byebug %>
+                  <%= link_to edit_project_node_evidence_path(current_project, node, instance, back_to: :issue), class: 'action-link' do %>
                     <i class="fa fa-pencil"></i> Edit
                   <% end %>
                   <%= link_to [current_project, node, instance],

--- a/app/views/issues/nodes/_evidence.html.erb
+++ b/app/views/issues/nodes/_evidence.html.erb
@@ -33,7 +33,6 @@
               <h3>
                 Instance #<%= i+1 %> for <%= link_to node.label, project_node_path(current_project, node) %> -
                 <span class="actions">
-                  <% byebug %>
                   <%= link_to edit_project_node_evidence_path(current_project, node, instance, back_to: :issue), class: 'action-link' do %>
                     <i class="fa fa-pencil"></i> Edit
                   <% end %>


### PR DESCRIPTION
In this template using `node.project` works because in CE `Project` is not an ActiveRecord and the database relationship does not really exist.

Since `project_id` is not being populated for this concrete node query: https://github.com/dradis/dradis-ce/blob/master/app/controllers/issues_controller.rb#L29, if we use `node.project` the code fails when in other environments the relationship exists.

Using `current_project` for consistency between environments.
