### PR TITLE
Port Boards: Lists

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,0 +1,69 @@
+class ListsController < AuthenticatedController
+  include ActivityTracking
+  include ProjectScoped
+
+  before_action :set_current_board
+  before_action :set_list, only: [:show, :edit, :update, :destroy, :move]
+
+  def new
+    @list = @board.lists.new
+  end
+
+  def create
+    @list = @board.lists.new(list_params)
+    @list.previous_id = @board.last_list.try(:id)
+
+    if @list.save
+      track_created(@list)
+      redirect_to [current_project, @board], notice: 'List added.'
+    else
+      redirect_to [current_project, @board], alert: @list.errors.full_messages.join('; ')
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @list.update_attributes(list_params)
+      track_updated(@list)
+      redirect_to [current_project, @board], notice: 'List renamed.'
+    else
+      redirect_to [current_project, @board], alert: @list.errors.full_messages.join('; ')
+    end
+  end
+
+  def move
+    Board.move(
+      @list,
+      prev_item: @board.lists.find_by(id: params[:prev_id]),
+      next_item: @board.lists.find_by(id: params[:next_id])
+    )
+
+    track_updated(@list)
+
+    render json: @list
+  end
+
+  def destroy
+    if @list.destroy
+      track_destroyed(@list)
+      redirect_to [current_project, @board], notice: 'List deleted.'
+    else
+      redirect_to [current_project, @board], notice: "Error deleting list: #{@list.errors.full_messages.join('; ')}"
+    end
+  end
+
+  private
+
+  def list_params
+    params.require(:list).permit(:name)
+  end
+
+  def set_current_board
+    @board = current_project.boards.find(params[:board_id])
+  end
+
+  def set_list
+    @list = @board.lists.find(params[:id])
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,6 +12,10 @@ class Project
   end
 
   # -- Instance Methods -----------------------------------------------------
+  def authors
+    User.all
+  end
+
   def initialize(id: 1, name: 'Dradis CE', **_attrs)
     @id   = id
     @name = name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  alias_attribute :name, :email
   # -- Relationships --------------------------------------------------------
   has_many :activities
   has_many :comments, dependent: :nullify

--- a/spec/features/board_pages/board_pages_spec.rb
+++ b/spec/features/board_pages/board_pages_spec.rb
@@ -39,5 +39,11 @@ describe 'Board pages:' do
         expect(page).not_to have_text node_board.name
       end
     end
+
+    describe 'when in show page' do
+      let(:board_path) { project_board_path(current_project, board) }
+
+      include_examples 'managing lists'
+    end
   end
 end

--- a/spec/features/board_pages/linked_items_spec.rb
+++ b/spec/features/board_pages/linked_items_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe "Linked items", js: true do
+  subject { page }
+
+  before do
+    login_to_project_as_user
+
+    @board = create(:board, project: current_project, node: current_project.methodology_library)
+    @list1 = create(:list, board: @board)
+  end
+
+  describe "showing linked Lists in the board show page" do
+    before do
+      @list3 = create(:list, board: @board, previous_id: @list1.id)
+      @list2 = create(:list, board: @board, previous_id: @list3.id)
+
+      visit project_board_path(current_project, @board)
+    end
+
+    it "is in order" do
+      # The last .list item is the Add new list link.
+      lists = all("li.list")[0..2]
+      expect(lists.count).to eq(3)
+      expected_elements = [
+        find("li.list[data-list-id='#{@list1.id}']"),
+        find("li.list[data-list-id='#{@list3.id}']"),
+        find("li.list[data-list-id='#{@list2.id}']")
+      ]
+
+      lists.each_with_index do |list, i|
+        expect(list).to eq(expected_elements[i])
+      end
+    end
+  end
+
+  describe "showing linked Cards in the board show page" do
+    before do
+      @card1 = create(:card, list: @list1)
+      @card3 = create(:card, list: @list1, previous_id: @card1.id)
+      @card2 = create(:card, list: @list1, previous_id: @card3.id)
+
+      visit project_board_path(current_project, @board)
+    end
+
+    it "is in order" do
+      cards = all("li.card")
+      expected_elements = [
+        find("li.card[data-card-id='#{@card1.id}']"),
+        find("li.card[data-card-id='#{@card3.id}']"),
+        find("li.card[data-card-id='#{@card2.id}']"),
+      ]
+
+      cards.each_with_index do |card, i|
+        expect(card).to eq(expected_elements[i])
+      end
+    end
+  end
+end

