### PR TITLE
Dropdown menu layer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v3.15 (* 2019)
  - Fix node merging bug when `services_extras` properties are present
  - Removed bullet style in node modals.
+ - Fix partially hidden dropdown menu's when sidebar is narrow.
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -184,8 +184,9 @@ document.addEventListener "turbolinks:load", ->
 
   # Dropdown menu position in sidebar based on sidebar width
   $(window).on('resize', ->
-    if (($('[data-behavior=sidebar-dropdown]').outerWidth() + 30) > $('[data-behavior=secondary-navbar]').width())
-      $('[data-behavior=sidebar-dropdown]').css({
-        right: $('[data-behavior=secondary-navbar]').width() - ($('[data-behavior=sidebar-dropdown]').width() + 30)
-      })
+    $('[data-behavior=sidebar-dropdown]').each ->
+      if (($(this).outerWidth() + 30) > $('[data-behavior=secondary-navbar]').width())
+        $(this).css({
+          right: $('[data-behavior=secondary-navbar]').width() - ($(this).width() + 30)
+        })
   ).resize()

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -181,3 +181,11 @@ document.addEventListener "turbolinks:load", ->
       $this.find('[data-behavior~=toggle-chevron]').toggleClass('fa-chevron-down fa-chevron-up')
       if $('[data-behavior~=import-box]').length
         $('[data-behavior~=import-box]').find("input[type='text']:first").focus()
+
+  # Dropdown menu position in sidebar based on sidebar width
+  $(window).on('resize', ->
+    if (($('[data-behavior=sidebar-dropdown]').outerWidth() + 30) > $('[data-behavior=secondary-navbar]').width())
+      $('[data-behavior=sidebar-dropdown]').css({
+        right: $('[data-behavior=secondary-navbar]').width() - ($('[data-behavior=sidebar-dropdown]').width() + 30)
+      })
+  ).resize()

--- a/app/views/layouts/snowcrash.html.erb
+++ b/app/views/layouts/snowcrash.html.erb
@@ -78,7 +78,7 @@
 
         <div id="view-content" class="view-content">
           <% if content_for?(:sidebar) %>
-            <div class="secondary-navbar">
+            <div class="secondary-navbar" data-behavior="secondary-navbar">
               <div class="inner">
                 <%= yield :sidebar %>
               </div>

--- a/app/views/shared/_add_item_dropdown.html.erb
+++ b/app/views/shared/_add_item_dropdown.html.erb
@@ -10,7 +10,7 @@
     <i class="fa fa-chevron-up" data-behavior="toggle-chevron"></i>
   <% end %>
 
-  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_class, '') %>" role="menu">
+  <ul class="dropdown-menu <%= local_assigns.fetch(:menu_class, '') %>" role="menu" data-behavior="sidebar-dropdown">
     <li>
       <%= link_to 'Empty (no template)',
         new_path,


### PR DESCRIPTION
Currently, when the browser window is narrowed and I click the "+" in the sidebar to add evidence or any item in the sub-nav the dropdown menu may be partially hidden.

This PR fixes this issue by checking the sidebar width and adjusting the dropdown menu position accordingly.


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
