### PR TITLE
add more detailed warnings to delete actions.

### DIFF
--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -13,7 +13,7 @@ document.addEventListener "turbolinks:load", ->
   $('.jquery-upload').fileupload
     dropZone: $('#drop-zone')
     destroy: (e, data) ->
-      if confirm('Are you sure?')
+      if confirm('Are you sure?\n\nProceeding will delete this attachment from the associated node.')
         $.blueimp.fileupload.prototype.options.destroy.call(this, e, data)
 
     paste: (e, data)->

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -20,7 +20,7 @@
         <% end %>
         <%= link_to [current_project, comment],
                     method: :delete,
-                    data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this comment, making it no longer visible to anyone.' },
+                    data: { confirm: "Are you sure?\n\nProceeding will delete this comment, making it no longer visible to anyone." },
                     remote: true,
                     class: 'text-error' do %>
           <i class="fa fa-trash"></i> Delete

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -20,7 +20,7 @@
         <% end %>
         <%= link_to [current_project, comment],
                     method: :delete,
-                    data: { confirm: 'Are you sure?' },
+                    data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this comment, making it no longer visible to anyone.' },
                     remote: true,
                     class: 'text-error' do %>
           <i class="fa fa-trash"></i> Delete

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -19,7 +19,7 @@
 
     <%= link_to [current_project, @node, evidence],
           method: :delete,
-          data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
+          data: { confirm: "Are you sure?\n\n\Proceeding will delete this evidence from the associated node." },
           class: 'list-item-action-delete' do %>
       <i class="fa fa-trash"></i> Delete
     <% end %>

--- a/app/views/evidence/_evidence.html.erb
+++ b/app/views/evidence/_evidence.html.erb
@@ -19,7 +19,7 @@
 
     <%= link_to [current_project, @node, evidence],
           method: :delete,
-          data: { confirm: 'Are you sure?' },
+          data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
           class: 'list-item-action-delete' do %>
       <i class="fa fa-trash"></i> Delete
     <% end %>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -30,7 +30,7 @@
             <% end %>
             <%= link_to [current_project, @node, @evidence],
                   class: 'action-link text-error',
-                  data: { confirm: 'Are you sure?' },
+                  data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %> -

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -30,7 +30,7 @@
             <% end %>
             <%= link_to [current_project, @node, @evidence],
                   class: 'action-link text-error',
-                  data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
+                  data: { confirm: "Are you sure?\n\nProceeding will delete this evidence from the associated node." },
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %> -

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -19,7 +19,7 @@
 
     <%= link_to main_app.project_issue_path(current_project, issue),
           method: :delete,
-          data: { confirm: 'Are you sure?' },
+          data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this issue and any associated evidence.' },
           class: 'list-item-action-delete' do %>
       <i class="fa fa-trash"></i> Delete
     <% end %>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -19,7 +19,7 @@
 
     <%= link_to main_app.project_issue_path(current_project, issue),
           method: :delete,
-          data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this issue and any associated evidence.' },
+          data: { confirm: "Are you sure?\n\nProceeding will delete this issue and any associated evidence." },
           class: 'list-item-action-delete' do %>
       <i class="fa fa-trash"></i> Delete
     <% end %>

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -41,7 +41,7 @@
             <%= link_to edit_project_issue_path(current_project, issue), class: '' do %>
               <i class="fa fa-pencil"></i> Edit
             <% end %>
-            <%= link_to [current_project, issue], method: :delete, data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this issue and any associated evidence.' }, class: 'text-error' do %>
+            <%= link_to [current_project, issue], method: :delete, data: { confirm: "Are you sure?\n\nProceeding will delete this issue and any associated evidence." }, class: 'text-error' do %>
               <i class="fa fa-trash"></i> Delete
             <% end %>
           </td>

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -41,7 +41,7 @@
             <%= link_to edit_project_issue_path(current_project, issue), class: '' do %>
               <i class="fa fa-pencil"></i> Edit
             <% end %>
-            <%= link_to [current_project, issue], method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-error' do %>
+            <%= link_to [current_project, issue], method: :delete, data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this issue and any associated evidence.' }, class: 'text-error' do %>
               <i class="fa fa-trash"></i> Delete
             <% end %>
           </td>

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="btn-group items-table-actions js-items-table-actions">
-    <a id="delete-selected" class="btn items-table-delete js-items-table-delete" data-confirm="Are you sure?" data-method="delete" title="Delete selected issues"><i class="fa fa-trash text-error"></i> Delete</a>
+    <a id="delete-selected" class="btn items-table-delete js-items-table-delete" data-confirm="Are you sure?&#10;&#10;Proceeding will delete the selected issue(s) and any associated evidence." data-method="delete" title="Delete selected issues"><i class="fa fa-trash text-error"></i> Delete</a>
     <a
       class="btn"
       id="merge-selected"

--- a/app/views/issues/nodes/_evidence.html.erb
+++ b/app/views/issues/nodes/_evidence.html.erb
@@ -10,7 +10,7 @@
           <% end %>
           <%= link_to [current_project, node, evidence],
                 class: 'action-link text-error',
