### PR TITLE
Collapsable issues

### DIFF
--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -179,4 +179,5 @@ document.addEventListener "turbolinks:load", ->
     $('[data-behavior~=collapse-collection]').click ->
       $this = $(this)
       $this.find('[data-behavior~=toggle-chevron]').toggleClass('fa-chevron-down fa-chevron-up')
-      $('[data-behavior~=import-box]').find("input[type='text']:first").focus()
+      if $('[data-behavior~=import-box]').length
+        $('[data-behavior~=import-box]').find("input[type='text']:first").focus()

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -175,9 +175,8 @@ document.addEventListener "turbolinks:load", ->
     $('.form-search').submit()
 
   # Collapsable div in sidebar collections
-  if $('body.issues, body.nodes, body.cards').length
+  if $('[data-behavior~=collapse-collection]').length
     $('[data-behavior~=collapse-collection]').click ->
       $this = $(this)
       $this.find('[data-behavior~=toggle-chevron]').toggleClass('fa-chevron-down fa-chevron-up')
       $('[data-behavior~=import-box]').find("input[type='text']:first").focus()
-      

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -156,7 +156,6 @@ document.addEventListener "turbolinks:load", ->
   $('form').submit (ev)->
     $('input[type=submit]', this).attr('disabled', 'disabled').val('Processing...')
 
-
   # Search form
   $('#js-search-form-toggle').on 'click', (e)->
     e.preventDefault()
@@ -174,3 +173,11 @@ document.addEventListener "turbolinks:load", ->
 
   $('.navbar .btn-search').on 'click', ->
     $('.form-search').submit()
+
+  # Collapsable div in sidebar collections
+  if $('body.issues, body.nodes, body.cards').length
+    $('[data-behavior~=collapse-collection]').click ->
+      $this = $(this)
+      $this.find('[data-behavior~=toggle-chevron]').toggleClass('fa-chevron-down fa-chevron-up')
+      $('[data-behavior~=import-box]').find("input[type='text']:first").focus()
+      

--- a/app/assets/javascripts/snowcrash/modules/issues.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues.js.coffee
@@ -3,10 +3,3 @@
 //= require snowcrash/modules/issues/merge
 //= require snowcrash/modules/issues/table
 //= require snowcrash/modules/issues/tag-input
-
-document.addEventListener "turbolinks:load", ->
-  if $('body.issues, body.nodes, body.cards').length
-    $('.import-toggle').click ->
-      $this = $(this)
-      $this.find('i').toggleClass('fa-chevron-down fa-chevron-up')
-      $($this.data('target')).find("input[type='text']:first").focus()

--- a/app/assets/javascripts/snowcrash/modules/issues.js.coffee
+++ b/app/assets/javascripts/snowcrash/modules/issues.js.coffee
@@ -5,7 +5,7 @@
 //= require snowcrash/modules/issues/tag-input
 
 document.addEventListener "turbolinks:load", ->
