### PR TITLE
Selenium deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,12 +183,12 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'capybara', '~> 3.6.0'
-  gem 'chromedriver-helper'
+  gem 'capybara'
   gem 'guard-rspec', require: false
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'timecop'
+  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,10 +61,8 @@ GEM
       tzinfo (~> 1.1)
     acts_as_tree (2.7.1)
       activerecord (>= 3.0.0)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
     bcrypt (3.1.12)
@@ -82,18 +80,16 @@ GEM
       thor (~> 0.18)
     byebug (10.0.2)
     cancancan (1.17.0)
-    capybara (3.6.0)
+    capybara (3.26.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      xpath (~> 3.1)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chronic (0.10.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -143,7 +139,6 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     image_size (1.3.1)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -190,7 +185,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
-    mini_mime (1.0.1)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     mono_logger (1.1.0)
@@ -218,7 +213,7 @@ GEM
     pry (0.12.0)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.3)
+    public_suffix (3.1.1)
     puma (3.12.0)
     rack (2.0.7)
     rack-protection (2.0.2)
@@ -260,6 +255,7 @@ GEM
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     ref (2.0.0)
+    regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
     rerun (0.13.0)
@@ -375,6 +371,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.1)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -397,8 +397,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   cancancan (~> 1.10)
-  capybara (~> 3.6.0)
-  chromedriver-helper
+  capybara
   coffee-rails (~> 4.2)
   database_cleaner
   differ (~> 0.1.2)
@@ -453,6 +452,7 @@ DEPENDENCIES
   unicorn (= 5.4.1)
   warden (~> 1.2.3)
   web-console (>= 3.3.0)
+  webdrivers
   whenever
 
 BUNDLED WITH


### PR DESCRIPTION
### Specs
We are seeing this warning when executing specs:
```
WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
```

**Proposed solution**
2 steps where required to fix it:
* Update [capybara](https://github.com/teamcapybara/capybara)
* The [chromedriver-helper](https://github.com/flavorjones/chromedriver-helper) gem is deprecated in favor of [webdrivers](https://github.com/titusfortner/webdrivers) gem.

### How to test
Specs should be green.