-                data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
+                data: { confirm: "Are you sure?\n\nProceeding will delete this evidence from the associated node." },
                 method: :delete do %>
             <i class="fa fa-trash"></i> Delete
           <% end %>
@@ -38,7 +38,7 @@
                   <% end %>
                   <%= link_to [current_project, node, instance],
                         class: 'action-link text-error',
-                        data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
+                        data: { confirm: "Are you sure?\n\nProceeding will delete this evidence from the associated node." },
                         method: :delete do %>
                     <i class="fa fa-trash"></i> Delete
                   <% end %>

--- a/app/views/issues/nodes/_evidence.html.erb
+++ b/app/views/issues/nodes/_evidence.html.erb
@@ -10,7 +10,7 @@
           <% end %>
           <%= link_to [current_project, node, evidence],
                 class: 'action-link text-error',
-                data: { confirm: 'Are you sure?' },
+                data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
                 method: :delete do %>
             <i class="fa fa-trash"></i> Delete
           <% end %>
@@ -38,7 +38,7 @@
                   <% end %>
                   <%= link_to [current_project, node, instance],
                         class: 'action-link text-error',
-                        data: { confirm: 'Are you sure?' },
+                        data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this evidence from the associated node.' },
                         method: :delete do %>
                     <i class="fa fa-trash"></i> Delete
                   <% end %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -37,7 +37,7 @@
             <% end %>
             <%= link_to [current_project, @issue],
                   class: 'action-link text-error',
-                  data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this issue and any associated evidence.' },
+                  data: { confirm: "Are you sure?\n\nProceeding will delete this issue and any associated evidence." },
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %> -

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -37,7 +37,7 @@
             <% end %>
             <%= link_to [current_project, @issue],
                   class: 'action-link text-error',
-                  data: { confirm: 'Are you sure?' },
+                  data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this issue and any associated evidence.' },
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %> -

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -41,7 +41,7 @@
             <%= link_to [:edit, @node.project, @node, item] do %>
               <i class="fa fa-pencil"></i> Edit
             <% end %>
-            <%= link_to [@node.project, @node, item], method: :delete, data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this item from the associated node.' }, class: 'text-error' do %>
+            <%= link_to [@node.project, @node, item], method: :delete, data: { confirm: "Are you sure?\n\nProceeding will delete this item from the associated node." }, class: 'text-error' do %>
               <i class="fa fa-trash"></i> Delete
             <% end %>
           </td>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -41,7 +41,7 @@
             <%= link_to [:edit, @node.project, @node, item] do %>
               <i class="fa fa-pencil"></i> Edit
             <% end %>
-            <%= link_to [@node.project, @node, item], method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-error' do %>
+            <%= link_to [@node.project, @node, item], method: :delete, data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this item from the associated node.' }, class: 'text-error' do %>
               <i class="fa fa-trash"></i> Delete
             <% end %>
           </td>

--- a/app/views/nodes/items_table/_toolbar.html.erb
+++ b/app/views/nodes/items_table/_toolbar.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="btn-group items-table-actions js-items-table-actions">
-    <a class="btn items-table-delete js-items-table-delete" data-confirm="Are you sure?" title="Delete selected">
+    <a class="btn items-table-delete js-items-table-delete" data-confirm="Are you sure?&#10;&#10;Proceeding will delete the selected item(s) from the associated node." title="Delete selected">
       <i class="fa fa-trash text-error"></i> Delete
     </a>
   </div>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -19,7 +19,7 @@
 
     <%= link_to [@node.project, @node, note],
           method: :delete,
-          data: { confirm: 'Are you sure?' },
+          data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this note from the associated node.' },
           class: 'list-item-action-delete' do %>
       <i class="fa fa-trash"></i> Delete
     <% end %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -19,7 +19,7 @@
 
     <%= link_to [@node.project, @node, note],
           method: :delete,
-          data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this note from the associated node.' },
+          data: { confirm: "Are you sure?\n\nProceeding will delete this note from the associated node." },
           class: 'list-item-action-delete' do %>
       <i class="fa fa-trash"></i> Delete
     <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -21,7 +21,7 @@
             <% end %>
             <%= link_to [current_project, @node, @note],
                   class: 'action-link text-error',
-                  data: { confirm: 'Are you sure?' },
+                  data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this note from the associated node.' },
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -21,7 +21,7 @@
             <% end %>
             <%= link_to [current_project, @node, @note],
                   class: 'action-link text-error',
-                  data: { confirm: "Are you sure?\n\n" + 'Proceeding will delete this note from the associated node.' },
+                  data: { confirm: "Are you sure?\n\nProceeding will delete this note from the associated node." },
                   method: :delete do %>
               <i class="fa fa-trash"></i> Delete
             <% end %>


### PR DESCRIPTION
**Spec**
Currently, when a user clicks Delete, they simply get an "Are you sure?" warning without any details.

**Proposed solution**
Go through all the :delete actions and add a meaningful warning explaining the consequences of the action.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
