### PR TITLE
Delete multiple Evidence from Issue#show page

### DIFF
--- a/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
@@ -1,40 +1,106 @@
 document.addEventListener "turbolinks:load", ->
-  if $('body.issues.show').length
-    $('#evidence-tabs li').first().addClass('active')
-    $('#evidence-tabs .tab-pane').first().addClass('active')
+  return unless $('body.issues.show').length
 
-    $('i[data-toggle="tooltip"]').tooltip()
+  $('#evidence-tabs li').first().addClass('active')
+  $('#evidence-tabs .tab-pane').first().addClass('active')
 
-    $('#evidence-host-list a[data-toggle="tab"]').on 'shown', (ev)->
-      tabContentHeight = $('#evidence-tabs .tab-content').height()
-      $tabs            = $('#evidence-tabs #evidence-host-list')
+  $('i[data-toggle="tooltip"]').tooltip()
 
-      # This enlarges the tab's height. Later if the tab content is shorter
-      # the tabs would be a bit taller than necessary, but thats a better
-      # visual effect than the other way around (short tabs w/ tall content)
-      if $tabs.height() < tabContentHeight
-        $tabs.css('height', tabContentHeight)
+  $('#evidence-host-list a[data-toggle="tab"]').on 'shown', (ev)->
+    tabContentHeight = $('#evidence-tabs .tab-content').height()
+    $tabs            = $('#evidence-tabs #evidence-host-list')
 
-      path   = $(this).data('path')
-      node   = $(this).data('node')
-      fetch(path, {credentials: 'include'}).then (response) ->
-        if response.redirected
-          window.location.href = '/'
-        else
-          response.text()
-          .then (html) ->
-            $("##{node}").html(html)
+    # This enlarges the tab's height. Later if the tab content is shorter
+    # the tabs would be a bit taller than necessary, but thats a better
+    # visual effect than the other way around (short tabs w/ tall content)
+    if $tabs.height() < tabContentHeight
+      $tabs.css('height', tabContentHeight)
 
-    $('.js-add-evidence').click ->
-      $('#js-add-evidence-container').slideToggle()
+    path   = $(this).data('path')
+    node   = $(this).data('node')
+    fetch(path, {credentials: 'include'}).then (response) ->
+      if response.redirected
+        window.location.href = '/'
+      else
+        response.text()
+        .then (html) ->
+          $("##{node}").html(html)
 
-    $('#js-add-evidence-container').on 'change', '#evidence_content', ->
-      # $('#evidence_content').val($(this).val())
-      $('#template-content').text($(this).val())
+  $('.js-add-evidence').click ->
+    $('#js-add-evidence-container').slideToggle()
 
