### PR TITLE
Merge nodes functionality

### DIFF
--- a/app/assets/stylesheets/snowcrash/modules/nodes.scss
+++ b/app/assets/stylesheets/snowcrash/modules/nodes.scss
@@ -46,3 +46,14 @@ td.services-extras-datum-output {
   // layout:
   word-break: break-all;
 }
+
+.btn-node-action, .btn-node-action.open {
+  .btn.dropdown-toggle,
+  .btn.dropdown-toggle:hover {
+    background-color: #285d28; color: white; margin: 5px 10px 0 0;
+  }
+
+  .caret {
+    border-top-color: #eee; border-bottom-color: #eee;
+  }
+}

--- a/app/controllers/nodes/merges_controller.rb
+++ b/app/controllers/nodes/merges_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Nodes::MergesController < NodesController
+  def create
+    old_node = Node.find(params[:id])
+
+    MergeNode.new(old_node, @node).execute
+
+    redirect_to [current_project, @node]
+  end
+end

--- a/app/services/merge_node.rb
+++ b/app/services/merge_node.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class MergeNode
+  attr_reader :old_node, :new_node
+
+  def initialize(old_node, new_node)
+    @old_node = old_node
+    @new_node = new_node
+  end
+
+  def execute
+    ActiveRecord::Base.transaction do
+      update_child_nodes
+      update_activities
+      update_evidence
+      update_notes
+      update_attachments
+      old_node.delete
+    end
+  end
+
+  private
+
+  def update_activities
+    activities_ids = old_node.activities.pluck :id
+    Activity.where(id: activities_ids).update_all(trackable_id: new_node.id) if activities_ids.present?
+  end
+
+  def update_evidence
+    evidence_ids = old_node.evidence.pluck :id
+    Evidence.where(id: evidence_ids).update_all(node_id: new_node.id) if evidence_ids.present?
+  end
+
+  def update_notes
+    notes_ids = old_node.notes.pluck :id
+    Note.where(id: notes_ids).update_all(node_id: new_node.id) if notes_ids.present?
+  end
+
+  def update_child_nodes
+    if old_node.children_count > 0
+      Node.where(parent_id: old_node.id).update_all(parent_id: new_node.id)
+      Node.reset_counters new_node.id, :children_count
+    end
+  end
+
+  def update_attachments
+    old_node.attachments.each {|r| r.node_id = new_node.id; r.save}
+  end
+end

--- a/app/views/layouts/snowcrash/_breadcrumb.html.erb
+++ b/app/views/layouts/snowcrash/_breadcrumb.html.erb
@@ -9,12 +9,19 @@
     </ul>
   </div>
   <div class="span6">
-    <ul class="nav nav-pills pull-right">
-      <li><a href="#modal_add_child_node" tabindex="-1" data-toggle="modal"><i class="fa fa-plus"></i> Add subnode</a></li>
-      <li><a href="#modal_delete_node" class="text-error" tabindex="-1" data-toggle="modal"><i class="fa fa-trash"></i> Delete</a></li>
-      <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
-      <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
-    </ul>
+    <div class="btn-group pull-right btn-node-action">
+      <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+        Action
+        <span class="caret"></span>
+      </a>
+      <ul class="dropdown-menu">
+        <li><a href="#modal_add_child_node" tabindex="-1" data-toggle="modal"><i class="fa fa-plus"></i> Add subnode</a></li>
+        <li><a href="#modal_delete_node" class="text-error" tabindex="-1" data-toggle="modal"><i class="fa fa-trash"></i> Delete</a></li>
+        <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
+        <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
+        <li><a href="#modal_merge_node" tabindex="-1" data-toggle="modal"><i class="fa fa-random"></i> Merge</a></li>
+      </ul>
+    </div>
   </div>
 </div>
 
@@ -23,6 +30,7 @@
 <%= render partial: 'nodes/modals/delete' %>
 <%= render partial: 'nodes/modals/rename' %>
 <%= render partial: 'nodes/modals/move' %>
+<%= render partial: 'nodes/modals/merge' %>
 <% end %>
 
 <% if content_for?(:breadcrums) %>

