### PR TITLE
fix extra space above tabs in notes#show and evidence#show

### DIFF
--- a/app/assets/stylesheets/snowcrash/modules/nodes.scss
+++ b/app/assets/stylesheets/snowcrash/modules/nodes.scss
@@ -5,13 +5,14 @@ body.nodes, body.notes, body.evidence {
     li a:hover .text-error {
       color: white;
     }
+
+    ul.nav-pills {
+      margin-bottom: 0;
+    }
   }
 }
 
 body.nodes {
-  .node-header ul.nav-pills {
-    margin-bottom: 0;
-  }
 
   &.edit {
     textarea.json {


### PR DESCRIPTION
**Spec**
Currently, Notes#show and Evidence#show have too much space above the tabs (but not in the main Nodes#show)

**Proposed solution**
Adjust CSS to show the correct margin. 

ul.nav-pills {margin-bottom:0} is set specifically for body.nodes and needs to be opened up to body.notes as well as body.evidence

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
