### PR TITLE
Combine node feature

### DIFF
--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -312,6 +312,14 @@ body {
 
     .node-header {
 //      height: $breadCrumbHeight;
+
+      // Styling of the breadcrumbs menu items conflicts when trying to match
+      // dropdown style of the main navigation. The dropdown ends up always
+      // pulling right, off the screen. This pulls it left, and makes it visible
+      .dropdown-menu-more {
+        left: auto;
+        right: 0;
+      }
     }
     .breadcrumb {
       margin-bottom: 0;

--- a/app/controllers/nodes/merge_controller.rb
+++ b/app/controllers/nodes/merge_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Nodes::MergeController < NodesController
+  def create
+    source_node = Node.find(params[:node_id])
+
+    result = Nodes::Merger.call(params[:target_id], source_node) do
+      Node.destroy(source_node.id)
+    end
+
+    respond_to do |format|
+      format.html do
+        if result.empty?
+          target_node = Node.find(params[:target_id])
+          redirect_to project_node_path(current_project, params[:target_id]), notice: "#{source_node.label} merged into #{target_node.label}."
+        else
+          redirect_to project_node_path(current_project, source_node.id), alert: 'Could not merge nodes.'
+        end
+      end
+    end
+  end
+end

--- a/app/services/nodes/merger.rb
+++ b/app/services/nodes/merger.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Nodes::Merger
+  SOURCES = {
+    activities: :trackable_id,
+    children: :parent_id,
+    evidence: :node_id,
+    notes: :node_id
+  }.freeze
+
+  attr_accessor :target_node_id, :source_node, :source_attachments
+
+  def self.call(target_node_id, source_node, &block)
+    new(target_node_id, source_node).call(&block)
+  end
+
+  def initialize(target_node_id, source_node)
+    @source_attachments = source_node.attachments
+    @source_node = source_node
+    @target_node_id = target_node_id
+  end
+
+  def call(&block)
+    Node.transaction do
+      SOURCES.each do |relation, column|
+        source_node.send(relation).update_all(column => target_node_id)
+      end
+
+      Node.reset_counters target_node_id, :children_count
+      Node.reset_counters source_node.id, :children_count
+
+      source_node.attachments.each do |attachment|
+        attachment.node_id = target_node_id
+        attachment.save
+      end
+
+      yield if block
+
+      return []
+    end
+  rescue StandardError => e
+    Rails.logger.error 'Node merge error occured, attempting to rectify attachments.'
+    Rails.logger.error e.backtrace
+
+    undo_attachments_move
+
+    return [e.message]
+  end
+
+  def undo_attachments_move
+    source_attachments.each do |attachment|
+      next if File.exist? attachment.fullpath
+
+      saved_attachment = Attachment.find(attachment.filename,
+        conditions: { node_id: target_node_id })
+
+      saved_attachment.node_id = source_node.id
+      saved_attachment.save
+    end
+  end
+end

--- a/app/services/nodes/merger.rb
+++ b/app/services/nodes/merger.rb
@@ -8,31 +8,20 @@ class Nodes::Merger
     notes: :node_id
   }.freeze
 
-  attr_accessor :target_node_id, :source_node, :source_attachments
-
   def self.call(target_node_id, source_node, &block)
     new(target_node_id, source_node).call(&block)
   end
 
   def initialize(target_node_id, source_node)
-    @source_attachments = source_node.attachments
     @source_node = source_node
     @target_node_id = target_node_id
   end
 
   def call(&block)
     Node.transaction do
-      SOURCES.each do |relation, column|
-        source_node.send(relation).update_all(column => target_node_id)
-      end
-
-      Node.reset_counters target_node_id, :children_count
-      Node.reset_counters source_node.id, :children_count
-
-      source_node.attachments.each do |attachment|
-        attachment.node_id = target_node_id
-        attachment.save
-      end
+      move_descendents
+      reset_counter_caches
+      move_attachments
 
       yield if block
 
@@ -47,15 +36,39 @@ class Nodes::Merger
     return [e.message]
   end
 
-  def undo_attachments_move
-    source_attachments.each do |attachment|
-      next if File.exist? attachment.fullpath
+  private
 
-      saved_attachment = Attachment.find(attachment.filename,
-        conditions: { node_id: target_node_id })
+    attr_accessor :target_node_id, :source_node, :source_attachments
 
-      saved_attachment.node_id = source_node.id
-      saved_attachment.save
+    def move_descendents
+      SOURCES.each do |relation, column|
+        source_node.send(relation).update_all(column => target_node_id)
+      end
     end
-  end
+
+    def reset_counter_caches
+      Node.reset_counters target_node_id, :children_count
+      Node.reset_counters source_node.id, :children_count
+    end
+
+    def move_attachments
+      self.source_attachments = source_node.attachments
+
+      source_node.attachments.each do |attachment|
+        attachment.node_id = target_node_id
+        attachment.save
+      end
+    end
+
+    def undo_attachments_move
+      source_attachments.each do |attachment|
+        next if File.exist? attachment.fullpath
+
+        saved_attachment = Attachment.find(attachment.filename,
+          conditions: { node_id: target_node_id })
+
+        saved_attachment.node_id = source_node.id
+        saved_attachment.save
+      end
+    end
 end

--- a/app/views/layouts/snowcrash/_breadcrumb.html.erb
+++ b/app/views/layouts/snowcrash/_breadcrumb.html.erb
@@ -16,6 +16,7 @@
         <ul class="dropdown-menu dropdown-menu-more">
           <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
           <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
+          <li><a href="#modal_merge_node" tabindex="-1" data-toggle="modal"><i class="fa fa-object-group"></i> Merge</a></li>
           <li><a href="#modal_delete_node" tabindex="-1" data-toggle="modal"><span class="text-error"><i class="fa fa-trash"></i> Delete</span></a></li>
         </ul>
       </li>
@@ -28,6 +29,7 @@
 <%= render partial: 'nodes/modals/delete' %>
 <%= render partial: 'nodes/modals/rename' %>
 <%= render partial: 'nodes/modals/move' %>
+<%= render partial: 'nodes/modals/merge' %>
 <% end %>
 
 <% if content_for?(:breadcrums) %>

--- a/app/views/layouts/snowcrash/_breadcrumb.html.erb
+++ b/app/views/layouts/snowcrash/_breadcrumb.html.erb
@@ -11,9 +11,14 @@
   <div class="span6">
     <ul class="nav nav-pills pull-right">
       <li><a href="#modal_add_child_node" tabindex="-1" data-toggle="modal"><i class="fa fa-plus"></i> Add subnode</a></li>
-      <li><a href="#modal_delete_node" class="text-error" tabindex="-1" data-toggle="modal"><i class="fa fa-trash"></i> Delete</a></li>
-      <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
-      <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" data-behavior="nodes-more-dropdown"><i class="fa fa-bars fa-lg"></i><b class="caret"></b></a>
+        <ul class="dropdown-menu dropdown-menu-more">
+          <li><a href="#modal_rename_node" tabindex="-1" data-toggle="modal"><i class="fa fa-edit"></i> Rename</a></li>
+          <li><a href="#modal_move_node" tabindex="-1" data-toggle="modal"><i class="fa fa-mail-forward"></i> Move</a></li>
+          <li><a href="#modal_delete_node" tabindex="-1" data-toggle="modal"><span class="text-error"><i class="fa fa-trash"></i> Delete</span></a></li>
+        </ul>
+      </li>
     </ul>
   </div>
 </div>

--- a/app/views/nodes/modals/_merge.html.erb
+++ b/app/views/nodes/modals/_merge.html.erb
@@ -1,0 +1,24 @@
+<div id="modal_merge_node" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <%= form_tag project_node_merge_path(current_project, @node), class: 'form-horizontal modal-node-selection-form', data: { node_id: @node.id, hidden_field: '#target_id' } do |f| %>
+    <%= hidden_field_tag :target_id %>
+
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+      <h3 id="myModalLabel">Merge <%= @node.label %> node</h3>
+    </div>
+    <div class="modal-body">
+      <p>Which node do you want to merge <strong><%= @node.label %></strong> into?</p>
+
+      <div class="tree-modal-box">
+        <%= render "layouts/snowcrash/nodes" %>
+      </div>
+      <p id="merge-under">
+        <span>This will merge <strong><%= @node.label %></strong> into: <strong><span id="current-selection"></span></strong></span>
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary">Merge</button>
+      <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
         get :tree
       end
 
+      resource :merge, only: [:create], controller: 'nodes/merge'
+
       resources :notes, concerns: :multiple_destroy do
         resources :revisions, only: [:index, :show]
       end

--- a/spec/features/evidence_spec.rb
+++ b/spec/features/evidence_spec.rb
@@ -57,6 +57,7 @@ describe "evidence" do
     describe "clicking 'delete'", js: true do
       let(:submit_form) do
         page.accept_confirm do
+          find('[data-behavior~=nodes-more-dropdown]').click
           within('.note-text-inner') { click_link "Delete" }
         end
         expect(page).to have_text "Successfully deleted evidence for '#{@evidence.issue.title}.'"

--- a/spec/features/node_merging_spec.rb
+++ b/spec/features/node_merging_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'merging a node', js: true do
+
+  subject { page }
+
+  let(:root_node) { create(:node) }
+
+  before do
+    login_to_project_as_user
+  end
+
+  let!(:source_node) { create(:node, label: 'Node-1', parent_id: root_node, project: current_project) }
+  let!(:target_node) { create(:node, label: 'Node-2', parent_id: root_node, project: current_project) }
+
+  before do
+    visit project_node_path(source_node.project, source_node)
+    find('[data-behavior~=nodes-more-dropdown]').click
+    click_link 'Merge'
+  end
+
+  it 'redirects to the target node' do
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect(current_path).to eq project_node_path(current_project, target_node)
+  end
+
+  it 'moves notes to target node' do
+    note = create(:note, node: source_node)
+
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect(target_node.notes).to include note
+    expect(current_path).to eq project_node_path(current_project, target_node)
+  end
+
+  it 'moves evidence to target node' do
+    evidence = create(:evidence, node: source_node)
+
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect(target_node.evidence).to include evidence
+  end
+
+  it 'moves activity to target node' do
+    activity = create(:activity, trackable: source_node)
+
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect(target_node.activities).to include activity
+  end
+
+  it 'moves children to target node' do
+    child_node = create(:node, parent: source_node)
+
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect(target_node.children).to include child_node
+  end
+
+  it 'moves attachments to target node' do
+    create(:attachment, node: source_node)
+
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect(target_node.reload.attachments.count).to eq 1
+  end
+
+  it 'destroys the source node' do
+    within_merge_node_modal do
+      click_link(target_node.label)
+      find_button('Merge').click
+    end
+
+    expect { Node.find(source_node.id) }.to raise_error ActiveRecord::RecordNotFound
+  end
+
+  def within_merge_node_modal
+    within('#modal_merge_node') { yield }
+  end
+end

--- a/spec/features/node_moving_spec.rb
+++ b/spec/features/node_moving_spec.rb
@@ -27,6 +27,7 @@ describe "moving a node", js: true do
 
   before do
     visit project_node_path(current_node.project, current_node)
+    find('[data-behavior~=nodes-more-dropdown]').click
     click_link "Move"
   end
 

--- a/spec/features/node_pages/polling_spec.rb
+++ b/spec/features/node_pages/polling_spec.rb
@@ -261,7 +261,10 @@ describe "node pages", js: true do
   end
 
   def show_move_node_modal
-    click_link "Move" unless move_modal_visible?
+    if !move_modal_visible?
+      find('[data-behavior~=nodes-more-dropdown]').click
+      click_link "Move"
+    end
   end
 
   def move_modal_visible?

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -184,6 +184,7 @@ describe "node pages" do
     before do
       @node = create(:node, label: "My node", project: current_project)
       visit project_node_path(@node.project, @node)
+      find('[data-behavior~=nodes-more-dropdown]').click
       click_link "Rename"
     end
 
@@ -229,6 +230,7 @@ describe "node pages" do
     before do
       @node = create(:node, label: "My node", project: current_project)
       visit project_node_path(@node.project, @node)
+      find('[data-behavior~=nodes-more-dropdown]').click
       click_link "Delete"
     end
 

--- a/spec/features/note_pages_spec.rb
+++ b/spec/features/note_pages_spec.rb
@@ -57,7 +57,9 @@ describe "note pages" do
     describe "clicking 'delete'", js: true do
       let(:submit_form) do
         page.accept_confirm do
-          within('.note-text-inner') { click_link 'Delete' }
+          within('.note-text-inner') do
+            click_link 'Delete'
+          end
         end
         expect(page).to have_text 'Note deleted'
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -112,6 +112,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
+    Attachment.all.each(&:delete)
   end
 end
 

--- a/spec/services/nodes/merger_spec.rb
+++ b/spec/services/nodes/merger_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Nodes::Merger do
+  describe '.call' do
+    subject(:merge_nodes) { described_class.call(target_node.id, source_node) }
+
+    let(:root_node) { create(:node) }
+    let(:source_node) { create(:node, parent_id: root_node) }
+    let(:target_node) { create(:node, parent_id: root_node) }
+
+    it { should match_array [] }
+
+    it 'moves notes to target node', :aggregate_failures do
+      note = create(:note, node: source_node)
+
+      expect { merge_nodes }.to change(target_node.notes, :count).by 1
+      expect(target_node.notes).to include note
+    end
+
+    it 'moves evidence to target node', :aggregate_failures do
+      evidence = create(:evidence, node: source_node)
+
+      expect { merge_nodes }.to change(target_node.evidence, :count).by 1
+      expect(target_node.evidence).to include evidence
+    end
+
+    it 'moves activities to target node', :aggregate_failures do
+      activity = create(:activity, trackable: source_node)
+
+      expect { merge_nodes }.to change(target_node.activities, :count).by 1
+      expect(target_node.activities).to include activity
+    end
+
+    it 'moves children to target node', :aggregate_failures do
+      child_node = create(:node, parent: source_node)
+
+      expect { merge_nodes }.to change(target_node.children, :count).by 1
+      expect(target_node.children).to include child_node
+    end
+
+    it "updates the source node's children counter cache" do
+      create(:node, parent: source_node)
+
+      expect { merge_nodes }.to change { source_node.reload.children_count }.by -1
+    end
+
+    it "updates the target node's children counter cache" do
+      create(:node, parent: source_node)
+
+      expect { merge_nodes }.to change { target_node.reload.children_count }.by 1
+    end
+
+    it "move's attachments to target node", :aggregate_failures do
+      attachment = create(:attachment, node: source_node)
+
+      expect { merge_nodes }.to change { target_node.attachments.count }.by 1
+      expect(File.exist?(attachment.fullpath)).to be false
+    end
+
+    it 'executes a given block within the transaction' do
+      block = double
+      expect(block).to receive(:called!)
+
+      described_class.call(target_node.id, source_node) do
+        block.called!
+      end
+    end
+
+    describe 'when an error is raised' do
+      subject(:merge_nodes) {
+        described_class.call(target_node.id, source_node) do
+          raise StandardError
+        end
+      }
+
+      it { should match_array ['StandardError'] }
+
+      it 'source retains notes', :aggregate_failures do
+        note = create(:note, node: source_node)
+
+        expect { merge_nodes }.not_to change(source_node.notes, :count)
+        expect(target_node.notes).not_to include note
+      end
+
+      it 'source retains evidence', :aggregate_failures do
+        evidence = create(:evidence, node: source_node)
+
+        expect { merge_nodes }.not_to change(source_node.evidence, :count)
+        expect(target_node.evidence).not_to include evidence
+      end
+
+      it 'source retains activities', :aggregate_failures do
+        activity = create(:activity, trackable: source_node)
+
+        expect { merge_nodes }.not_to change(source_node.activities, :count)
+        expect(target_node.activities).not_to include activity
+      end
+
+      it 'source retains children', :aggregate_failures do
+        child_node = create(:node, parent: source_node)
+
+        expect { merge_nodes }.not_to change(source_node.children, :count)
+        expect(target_node.children).not_to include child_node
+      end
+
+      it 'no changes to counter caches' do
+        create(:node, parent: source_node)
+
+        expect { merge_nodes }.not_to change { source_node.reload.children_count }
+        expect { merge_nodes }.not_to change { target_node.reload.children_count }
+      end
+
+      it 'source retains attachments', :aggregate_failures do
+        attachment = create(:attachment, node: source_node)
+
+        expect { merge_nodes }.not_to change { target_node.attachments.count }
+        expect(File.exist?(attachment.fullpath)).to be true
+      end
+    end
+  end
+end

--- a/spec/support/revision_shared_examples.rb
+++ b/spec/support/revision_shared_examples.rb
@@ -53,6 +53,7 @@ shared_examples "recover deleted item without node" do |item_type|
     with_versioning do
       submit_form
       visit project_node_path(model.node.project, model.node.id)
+      find('[data-behavior~=nodes-more-dropdown]').click
       click_link 'Delete'
       within '#modal_delete_node' do
         click_link 'Delete'


### PR DESCRIPTION
## Spec

At the moment when you create a Node in the tree you can only move it around to a different part of the tree.

There are situations in which you create a Node, for example for IP 10.0.0.1 and add some data to it, and then you realise that a node already existed for that IP somewhere in the tree.

There is no way to move the Notes, Evidence and Attachments associated with a node to another node.

## Proposed solution

A new "Merge" action should be added to the node's actions bar that would move associated: Notes, Evidence, Attachment and Activities from the source node into the target node.

Upon clicking that action, a modal similar to the one triggered by the Move action will be displayed so the user can chose the target node for the combine operation.

The source node will be deleted after the combine.

## How to test
1. Create new nodes to test with by using the `+` button to open a new node modal.
    <img width="241" alt="image" src="https://user-images.githubusercontent.com/179134/59050893-d82a6700-888b-11e9-875d-f5d759dc36d8.png">
2. In the modal select "Add multiple" and add two new node names. One on each line.
    <img width="587" alt="image" src="https://user-images.githubusercontent.com/179134/59051119-6d2d6000-888c-11e9-85e9-f8e876514f90.png">
3. Navigate to you duplicated node.
4. Add a new note, piece of evidence, and an attachment.
5. Now utilize the new "burger" menu on the top right of the screen and select "Merge"
    ![burger-menu](https://user-images.githubusercontent.com/179134/59051369-03618600-888d-11e9-87dc-f147e00659c0.gif)
6. Select the node you wish to Merge the current duplicate into, and than press "Merge"
    <img width="564" alt="image" src="https://user-images.githubusercontent.com/179134/59051426-255b0880-888d-11e9-9a65-1441e661b0a4.png">
7. Now you should be redirected to the Node you had selected to merge into.
8. The note, evidence, and attachment from the duplicate will now be present on your current node.

## Example Usage

### Successful merge
 - In this example `Subnode - 1.1.1.1` contains no additional notes, evidence, or attachments.
 - `Subnode Dup - 1.1.1.1` contains a single piece of evidence, a note, and an attachment.
 - `Subnode Dup - 1.1.1.1`'s evidence, note, and attachment will all be merged over to `Subnode - 1.1.1.1`
 - The page will redirect to `Subnode - 1.1.1.1`
![dradis-combine-node-success](https://user-images.githubusercontent.com/179134/59050639-1b380a80-888b-11e9-82ca-0722b6d206b4.gif)

### Failed merge
![dradis-combine-node-error](https://user-images.githubusercontent.com/179134/59050661-2854f980-888b-11e9-81cd-5d28496e9afe.gif)