-    $('#js-add-evidence-container').on 'keyup', '#evidence_node', ->
-      rule = new RegExp($(this).val(), 'i')
-      $('#existing-node-list label').hide();
-      $('#existing-node-list label').filter ->
-        rule.test($(this).text())
-      .show()
+  $('#js-add-evidence-container').on 'change', '#evidence_content', ->
+    # $('#evidence_content').val($(this).val())
+    $('#template-content').text($(this).val())
+
+  $('#js-add-evidence-container').on 'keyup', '#evidence_node', ->
+    rule = new RegExp($(this).val(), 'i')
+    $('#existing-node-list label').hide();
+    $('#existing-node-list label').filter ->
+      rule.test($(this).text())
+    .show()
+
+
+
+  # when selecting items or 'select all', refresh toolbar buttons
+  $(".js-items-table-select-all, input[type=checkbox].js-multicheck").click =>
+    # @refreshToolbar()
+    checked = $("input[type=checkbox].js-multicheck:checked:visible").length
+    if checked
+      $(".js-items-table-actions").css('display', 'inline-block')
+    else
+      $(".js-items-table-actions").css('display', 'none')
+
+  $('.js-items-table-delete').on 'confirm:complete', (element, answer) ->
+    if answer
+      that = this
+      ids = []
+
+      $('.evidence-content.active input[type=checkbox]:checked:visible').each ->
+        # $row = $(this).parent().parent()
+        # $($row.find('td')[2]).replaceWith("<td class=\"loading\">Deleting...</td>")
+
+        # $('#evidence-host-list li.active a').data('node-id')
+        ids.push($(this).val())
+
+      $.ajax $('#evidence-host-list li.active a').data('destroy-url'), {
+        method: 'DELETE'
+        dataType: 'json'
+        data: { ids: ids, custom_controller: 'evidence', notice: 'Evidence deleted for selected nodes.' }
+        success: (data) ->
+          window.location.replace($('#evidence-host-list li.active a').data('redirect-to'))
+
+          # for id in ids
+          #   $("#checkbox_#{that.itemName}_#{id}").closest('tr').remove()
+          #   $("##{that.itemName}_#{id}_link").remove()
+
+          # if $(that.selectedItemsSelector).length == 0
+          #   that.resetToolbar()
+
+          # if data.success
+          #   if data.jobId?
+          #     # background deletion
+          #     that.showConsole(data.jobId)
+          #   else
+          #     # inline deletion
+          #     that.showAlert(data.msg, 'success')
+          # else
+          #   that.showAlert(data.msg, 'error')
+
+          # TODO: show placeholder if no items left
+
+        error: ->
+          # for id in ids
+          #   $row = $("#checkbox_#{that.itemName}_#{id}").closest('tr')
+          #   $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
+      }
+
+    # prevent Rails UJS from doing anything else.
+    false
+
+  # refreshToolbar: =>
+  #   checked = $("input[type=checkbox].js-multicheck:checked:visible").length
+  #   if checked
+  #     $(".js-items-table-actions").css('display', 'inline-block')
+  #   else
+  #     $(".js-items-table-actions").css('display', 'none')

--- a/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
@@ -43,13 +43,28 @@ document.addEventListener "turbolinks:load", ->
 
 
   # when selecting items or 'select all', refresh toolbar buttons
-  $(".js-items-table-select-all, input[type=checkbox].js-multicheck").click =>
+  $(".js-items-table-select-all, input[type=checkbox].js-multicheck").change =>
     # @refreshToolbar()
     checked = $("input[type=checkbox].js-multicheck:checked:visible").length
     if checked
       $(".js-items-table-actions").css('display', 'inline-block')
     else
       $(".js-items-table-actions").css('display', 'none')
+
+  checker = (checked_value) ->
+    $('input[type=checkbox].js-multicheck').each (index, element) ->
+        jqueried_element = $('#' + element['id'])
+        jqueried_element.prop('checked', checked_value)
+
+  $('#issues-evidence-select-all').change =>
+    if $('#issues-evidence-select-all').prop('checked')
+      checker(true)
+    else
+      checker(false)
+      $(".js-items-table-actions").css('display', 'none')
+
+  $('[data-toggle="tab"]').click =>
+    $(".js-items-table-actions").css('display', 'none')
 
   $('.js-items-table-delete').on 'confirm:complete', (element, answer) ->
     if answer

--- a/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
@@ -65,6 +65,8 @@ document.addEventListener "turbolinks:load", ->
 
   $('[data-toggle="tab"]').click =>
     $(".js-items-table-actions").css('display', 'none')
+    $('#issues-evidence-select-all').prop('checked', false)
+    checker(false)
 
   $('.js-items-table-delete').on 'confirm:complete', (element, answer) ->
     if answer

--- a/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues/evidence.js.coffee
@@ -40,84 +40,46 @@ document.addEventListener "turbolinks:load", ->
       rule.test($(this).text())
     .show()
 
-
-
-  # when selecting items or 'select all', refresh toolbar buttons
-  $(".js-items-table-select-all, input[type=checkbox].js-multicheck").change =>
-    # @refreshToolbar()
-    checked = $("input[type=checkbox].js-multicheck:checked:visible").length
+  $(".js-issues-evidence-select-all, .js-multicheck").change =>
+    checked = $(".js-multicheck:checked:visible").length
     if checked
-      $(".js-items-table-actions").css('display', 'inline-block')
+      $(".js-issues-evidence-actions").css('display', 'inline-block')
     else
