### PR TITLE
Fix secret key base

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -26,4 +26,4 @@ secret_token = (secret_token_file.exist? and secret_token_file.read.chomp) or (
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-Dradis::Application.config.secret_key_base = secret_token
+Dradis::Application.secrets.secret_key_base = secret_token


### PR DESCRIPTION
Fix this error:

```
DEPRECATION WARNING: You didn't set `secret_key_base`. Read the upgrade documentation to learn more about this new config option. (called from env_config at /Users/xavi/.rvm/gems/ruby-2.4.1/gems/railties-5.1.7/lib/rails/application.rb:247)
2019-06-04 09:49:11 +0100: Rack app error handling request { GET / }
#<RuntimeError: Missing `secret_key_base` for 'development' environment, set this value in `config/secrets.yml`>
```