-  if $('body.issues').length
+  if $('body.issues, body.nodes, body.cards').length
     $('.import-toggle').click ->
       $this = $(this)
       $this.find('i').toggleClass('fa-chevron-down fa-chevron-up')

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -399,12 +399,12 @@ body {
         padding: 1em;
         min-height: 600px;
 
-        .collapsable-collection {
+        /*.collapsable-collection {
           height: auto;
           max-height: 60vh;
           overflow-y: scroll;
           margin-bottom: .5em;
-        }
+        }*/
 
         .header-inner {
           position: relative;

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -537,7 +537,13 @@ body {
 }
 
 .attachments-box {
-  .table {margin-bottom: 0}
+  .table {
+    margin-bottom: 0;
+    
+    td {
+      border: none;
+    }
+  }
 
   .btn {
     box-shadow: none;

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -403,9 +403,13 @@ body {
         .header-inner {
           position: relative;
           .options {
-            position: absolute;
-            top: 0;
-            right: 0;
+            .dropdown {
+              float: right;
+              margin-left: 2px;
+              position: absolute;
+              top: 0;
+              right: 0;
+            }
           }
 
 

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -399,6 +399,12 @@ body {
         padding: 1em;
         min-height: 600px;
 
+        .collapsable-collection {
+          height: auto;
+          max-height: 60vh;
+          overflow-y: scroll;
+          margin-bottom: .5em;
+        }
 
         .header-inner {
           position: relative;
@@ -541,6 +547,7 @@ body {
     }
   }
 }
+
 .drop-zone {
   @include rounded;
   background: lighten($secondaryNavBarBgColor, 10%);

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -149,7 +149,7 @@ table.table-ajax-inputs {
   }
 }
 
-#issues {
+#issues, #notes, #evidence, #tasks {
   height: auto;
   max-height: 60vh;
   overflow-y: scroll;

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -148,3 +148,10 @@ table.table-ajax-inputs {
     }
   }
 }
+
+#issues {
+  height: auto;
+  max-height: 60vh;
+  overflow-y: scroll;
+  margin-bottom: .5em;
+}

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -148,10 +148,3 @@ table.table-ajax-inputs {
     }
   }
 }
-
-.collapsable-collection {
-  height: auto;
-  max-height: 60vh;
-  overflow-y: scroll;
-  margin-bottom: .5em;
-}

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -30,6 +30,11 @@
 
 .note-list {
   margin-bottom: 2em;
+
+  &.collapse {
+    margin-bottom: .5em;
+  }
+
   .list-item {
     line-height: 2em;
     padding-left: 1ex;

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -87,6 +87,7 @@
     &.placeholder {
       color: #ccc;
       font-style: italic;
+      margin-bottom: 2rem;
     }
     .remove-note {
       visibility: hidden;

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -149,7 +149,7 @@ table.table-ajax-inputs {
   }
 }
 
-#issues, #notes, #evidence, #tasks {
+.collapsable-collection {
   height: auto;
   max-height: 60vh;
   overflow-y: scroll;

--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -29,7 +29,7 @@
               <i class="fa fa-paperclip"></i> <%= short_filename(attachment.filename) %>
               <% end %>
 
-              <div class="text-right">
+              <span class="pull-right">
                 <span class="size">
                   <small><%= number_to_human_size(File.size(attachment)) %></small>
                 </span>
@@ -50,7 +50,7 @@
                 >
                   <i class="fa fa-link"></i>
                 </button>
-              </div>
+              </span>
             </div>
           </td>
         </tr>

--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -1,90 +1,101 @@
 <% node = @node || @issuelib %>
 
 <div class="attachments-box jquery-upload">
+
   <div class="header">
     <div class="header-inner">
+      <div class="options">
+        <div class="dropdown">
+          <%= link_to 'javascript:void(0)', 
+            data: { toggle: 'collapse', target: '#attachment-box', behavior: 'collapse-collection' } do %>
+            <i class="fa fa-chevron-up" data-behavior="toggle-chevron"></i>
+          <% end %>
+        </div>
+      </div>
       <h3>Attachments</h3>
     </div>
   </div>
 
-  <!-- The table listing the files available for upload/download -->
-  <table class="table">
-    <tbody class="files" data-toggle="modal-gallery" data-target="#modal-gallery">
-      <% if node.attachments.any? %>
-        <% for attachment in node.attachments do %>
-      <tr class="template-download">
-        <td class="name" colspan="4">
-          <div>
-            <%= link_to project_node_attachment_path(node.project, node, attachment.filename), download: attachment.filename, title: attachment.filename do %>
-            <i class="fa fa-paperclip"></i> <%= short_filename(attachment.filename) %>
-            <% end %>
+  <div class="in collapse" id="attachment-box">
+    <!-- The table listing the files available for upload/download -->
+    <table class="table">
+      <tbody class="files" data-toggle="modal-gallery" data-target="#modal-gallery">
+        <% if node.attachments.any? %>
+          <% for attachment in node.attachments do %>
+        <tr class="template-download">
+          <td class="name" colspan="4">
+            <div>
+              <%= link_to project_node_attachment_path(node.project, node, attachment.filename), download: attachment.filename, title: attachment.filename do %>
+              <i class="fa fa-paperclip"></i> <%= short_filename(attachment.filename) %>
+              <% end %>
 
-            <div class="text-right">
-              <span class="size">
-                <small><%= number_to_human_size(File.size(attachment)) %></small>
-              </span>
+              <div class="text-right">
+                <span class="size">
+                  <small><%= number_to_human_size(File.size(attachment)) %></small>
+                </span>
 
-              <span class="delete">
+                <span class="delete">
+                  <button
+                    class="btn btn-transparent btn-danger"
+                    data-type="DELETE"
+                    data-url="<%= project_node_attachment_path(node.project, node, attachment.filename) %>"
+                  >
+                    <i class="fa fa-trash"></i>
+                  </button>
+                </span>
+
                 <button
-                  class="btn btn-transparent btn-danger"
-                  data-type="DELETE"
-                  data-url="<%= project_node_attachment_path(node.project, node, attachment.filename) %>"
+                  class="btn btn-transparent js-attachment-url-copy"
+                  data-clipboard-text="!<%= project_node_attachment_path(node.project, node, attachment.filename) %>!"
                 >
-                  <i class="fa fa-trash"></i>
+                  <i class="fa fa-link"></i>
                 </button>
-              </span>
-
-              <button
-                class="btn btn-transparent js-attachment-url-copy"
-                data-clipboard-text="!<%= project_node_attachment_path(node.project, node, attachment.filename) %>!"
-              >
-                <i class="fa fa-link"></i>
-              </button>
+              </div>
             </div>
-          </div>
-        </td>
-      </tr>
+          </td>
+        </tr>
+          <% end %>
+        <% else %>
+          <%# display some sort of Nothing yet message %>
         <% end %>
-      <% else %>
-        <%# display some sort of Nothing yet message %>
-      <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
 
-  <div id="drop-zone" class="drop-zone" dropzone="" data-toggle="tooltip" data-placement="right" title="Drag attachments from your desktop and drop them here" ondrop="">Drop zone</div>
+    <div id="drop-zone" class="drop-zone" dropzone="" data-toggle="tooltip" data-placement="right" title="Drag attachments from your desktop and drop them here" ondrop="">Drop zone</div>
 
-  <!-- The file upload form used as target for the file upload widget -->
-  <%= form_tag project_node_attachments_path(node.project, node, format: :json), id: 'fileupload', multipart: true do %>
+    <!-- The file upload form used as target for the file upload widget -->
+    <%= form_tag project_node_attachments_path(node.project, node, format: :json), id: 'fileupload', multipart: true do %>
 
-    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
-    <div class="row-fluid fileupload-buttonbar">
-      <div class="span8">
-        <!-- The fileinput-button span is used to style the file input field as button -->
-        <span class="btn btn-success fileinput-button" data-toggle="tooltip" data-placement="bottom" title="Add...">
-          <i class="fa fa-plus fa-inverse"></i>
-          <span></span>
-          <input type="file" name="files[]" multiple>
-        </span>
-        <button type="submit" class="btn btn-primary start" data-toggle="tooltip" data-placement="bottom" title="Start">
-          <i class="fa fa-upload fa-inverse"></i>
-          <span></span>
-        </button>
-        <button type="reset" class="btn btn-warning cancel" data-toggle="tooltip" data-placement="bottom" title="Cancel">
-          <i class="fa fa-ban fa-inverse"></i>
-          <span></span>
-        </button>
-      </div>
+      <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+      <div class="row-fluid fileupload-buttonbar">
+        <div class="span8">
+          <!-- The fileinput-button span is used to style the file input field as button -->
+          <span class="btn btn-success fileinput-button" data-toggle="tooltip" data-placement="bottom" title="Add...">
+            <i class="fa fa-plus fa-inverse"></i>
+            <span></span>
+            <input type="file" name="files[]" multiple>
+          </span>
+          <button type="submit" class="btn btn-primary start" data-toggle="tooltip" data-placement="bottom" title="Start">
+            <i class="fa fa-upload fa-inverse"></i>
+            <span></span>
+          </button>
+          <button type="reset" class="btn btn-warning cancel" data-toggle="tooltip" data-placement="bottom" title="Cancel">
+            <i class="fa fa-ban fa-inverse"></i>
+            <span></span>
+          </button>
+        </div>
 
-      <div class="span4">
-        <!-- The global progress bar -->
-        <div class="progress progress-success progress-striped active fade">
-           <div class="bar" style="width:0%;"></div>
+        <div class="span4">
+          <!-- The global progress bar -->
+          <div class="progress progress-success progress-striped active fade">
+            <div class="bar" style="width:0%;"></div>
+          </div>
         </div>
       </div>
-    </div>
-    <!-- The loading indicator is shown during image processing -->
-    <div class="fileupload-loading"></div>
-  <% end %>
+      <!-- The loading indicator is shown during image processing -->
+      <div class="fileupload-loading"></div>
+    <% end %>
+  </div>
 
 </div>
 

--- a/app/views/issues/_import_box.html.erb
+++ b/app/views/issues/_import_box.html.erb
@@ -2,7 +2,12 @@
   <div class="header-inner">
     <div class="options">
       <div class="dropdown">
-        <%= link_to raw('<i class="fa fa-chevron-down" data-behavior="toggle-chevron"></i>'), 'javascript:void(0)', class: 'import-toggle', data: { toggle: 'collapse', target: '.import-box', behavior: 'collapse-collection' } %>
+
+        <%= link_to 'javascript:void(0)', 
+          class: 'import-toggle', 
+          data: { toggle: 'collapse', target: '.import-box', behavior: 'collapse-collection' } do %>
+          <i class="fa fa-chevron-down" data-behavior="toggle-chevron"></i>
+        <% end %>
       </div>
     </div>
     <h3>Import issues</h3>

--- a/app/views/issues/_import_box.html.erb
+++ b/app/views/issues/_import_box.html.erb
@@ -5,7 +5,7 @@
 
         <%= link_to 'javascript:void(0)', 
           class: 'import-toggle', 
-          data: { toggle: 'collapse', target: '.import-box', behavior: 'collapse-collection' } do %>
+          data: { toggle: 'collapse', target: '#import-box', behavior: 'collapse-collection' } do %>
           <i class="fa fa-chevron-down" data-behavior="toggle-chevron"></i>
         <% end %>
       </div>
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<%= content_tag :div, class: 'import-box collapse', data: { behavior: 'import-box'} do %>
+<%= content_tag :div, class: 'import-box collapse', id: 'import-box', data: { behavior: 'import-box'} do %>
   <% Dradis::Plugins::with_feature(:import).each do |plugin| %>
   <div>
     <h5><%= plugin.plugin_description %></h5>

--- a/app/views/issues/_import_box.html.erb
+++ b/app/views/issues/_import_box.html.erb
@@ -2,14 +2,14 @@
   <div class="header-inner">
     <div class="options">
       <div class="dropdown">
-        <%= link_to raw('<i class="fa fa-chevron-down"></i>'), 'javascript:void(0)', class: 'import-toggle', data: { toggle: 'collapse', target: '.import-box' } %>
+        <%= link_to raw('<i class="fa fa-chevron-down" data-behavior="toggle-chevron"></i>'), 'javascript:void(0)', class: 'import-toggle', data: { toggle: 'collapse', target: '.import-box', behavior: 'collapse-collection' } %>
       </div>
     </div>
     <h3>Import issues</h3>
   </div>
 </div>
 
-<%= content_tag :div, class: 'import-box collapse' do %>
+<%= content_tag :div, class: 'import-box collapse', data: { behavior: 'import-box'} do %>
   <% Dradis::Plugins::with_feature(:import).each do |plugin| %>
   <div>
     <h5><%= plugin.plugin_description %></h5>

--- a/app/views/shared/_add_item_dropdown.html.erb
+++ b/app/views/shared/_add_item_dropdown.html.erb
@@ -5,6 +5,14 @@
     <i class="fa fa-plus"> </i> <%= local_assigns.fetch(:text, '') %>
   <% end %>
 
+  <% if name == 'Issues' %>
+    <%= link_to 'javascript:void(0)', 
+      class: 'import-toggle', 
+      data: { toggle: 'collapse', target: '#issues' } do %>
+      <i class="fa fa-chevron-up"></i>
+    <% end %>
+  <% end %>
+
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_class, '') %>" role="menu">
     <li>
       <%= link_to 'Empty (no template)',

--- a/app/views/shared/_add_item_dropdown.html.erb
+++ b/app/views/shared/_add_item_dropdown.html.erb
@@ -6,7 +6,6 @@
   <% end %>
 
   <%= link_to 'javascript:void(0)', 
-    class: 'import-toggle', 
     data: { toggle: 'collapse', target: "##{name.downcase}", behavior: 'collapse-collection' } do %>
     <i class="fa fa-chevron-up" data-behavior="toggle-chevron"></i>
   <% end %>

--- a/app/views/shared/_add_item_dropdown.html.erb
+++ b/app/views/shared/_add_item_dropdown.html.erb
@@ -7,8 +7,8 @@
 
   <%= link_to 'javascript:void(0)', 
     class: 'import-toggle', 
-    data: { toggle: 'collapse', target: "##{name.downcase}" } do %>
-    <i class="fa fa-chevron-up"></i>
+    data: { toggle: 'collapse', target: "##{name.downcase}", behavior: 'collapse-collection' } do %>
+    <i class="fa fa-chevron-up" data-behavior="toggle-chevron"></i>
   <% end %>
 
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_class, '') %>" role="menu">

--- a/app/views/shared/_add_item_dropdown.html.erb
+++ b/app/views/shared/_add_item_dropdown.html.erb
@@ -5,12 +5,10 @@
     <i class="fa fa-plus"> </i> <%= local_assigns.fetch(:text, '') %>
   <% end %>
 
-  <% if name == 'Issues' %>
-    <%= link_to 'javascript:void(0)', 
-      class: 'import-toggle', 
-      data: { toggle: 'collapse', target: '#issues' } do %>
-      <i class="fa fa-chevron-up"></i>
-    <% end %>
+  <%= link_to 'javascript:void(0)', 
+    class: 'import-toggle', 
+    data: { toggle: 'collapse', target: "##{name.downcase}" } do %>
+    <i class="fa fa-chevron-up"></i>
   <% end %>
 
   <ul class="dropdown-menu <%= local_assigns.fetch(:menu_class, '') %>" role="menu">

--- a/app/views/shared/_sidebar_collection.html.erb
+++ b/app/views/shared/_sidebar_collection.html.erb
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<div id="<%= name.downcase %>" class="note-list collapsable-collection in collapse">
+<div id="<%= name.downcase %>" class="note-list in collapse">
   <% if collection.any? %>
     <%= render partial: collection.first.to_partial_path, collection: collection %>
   <% end %>

--- a/app/views/shared/_sidebar_collection.html.erb
+++ b/app/views/shared/_sidebar_collection.html.erb
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<div id="<%= name.downcase %>" class="note-list <%= 'in collapse' if name == 'Issues' %>">
+<div id="<%= name.downcase %>" class="note-list in collapse">
   <% if collection.any? %>
     <%= render partial: collection.first.to_partial_path, collection: collection %>
   <% end %>

--- a/app/views/shared/_sidebar_collection.html.erb
+++ b/app/views/shared/_sidebar_collection.html.erb
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<div id="<%= name.downcase %>" class="note-list">
+<div id="<%= name.downcase %>" class="note-list <%= 'in collapse' if name == 'Issues' %>">
   <% if collection.any? %>
     <%= render partial: collection.first.to_partial_path, collection: collection %>
   <% end %>

--- a/app/views/shared/_sidebar_collection.html.erb
+++ b/app/views/shared/_sidebar_collection.html.erb
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<div id="<%= name.downcase %>" class="note-list in collapse">
+<div id="<%= name.downcase %>" class="note-list collapsable-collection in collapse">
   <% if collection.any? %>
     <%= render partial: collection.first.to_partial_path, collection: collection %>
   <% end %>


### PR DESCRIPTION
Currently, when viewing issues, the list of issues in the sidebar can get quite long, causing the "Import issues" dropdown to be far down in the view. 

This PR adds the capability to collapse the issues list, which results in quick and easy access to the "Import issues" dropdown. The list of issues, when expanded, is now limited in size and is scrollable.