### PR TITLE
Cleanup attachments after lint tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,6 +88,7 @@ RSpec.configure do |config|
       FactoryBot.lint
     ensure
       DatabaseCleaner.clean_with(:truncation)
+      Attachment.all.each(&:delete)
     end
   end
 


### PR DESCRIPTION
# Spec
Factorybot runs a linter before the suite runs. When the attachment factory is created it creates a file in the attachments folder and leaves it there abandoned. This file can create conflicts with attachment tests in the suite. Ensure it's cleaned up.