### PR TITLE
set the defualt ul list style to none

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.14 (#### 2019)
  - Highlight code snippets.
+ - Removed bullet style in node modals.
 
 v3.13 (June 2019)
  - User-provided content takes priority over default local fields.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.15 (* 2019)
  - Fix node merging bug when `services_extras` properties are present
+ - Removed bullet style in node modals.
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -563,4 +563,8 @@ body {
 
 ul {
   list-style: none;
+
+  &.tree-navigation {
+    margin: 5px;
+  }
 }

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -107,7 +107,6 @@ body {
       padding:1em;
 
       > ul{
-        list-style: none;
         padding: 0 1em;
         margin: 0 0 2em 0;
         overflow: visible;
@@ -228,7 +227,6 @@ body {
 
         ul.children {
           overflow: visible;
-          list-style: none;
           display: none;
           margin: 0;
           padding: 0;
@@ -561,4 +559,8 @@ body {
   padding: 50px;
   text-align: center;
   margin-bottom: 1em;
+}
+
+ul {
+  list-style: none;
 }

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -121,7 +121,6 @@
   h4:first-child { margin-top: 10px; }
 
   ul {
-    list-style: none;
     margin-top: 1em;
   }
 }

--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -57,7 +57,6 @@
   margin: 0;
   margin-top: 2px;
   padding: 0;
-  list-style: none;
   background: #efefef;
 }
 .tribute-container li {

--- a/app/assets/stylesheets/snowcrash/modules/modals.scss
+++ b/app/assets/stylesheets/snowcrash/modules/modals.scss
@@ -25,7 +25,6 @@
 
   ul.children {
     overflow: visible;
-    list-style: none;
     display: none;
     margin: 0;
     padding: 0;

--- a/app/assets/stylesheets/snowcrash/modules/projects.scss
+++ b/app/assets/stylesheets/snowcrash/modules/projects.scss
@@ -20,7 +20,6 @@ body.projects {
     }
 
     ul.issue-list {
-      list-style: none;
       li {
         line-height: 3em;
         margin: 0;

--- a/app/assets/stylesheets/snowcrash/modules/versions.scss
+++ b/app/assets/stylesheets/snowcrash/modules/versions.scss
@@ -1,7 +1,6 @@
 #diff {
   margin-top: 10px;
 
-  ul { list-style: none; }
   del { background-color: #FCC; }
   ins { background-color: #CFC; }
 }


### PR DESCRIPTION
**Spec**
Currently, some lists show bullets while others, like nested ul's, do not. 

**Proposed solution**

Since all `<ul>` elements have `list-style: none`, this add's ul {list-style: none} to the base CSS file to set it as the default list style. Also removes redundant 'list-style: none' 