--- a/spec/support/list_shared_examples.rb
+++ b/spec/support/list_shared_examples.rb
@@ -1,0 +1,164 @@
+# This shared shared_example needs the folowing *let* variables:
+# - board:
+#   how to create a board (project level or node level)
+# - board_path:
+#   the path to board show page
+shared_examples 'managing lists' do
+  let(:model) { @list }
+
+  let(:delete_link) do
+    "a[href='#{project_board_list_path(current_project, @board, @list)}'][data-method='delete']"
+  end
+  
+  before do
+    @board = board
+    @list  = create(:list, board: @board)
+    @list2 = create(:list, board: @board, previous_id: @list.id)
+    visit board_path
+  end
+
+  it 'contains a link to add a list' do
+    expect(page).to have_text 'Add a list...'
+  end
+
+  it 'contains a link to rename each list' do
+    List.all.each do |list|
+      edit_link = "a[href='#modal-list-edit-#{list.id}']"
+      expect(page).to have_selector(edit_link)
+    end
+  end
+
+  it 'contains a link to add a card to the lists' do
+    expect(page).to have_selector("a[href='#{new_project_board_list_card_path(current_project, @board,@list)}']")
+  end
+
+  describe 'adding a list' do
+    let(:submit_form) { click_button 'Add list' }
+
+    before do
+      click_link 'Add a list...'
+      expect(page).to have_selector('#modal-list-new', visible: true)
+    end
+
+    describe 'submitting the form with valid information' do
+      before do
+        within '#modal-list-new' do
+          fill_in :list_name, with: 'New List'
+        end
+      end
+
+      it 'creates a new list under this board' do
+        expect do
+          submit_form
+          expect(page).to have_text('List added.')
+          expect(page).to have_current_path(board_path)
+        end.to change{List.count}.by(1)
+      end
+
+      include_examples 'creates an Activity', :create, List
+    end
+
+    describe 'submitting the form with invalid information' do
+      before do
+        within '#modal-list-new' do
+          fill_in :list_name, with: ''
+        end
+      end
+
+      it "doesn't create a new list" do
+        old_count = List.count
+        submit_form
+        expect(page).to have_text("can't be blank")
+        expect(old_count).to eq List.count
+      end
+
+      include_examples "doesn't create an Activity"
+    end
+  end
+
+  describe 'updating a list', js: true do
+    let(:submit_form) { click_button 'Update list' }
+
+    let(:modal_selector) { "#modal-list-edit-#{@list.id}" }
+
+    before do
+      find("li[data-list-id='#{@list.id}']").hover
+      find("a[href='#{modal_selector}']").click
+      expect(page).to have_selector(modal_selector, visible: true)
+    end
+
+    describe 'submitting the form with valid information' do
+      before do
+        within modal_selector do
+          fill_in :list_name, with: 'New List Name'
+        end
+      end
+
+      it 'updates the list' do
+        expect do
+          submit_form
+          expect(page).to have_text('List renamed')
+          expect(page).to have_text 'New List Name'
+          expect(page).to have_current_path(board_path)
+        end.not_to(change { List.count } )
+      end
+
+      include_examples 'creates an Activity', :update, @list
+    end
+
+    describe 'submitting the form with invalid information' do
+      before do
+        within modal_selector do
+          fill_in :list_name, with: ''
+        end
+      end
+
+      it "doesn't rename the list" do
+        old_name = @list.name
+        submit_form
+        expect(page).to have_text("can't be blank")
+        expect(old_name).to eq @list.reload.name
+      end
+
+      include_examples "doesn't create an Activity"
+    end
+  end
+
+  it 'contains a link to delete each list' do
+    expect(page).to have_selector(delete_link)
+  end
+
+  describe 'deleting a list' do
+    let(:submit_form) { page.find(delete_link).click }
+    it 'deletes the list' do
+      id = @list.id
+      submit_form
+      expect(List.exists?(id)).to be false
+      expect(page).to have_current_path(board_path)
+      expect(page).to have_text 'List deleted'
+    end
+
+    it "updates the board's linked list" do
+      id = @list2.id
+      submit_form
+      expect(List.find(id).previous_id).to be_nil
+    end
+
+    include_examples 'creates an Activity', :destroy
+  end
+
+  it 'displays assignees in each card' do
+    # create card with 2 assigned users
+    @card        = create(:card, list: @list)
+    @first_user  = create(:user)
+    @second_user = create(:user)
+    @card.assignees << [@first_user, @second_user]
+    @card.save
+
+    # reload
+    visit board_path
+
+    expect(page).to have_selector("img[title='#{@first_user.name}']")
+    expect(page).to have_selector("img[title='#{@second_user.name}']")
+  end
+end


### PR DESCRIPTION
**Spec**
We should be able, when viewing a board see a list of our lists, with the ability to create, rename, remove, and move the lists.

**Proposed solution**
Port from Pro the desired functionality

**How to test**

    Log into Dradis.
    Assert when you view a board you can see it's lists
    Assert you can rename a list
    Assert you can delete a list
    Assert you can move a list, and after a refresh the list retains it's position