--- a/app/views/nodes/modals/_merge.html.erb
+++ b/app/views/nodes/modals/_merge.html.erb
@@ -1,0 +1,24 @@
+<div id="modal_merge_node" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <%= form_tag project_merges_path(current_project), method: :post, class: 'form-horizontal modal-node-selection-form', data: { node_id: @node.id, hidden_field: '#node_id' } do %>
+    <%= hidden_field_tag :node_id %>
+
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+      <h3 id="myModalLabel">Merge <%= @node.label %> node</h3>
+    </div>
+    <div class="modal-body">
+      <p>Into which node do you want to merge <strong><%= @node.label %></strong> node?</p>
+
+      <div class="tree-modal-box">
+        <%= render "layouts/snowcrash/nodes" %>
+      </div>
+      <p id="move-under">
+        Merge into: <strong><span id="current-selection"></span></strong>
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary">Merge</button>
+      <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/nodes/modals/_merge.html.erb
+++ b/app/views/nodes/modals/_merge.html.erb
@@ -1,5 +1,5 @@
 <div id="modal_merge_node" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <%= form_tag project_merges_path(current_project), method: :post, class: 'form-horizontal modal-node-selection-form', data: { node_id: @node.id, hidden_field: '#node_id' } do %>
+  <%= form_tag project_merges_path(current_project.id, @node.id), method: :post, class: 'form-horizontal modal-node-selection-form', data: { node_id: @node.id, hidden_field: '#node_id' } do %>
     <%= hidden_field_tag :node_id %>
 
     <div class="modal-header">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
 
       member do
         get :tree
+        resources :merges, only: [:create], controller: 'nodes/merges', as: 'merges'
       end
 
       resources :notes, concerns: :multiple_destroy do

--- a/spec/features/node_merge_spec.rb
+++ b/spec/features/node_merge_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe 'merging a node', js: true do
+  subject { page }
+
+  before do
+    login_to_project_as_user
+
+    @node_0 = create_node(label: 'Node 0', project: current_project)
+    @node_1 = create_node(label: 'Node 1', parent: @node_0)
+    @node_2 = create_node(label: 'Node 2', parent: @node_0)
+    @node_3 = create_node(label: 'Node 3', parent: @node_1)
+
+    # Tree:
+    #
+    # - node_0
+    #   - node_1
+    #     - node_3
+    #   - node_2
+  end
+
+  before do
+    visit project_node_path(current_node.project, current_node)
+    click_link 'Action'
+    click_link 'Merge'
+  end
+
+  let(:current_node) { @node_1 }
+
+  describe 'merge of node into another node' do
+    before do
+      within_merge_node_modal do
+        click_link(@node_2.label)
+        find_button('Merge').click
+      end
+    end
+
+    it 'deletes source node' do
+      expect(Node.find_by(label: 'Node 1')).to eq nil
+    end
+
+    it 'moves child nodes into target node' do
+      expect(@node_2.reload.children).to include(@node_3)
+    end
+
+    it 'navigates to target node path' do
+      expect(current_path).to eq project_node_path(current_project, @node_2)
+    end
+  end
+
+  def within_merge_node_modal
+    within('#modal_merge_node') { yield }
+  end
+
+  def create_node(attrs={})
+    create(:node, attrs.merge(project: current_project))
+  end
+end

--- a/spec/features/node_moving_spec.rb
+++ b/spec/features/node_moving_spec.rb
@@ -27,7 +27,8 @@ describe "moving a node", js: true do
 
   before do
     visit project_node_path(current_node.project, current_node)
-    click_link "Move"
+    click_link 'Action'
+    click_link 'Move'
   end
 
   let(:current_node) { @node_2 }

--- a/spec/features/node_pages/polling_spec.rb
+++ b/spec/features/node_pages/polling_spec.rb
@@ -261,7 +261,10 @@ describe "node pages", js: true do
   end
 
   def show_move_node_modal
-    click_link "Move" unless move_modal_visible?
+    unless move_modal_visible?
+      click_link("Action")
+      click_link("Move")
+    end
   end
 
   def move_modal_visible?

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -104,6 +104,7 @@ describe "node pages" do
     describe "adding child nodes to an existing node", :js do
       before do
         visit project_node_path(node.project, node)
+        click_link "Action"
         click_link "Add subnode"
       end
 