-      $(".js-items-table-actions").css('display', 'none')
-
-  checker = (checked_value) ->
-    $('input[type=checkbox].js-multicheck').each (index, element) ->
-        jqueried_element = $('#' + element['id'])
-        jqueried_element.prop('checked', checked_value)
+      $(".js-issues-evidence-actions").css('display', 'none')
 
   $('#issues-evidence-select-all').change =>
     if $('#issues-evidence-select-all').prop('checked')
       checker(true)
     else
       checker(false)
-      $(".js-items-table-actions").css('display', 'none')
+
+  $(".js-multicheck").change =>
+    return unless $('#issues-evidence-select-all').prop('checked') && !this.checked
+
+    $('#issues-evidence-select-all').prop('checked', false)
 
   $('[data-toggle="tab"]').click =>
-    $(".js-items-table-actions").css('display', 'none')
+    $(".js-issues-evidence-actions").css('display', 'none')
     $('#issues-evidence-select-all').prop('checked', false)
     checker(false)
 
-  $('.js-items-table-delete').on 'confirm:complete', (element, answer) ->
-    if answer
-      that = this
-      ids = []
+  $('.js-issues-evidence-delete').on 'confirm:complete', (element, answer) ->
+    return unless answer
 
-      $('.evidence-content.active input[type=checkbox]:checked:visible').each ->
-        # $row = $(this).parent().parent()
-        # $($row.find('td')[2]).replaceWith("<td class=\"loading\">Deleting...</td>")
+    ids = []
 
-        # $('#evidence-host-list li.active a').data('node-id')
-        ids.push($(this).val())
+    $('.evidence-content.active .js-multicheck:checked:visible').each ->
+      ids.push($(this).val())
 
-      $.ajax $('#evidence-host-list li.active a').data('destroy-url'), {
-        method: 'DELETE'
-        dataType: 'json'
-        data: { ids: ids, custom_controller: 'evidence', notice: 'Evidence deleted for selected nodes.' }
-        success: (data) ->
-          window.location.replace($('#evidence-host-list li.active a').data('redirect-to'))
+    $.ajax $('#evidence-host-list li.active a').data('destroy-url'), {
+      method: 'DELETE'
+      dataType: 'json'
+      data: { ids: ids, custom_controller: 'evidence', notice: 'Evidence deleted for selected nodes.' }
+      success: (data) ->
+        window.location.replace($('#evidence-host-list li.active a').data('redirect-to'))
+    }
 
-          # for id in ids
-          #   $("#checkbox_#{that.itemName}_#{id}").closest('tr').remove()
-          #   $("##{that.itemName}_#{id}_link").remove()
-
-          # if $(that.selectedItemsSelector).length == 0
-          #   that.resetToolbar()
-
-          # if data.success
-          #   if data.jobId?
-          #     # background deletion
-          #     that.showConsole(data.jobId)
-          #   else
-          #     # inline deletion
-          #     that.showAlert(data.msg, 'success')
-          # else
-          #   that.showAlert(data.msg, 'error')
-
-          # TODO: show placeholder if no items left
-
-        error: ->
-          # for id in ids
-          #   $row = $("#checkbox_#{that.itemName}_#{id}").closest('tr')
-          #   $($row.find('td')[2]).replaceWith("<td class='text-error'>Please try again</td>")
-      }
-
-    # prevent Rails UJS from doing anything else.
-    false
-
-  # refreshToolbar: =>
-  #   checked = $("input[type=checkbox].js-multicheck:checked:visible").length
-  #   if checked
-  #     $(".js-items-table-actions").css('display', 'inline-block')
-  #   else
-  #     $(".js-items-table-actions").css('display', 'none')
+  checker = (checked_value) ->
+    $('.js-multicheck').each (index, element) ->
+      jqueried_element = $('#' + element['id'])
+      jqueried_element.prop('checked', checked_value)

