### PR TITLE
Correct diff behavior for first revision

### DIFF
--- a/app/models/diffed_revision.rb
+++ b/app/models/diffed_revision.rb
@@ -11,7 +11,7 @@ class DiffedRevision
   def diff
     @diff ||= Differ.diff_by_line(
                 after[content_attribute],
-                before[content_attribute]
+                before_content
               )
   end
 
@@ -40,6 +40,10 @@ class DiffedRevision
   def before
     # Version#object is the state of the object *before* the change was made.
     @before ||= YAML.load(@revision.object)
+  end
+
+  def before_content
+    @revision.previous.event == 'create' ? before[content_attribute].gsub("\n", "\r\n") : before[content_attribute]
   end
 
   def after

--- a/app/models/diffed_revision.rb
+++ b/app/models/diffed_revision.rb
@@ -43,7 +43,8 @@ class DiffedRevision
   end
 
   def before_content
-    @revision.previous.event == 'create' ? before[content_attribute].gsub("\n", "\r\n") : before[content_attribute]
+    harmonized_version = before[content_attribute].include?("\r\n") ? before[content_attribute] : before[content_attribute].gsub("\n", "\r\n")
+    @revision.previous.event == 'create' ? harmonized_version : before[content_attribute]
   end
 
   def after


### PR DESCRIPTION
### Summary

Fixes #462. The problem was that the first version uses `\n` for a newline and successive versions use `\r\n` so I made the first version use the same format to get the desired results.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
