### PR TITLE
break words when content exceeds viewport width

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v3.15 (* 2019)
  - Fix node merging bug when `services_extras` properties are present
  - Removed bullet style in node modals.
+ - Fix overflow issue where content would expand out of view.
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -507,6 +507,12 @@ body {
         background-color: #f5f5f5;
         padding: 0 0 0 1em;
       }
+
+      .tab-content {
+        .inner {
+          word-break: break-word;
+        }
+      }
     }
 
     a:hover {


### PR DESCRIPTION
This PR fixes a bug where note, issue, evidence, etc content would overflow if there was no breaks in a long word. 

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