--- a/app/assets/stylesheets/snowcrash/modules/issues.scss
+++ b/app/assets/stylesheets/snowcrash/modules/issues.scss
@@ -50,7 +50,13 @@ body.issues.show {
     }
 
     .tabs-left > .nav-tabs > li > a {
-      min-width: auto;
+      min-width: 28px;
+    }
+    .tabs-left > .nav-tabs > .js-multicheck {
+      float: left;
+      margin-top: 12px;
+      margin-left: 5px;
+      margin-right: 5px;
     }
     .tab-content {
       padding: 1em 0 0 2em;

--- a/app/controllers/concerns/multiple_destroy.rb
+++ b/app/controllers/concerns/multiple_destroy.rb
@@ -5,13 +5,14 @@ module MultipleDestroy
     # cache these values
     @count = params[:ids].size
     @max_deleted_inline = ::Configuration.max_deleted_inline
+    kontroller = params[:custom_controller] || params[:controller]
 
     if @count > 0
       @job_logger = Log.new
       job_params = {
         author_email: current_user.email,
         ids: params[:ids],
-        klass: params[:controller].singularize.capitalize,
+        klass: kontroller.singularize.capitalize,
         project_id: current_project.id,
         uid: @job_logger.uid
       }
@@ -25,5 +26,8 @@ module MultipleDestroy
         MultiDestroyJob.perform_now(job_params)
       end
     end
+
+    return unless params[:notice]
+    flash[:notice] = params[:notice]
   end
 end

--- a/app/views/issues/_evidence.html.erb
+++ b/app/views/issues/_evidence.html.erb
@@ -11,12 +11,19 @@
   <% if @issue.affected.empty? %>
     <p>None so far.</p>
   <% else %>
+    <%= render partial: 'evidence_toolbar' %>
     <div class="tabbable tabs-left" id="evidence-tabs">
       <ul class="nav nav-tabs" id="evidence-host-list">
         <% @affected_nodes.each do |node| %>
           <% cache [@issue, node, node.evidence_count, 'evidence-nav'] do %>
             <li>
-              <a href="#evidence_for_<%= dom_id(node) %>" data-toggle="tab" data-path="<%= project_issue_node_path(current_project, @issue, node) %>" data-node="<%= "evidence_for_#{dom_id(node)}" %>">
+              <a href="#evidence_for_<%= dom_id(node) %>" data-toggle="tab"
+                data-path="<%= project_issue_node_path(current_project, @issue, node) %>"
+                data-node="<%= "evidence_for_#{dom_id(node)}" %>"
+                data-node-id="<%= node.id %>"
+                data-destroy-url="<%= multiple_destroy_project_node_evidence_index_path(node.project, node) %>"
+                data-redirect-to="<%= project_issue_path(node.project, @issue) %>"
+              >
                 <i class="fa fa-<%= ['folder-o','laptop'][node.type_id] %>"></i> <%= node.label %> (<%= node.evidence_count %>)
               </a>
             </li>

--- a/app/views/issues/_evidence_toolbar.html.erb
+++ b/app/views/issues/_evidence_toolbar.html.erb
@@ -1,12 +1,12 @@
 <div class="btn-toolbar">
   <div class="btn-group">
-     <span class="btn js-items-table-select-all" title="Select all">
+     <span class="btn js-issues-evidence-select-all" title="Select all">
        <input type="checkbox" id="issues-evidence-select-all" />
      </span>
   </div>
 
-  <div class="btn-group items-table-actions js-items-table-actions">
-    <a class="btn items-table-delete js-items-table-delete" data-confirm="Are you sure?" title="Delete selected">
+  <div class="btn-group js-issues-evidence-actions">
+    <a class="btn js-issues-evidence-delete" data-confirm="Are you sure?" title="Delete selected">
       <i class="fa fa-trash text-error"></i> Delete
     </a>
   </div>

--- a/app/views/issues/_evidence_toolbar.html.erb
+++ b/app/views/issues/_evidence_toolbar.html.erb
@@ -1,0 +1,13 @@
+<div class="btn-toolbar">
+  <div class="btn-group">
+     <span class="btn js-items-table-select-all" title="Select all">
+       <input type="checkbox" id="select-all" />
+     </span>
+  </div>
+
+  <div class="btn-group items-table-actions js-items-table-actions">
+    <a class="btn items-table-delete js-items-table-delete" data-confirm="Are you sure?" title="Delete selected">
+      <i class="fa fa-trash text-error"></i> Delete
+    </a>
+  </div>
+</div>

--- a/app/views/issues/_evidence_toolbar.html.erb
+++ b/app/views/issues/_evidence_toolbar.html.erb
@@ -1,7 +1,7 @@
 <div class="btn-toolbar">
   <div class="btn-group">
      <span class="btn js-items-table-select-all" title="Select all">
-       <input type="checkbox" id="select-all" />
+       <input type="checkbox" id="issues-evidence-select-all" />
      </span>
   </div>
 

--- a/app/views/issues/nodes/_evidence.html.erb
+++ b/app/views/issues/nodes/_evidence.html.erb
@@ -23,8 +23,8 @@
       <div class="tabbable tabs-left">
         <ul class="nav nav-tabs">
           <% instances.each_with_index do |instance, i| %>
+            <%= check_box_tag "checkbox_#{instance.id}", instance.id, false, class: 'js-multicheck' %>
             <li class="<%= 'active' if i==0 %>">
-              <%= check_box_tag "checkbox_#{instance.id}", instance.id, false, class: 'js-multicheck' %>
               <a href="#node_<%= node.id %>_instance_<%= instance.id %>" data-toggle="tab">#<%= i+1 %></a>
             </li>
           <% end %>

--- a/app/views/issues/nodes/_evidence.html.erb
+++ b/app/views/issues/nodes/_evidence.html.erb
@@ -23,7 +23,10 @@
       <div class="tabbable tabs-left">
         <ul class="nav nav-tabs">
           <% instances.each_with_index do |instance, i| %>
-            <li class="<%= 'active' if i==0 %>"><a href="#node_<%= node.id %>_instance_<%= instance.id %>" data-toggle="tab">#<%= i+1 %></a></li>
+            <li class="<%= 'active' if i==0 %>">
+              <%= check_box_tag "checkbox_#{instance.id}", instance.id, false, class: 'js-multicheck' %>
+              <a href="#node_<%= node.id %>_instance_<%= instance.id %>" data-toggle="tab">#<%= i+1 %></a>
+            </li>
           <% end %>
         </ul>
 

--- a/spec/features/issue_pages/evidence_spec.rb
+++ b/spec/features/issue_pages/evidence_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'issue-evidence page' do
+  before do
+    login_to_project_as_user
+
+    issue = create(:issue, node: current_project.issue_library, evidence: build_list(:evidence, 2, node: current_project.issue_library))
+
+    visit project_issue_path(current_project, issue)
+
+    click_link('Evidence')
+  end
+
+  describe 'delete multiple evidence', js: true do
+    it 'selects and deletes evidence from issue' do
+      find('#issues-evidence-select-all').click
+
+      find('.js-issues-evidence-delete').click
+
+      # "Are you sure?" dialog
+      page.driver.browser.switch_to.alert.accept
+
+      expect(page).to have_content 'Evidence deleted for selected nodes.'
+      expect(Evidence.count).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Currently if an Issue is associated with multiple Nodes or multiple Evidence, there is no easy way to bulk-delete the evidence from the Issues#show view, you have to either open each Evidence individually or open each Node and bulk-delete all Evidence for that Node.

This PR's aim is to make it possible bulk-delete Evidence from Issue#show.

### Other Information

There is a problem I ran into in the past few hours while going over this that I didn't have time to find a solution for yet. If the user clicks on a node other than the pre-selected node, the full desired checking functionality breaks for selecting individual checkboxes (the Delete button will not appear). Using the Select All checkbox still selects all the checkboxes and it is possible to first do that and then deselect individual checkboxes but it will not deselect the Select All checkbox. Refreshing the page is the only way to get it to work again for the pre-selected node after that. These problems don't exist for the pre-selected node.

At first I thought it might be a conflict with another event listener but it looks like no listeners are bound to the checkboxes which are not initially displayed so I think it may be related to their "visibility" when the page is first loaded. What do you all think?

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
