### PR TITLE
Fix subnodes disappearing when moved

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.13 (XXX)
  - User-provided content takes priority over default local fields.
+ - Fix subnodes disappearing when moved
 
 v3.12 (April 2019)
  - Using ajax in comments

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -89,6 +89,7 @@ class Node < ApplicationRecord
   # SEE: https://github.com/amerine/acts_as_tree/issues/63
   # We add an empty method to handle the bug in acts_as_tree gem that
   # causes subnodes to disappear when moved.
+  # FIXME: This expected to be fixed in Rails 6. Remove this when upgraded.
   def update_parents_counter_cache; end
 
   private

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -86,6 +86,11 @@ class Node < ApplicationRecord
     Types::USER_TYPES.include?(self.type_id)
   end
 
+  # SEE: https://github.com/amerine/acts_as_tree/issues/63
+  # We add an empty method to handle the bug in acts_as_tree gem that
+  # causes subnodes to disappear when moved.
+  def update_parents_counter_cache; end
+
   private
   # Whenever a node is deleted all the associated attachments have to be
   # deleted too


### PR DESCRIPTION
Issue: #179 

Overriding the `update_parents_counter_cache` method with an empty one seems to solve the issue of subnodes disappearing.

### How to test:

1. Add a top level node
2. Add 2 subnodes under the node in Step 1
3. Move 1 subnode under another
4. Confirm that the subnodes are still visible in the sidebar