@@ -184,6 +185,7 @@ describe "node pages" do
     before do
       @node = create(:node, label: "My node", project: current_project)
       visit project_node_path(@node.project, @node)
+      click_link "Action"
       click_link "Rename"
     end
 
@@ -229,6 +231,7 @@ describe "node pages" do
     before do
       @node = create(:node, label: "My node", project: current_project)
       visit project_node_path(@node.project, @node)
+      click_link "Action"
       click_link "Delete"
     end
 

--- a/spec/services/merge_node_spec.rb
+++ b/spec/services/merge_node_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe MergeNode do
+  describe '.execute' do
+    subject(:merge_nodes) { described_class.new(node_1, node_2).execute }
+
+    let!(:attachment) { create(:attachment, node: node_1) }
+    let!(:activity) { create(:activity, trackable: node_1) }
+    let!(:evidence) { create(:evidence, node: node_1, issue: issue) }
+    let!(:issue) { create(:issue, node: node_1) }
+
+    let!(:node_0) { create(:node, label: 'Node 0', project: Project.new) }
+    let!(:node_1) { create(:node, label: 'Node 1', parent: node_0) }
+    let!(:node_2) { create(:node, label: 'Node 2', parent: node_0) }
+    let!(:node_3) { create(:node, label: 'Node 3', parent: node_1) }
+    # Tree:
+    #
+    # - node_0
+    #   - node_1
+    #     - node_3
+    #   - node_2
+
+
+    context 'when transaction successful' do
+      before { merge_nodes }
+      after do
+        delete_attachment_for node_1, node_2
+      end
+
+      it 'deletes source node' do
+        expect(Node.find_by(label: 'Node 1')).to eq nil
+      end
+
+      it 'moves children to target node' do
+        expect(node_2.children).to include(node_3)
+      end
+
+      it 'transfers associations to target node' do
+        node_2.reload
+        expect(node_2.evidence.first).to eq(evidence)
+        expect(node_2.issues.first).to eq(issue)
+        expect(node_2.activities.first).to eq(activity)
+        expect(File.exists?(node_2.attachments.first)).to be(true)
+      end
+    end
+
+    context 'when transaction fails' do
+      before do
+        allow(Node).to receive(:reset_counters).and_raise(StandardError)
+      end
+      after do
+        delete_attachment_for node_1
+      end
+
+      it 'does not delete source node' do
+        expect(Node.find_by(label: 'Node 1')).to eq(node_1)
+      end
+
+      it 'does not move children to target node' do
+        expect(node_2.children).to eq([])
+      end
+
+      it 'does not transfer associations to target node' do
+        expect(node_2.evidence.first).not_to eq(evidence)
+        expect(node_2.issues.first).not_to eq(issue)
+        expect(node_2.activities.first).not_to eq(activity)
+        expect(node_2.attachments).to eq([])
+      end
+    end
+  end
+
+  def delete_attachment_for(*nodes)
+    nodes.each { |node| FileUtils.rm_rf(Attachment.pwd.join(node.id.to_s)) }
+  end
+end

--- a/spec/support/revision_shared_examples.rb
+++ b/spec/support/revision_shared_examples.rb
@@ -53,6 +53,7 @@ shared_examples "recover deleted item without node" do |item_type|
     with_versioning do
       submit_form
       visit project_node_path(model.node.project, model.node.id)
+      click_link 'Action'
       click_link 'Delete'
       within '#modal_delete_node' do
         click_link 'Delete'


### PR DESCRIPTION
### Summary

This PR addresses [this issue](https://trello.com/c/xs0puZDz). 
In the node's actions bar there is a new `Merge` action that moves associated: `Notes`, `Evidence` `Attachments` and `Activities` from the source node into the target node.
After the merge, the source node is being deleted

### Other Information

- Action items are now grouped inside a drop down since there is many of them and they would otherwise go in 2 rows
- Since there is lots of data reassigning between nodes, the operation is wrapped inside a `ActiveRecord::Base.transaction` so that there is a rollback in case something goes wrong

### Demo
![merge-demo](https://user-images.githubusercontent.com/23106612/57988616-b27e1f00-7a90-11e9-9387-5772c6625392.gif)


### Copyright assignment

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
