### PR TITLE
Port Boards: Cards

### DIFF
--- a/app/assets/stylesheets/snowcrash/pages.scss
+++ b/app/assets/stylesheets/snowcrash/pages.scss
@@ -1,1 +1,2 @@
 @import "snowcrash/pages/boards";
+@import "snowcrash/pages/cards";

--- a/app/assets/stylesheets/snowcrash/pages/cards.scss
+++ b/app/assets/stylesheets/snowcrash/pages/cards.scss
@@ -1,0 +1,5 @@
+body.cards {
+  .checkbox {
+    min-height: 30px !important;
+  }
+}

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,0 +1,105 @@
+class CardsController < AuthenticatedController
+  include ActivityTracking
+  include Commented
+  include ContentFromTemplate
+  include ProjectScoped
+  include Mentioned
+  include NotificationsReader
+
+  # Not sorted because we need the Board and List first!
+  before_action :set_current_board_and_list
+  before_action :set_card, only: [:show, :edit, :update, :destroy, :move]
+  before_action :initialize_sidebar, only: [:show, :new, :edit]
+
+  layout 'cards'
+
+  def show
+    @activities   = @card.activities.latest
+    @subscription = @card.subscription_for(user: current_user)
+    render layout: !request.xhr?
+  end
+
+  def new
+    @card = @list.cards.new
+
+    # See ContentFromTemplate concern
+    @card.description = template_content if params[:template]
+  end
+
+  def create
+    @card = @list.cards.new(card_params)
+    # Set the new card as the last card of the list
+    @card.previous_id = @list.last_card.try(:id)
+
+    if @card.save
+      track_created(@card)
+      redirect_to [current_project, @board, @list, @card], notice: 'Task added.'
+    else
+      initialize_sidebar
+      render "new"
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @card.update_attributes(card_params)
+      track_updated(@card)
+      redirect_to [current_project, @board, @list, @card], notice: 'Task updated.'
+    else
+      initialize_sidebar
+      render "edit"
+    end
+  end
+
+  def move
+    List.move(
+      @card,
+      prev_item: @board.cards.find_by(id: params[:prev_id]),
+      next_item: @board.cards.find_by(id: params[:next_id])
+    )
+
+    if params[:new_list_id]
+      @card.list = @board.lists.find(params[:new_list_id])
+      @card.save
+    end
+
+    track_updated(@card)
+
+    render json: {
+      is_card:  true,
+      id:       @card.id,
+      link:     polymorphic_path([current_project, @board, @card.reload.list, @card]),
+      moveLink: move_project_board_list_card_path(current_project, @board, @card.reload.list, @card)
+    }
+  end
+
+  def destroy
+    if @card.destroy
+      track_destroyed(@card)
+      redirect_to [current_project, @board], notice: 'Task deleted'
+    else
+      redirect_to [current_project, @board, @list, @card], notice: "Error deleting task: #{@card.errors.full_messages.join('; ')}"
+    end
+  end
+
+  private
+
+  def card_params
+    params.require(:card).permit(:name, :description, :due_date, assignee_ids: [])
+  end
+
+  def initialize_sidebar
+    @sorted_cards = @list.ordered_cards.select(&:persisted?)
+  end
+
+  def set_card
+    @card = @list.cards.find(params[:id])
+  end
+
+  def set_current_board_and_list
+    @board = current_project.boards.includes(:lists).find(params[:board_id])
+    @list  = @board.lists.includes(:cards).find(params[:list_id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   alias_attribute :name, :email
+
   # -- Relationships --------------------------------------------------------
   has_many :activities
   has_many :comments, dependent: :nullify

--- a/app/views/cards/_breadcrumbs.html.erb
+++ b/app/views/cards/_breadcrumbs.html.erb
@@ -1,0 +1,11 @@
+<ul class="breadcrumb">
+  <li>
+    <%= link_to @board.node.label, project_boards_path(current_project, node_id: @board.node_id) %>
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <%= link_to "#{@board.name} - #{@list.name}", project_board_path(current_project, @board) %>
+    <span class="divider">/</span>
+  </li>
+  <li class="active"><%= @card.try!(:name) || 'New task' %></li>
+</ul>

--- a/app/views/cards/_card.html.erb
+++ b/app/views/cards/_card.html.erb
@@ -1,0 +1,28 @@
+<%
+  item_css = ['list-item']
+  item_css << ' active' if @card == card
+%>
+
+<%= content_tag :div, id: "#{dom_id(card)}_link", class: item_css.join do %>
+
+  <div class="expansion-container">
+    <%= link_to project_board_list_card_path(current_project, @board, @list, card) do %>
+      <i class="fa fa-address-card-o list-item-icon"></i>
+      <%= card.name %>
+    <% end %>
+  </div>
+
+  <div class="list-item-actions">
+    <%= link_to edit_project_board_list_card_path(current_project, @board, @list, card), class:'list-item-action-edit' do %>
+      <i class="fa fa-pencil"></i> Edit
+    <% end %>
+
+    <%= link_to [current_project, @board, @list, card],
+          method: :delete,
+          data: { confirm: "Are you sure?\n\nProceeding will delete this card from the task list." },
+          class: 'list-item-action-delete' do %>
+      <i class="fa fa-trash"></i> Delete
+    <% end %>
+  </div>
+
+<% end %>

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -1,0 +1,41 @@
+<%= simple_form_for [current_project, @board, @list, @card] do |f| %>
+  <%= f.error_notification %>
+
+  <%= f.input :name, required: false %>
+  <%= f.input :due_date %>
+
+  <%=
+    f.input :description,
+      input_html: {
+        class: 'textile',
+        label: false,
+        data: { preview_url: preview_path, help_url: markup_path }
+      }
+  %>
+
+  <hr>
+  <%=
+    f.association(
+      :assignees,
+      collection: current_project.authors.sort_by(&:name),
+      label_method: lambda do |user|
+        avatar_image(user, include_name: true, size: 30)
+      end,
+      value_method: :id,
+      as: :check_boxes,
+      item_wrapper_tag: :div,
+      boolean_style: :inline
+    )
+  %>
+  <hr>
+
+
+  <div class="form-actions">
+    <%= f.button :submit, nil, class: 'btn btn-primary' %> or
+    <%=
+      link_to 'Cancel',
+        @card.persisted? ? [current_project, @board, @list, @card] : [current_project, @board],
+        class: 'cancel-link'
+    %>
+  </div>
+<% end %>

--- a/app/views/cards/_poller_alerts.html.erb
+++ b/app/views/cards/_poller_alerts.html.erb
@@ -1,0 +1,32 @@
+<%# This alert is shown by activities/poller.js if another user deletes the
+  current card %>
+<div id="card-deleted-alert" class="alert alert-danger" style="display:none;">
+  <p>
+    <strong>Warning</strong>. This task has been deleted by another user since
+    you started viewing it.
+  </p>
+</div>
+
+<%# This alert is shown by activities/poller.js if another user updates the
+  current card %>
+<div id="card-updated-alert" class="alert alert-info" style="display:none;">
+  <%# content is set dynamically with js at show time %>
+</div>
+
+<%# This alert is shown by activities/poller.js if another user deletes the
+  current board %>
+<div id="board-deleted-alert" class="alert alert-danger" style="display:none;">
+  <p>
+    <strong>Warning</strong>. This methodology has been deleted by another user since
+    you started viewing it.
+  </p>
+</div>
+
+<%# This alert is shown by activities/poller.js if another user deletes the
+  current list %>
+<div id="list-deleted-alert" class="alert alert-danger" style="display:none;">
+  <p>
+    <strong>Warning</strong>. This list has been deleted by another user since
+    you started viewing it.
+  </p>
+</div>

--- a/app/views/cards/_sidebar.html.erb
+++ b/app/views/cards/_sidebar.html.erb
@@ -1,0 +1,21 @@
+  <div class="note-list">
+    <div class="list-item">
+      <div class="expansion-container">
+        <%= link_to project_board_path(current_project, @board) do %>
+          <i class="fa fa-arrow-left"></i> Back to board view
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cards -->
+  <%=
+    render 'shared/sidebar_collection',
+      name: 'Tasks',
+      collection: @sorted_cards,
+      new_path: new_project_board_list_card_path(current_project, @board, @list, @card),
+      category_id: nil do
+  %>
+    <%#-- We pass an empty block here or else "yield" in the rendered partial %>
+    <%#-- will return the whole view. %>
+  <% end %>

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Edit task: #{@card.name}" %>
+
+<%= render partial: 'poller_alerts' %>
+
+<%= render partial: 'breadcrumbs' %>
+
+<div id="cards_editor">
+  <div class="inner note-text-inner">
+    <h3>Edit task</h3>
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, 'New task' %>
+
+<%= render partial: 'poller_alerts' %>
+
+<%= render partial: 'breadcrumbs' %>
+
+<div id="cards_editor">
+  <div class="inner note-text-inner">
+    <h3>Add new task</h3>
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title, @card.name %>
+
+<%= render partial: 'poller_alerts' unless request.xhr? %>
+
+<div id="js-card">
+  <%= render partial: 'breadcrumbs' %>
+
+  <ul class="nav nav-tabs main-tabs">
+    <li class="active">
+      <a href="#info-tab" data-toggle="tab"><i class="fa fa-address-card-o"></i> Information</a>
+    </li>
+    <li><a href="#activity-tab" data-toggle="tab"><i class="fa fa-refresh"></i> Recent activity</a></li>
+  </ul>
+
+  <div class="tab-content">
+    <div class="tab-pane active" id="info-tab" data-behavior="subscription-actions" data-subscribed="<%= !@subscription.nil? %>">
+      <% cache ['card-information-tab', @card] do %>
+        <div class="inner note-text-inner">
+          <h3><%= @card.name %> -
+            <span class="actions">
+              <%= link_to edit_project_board_list_card_path(current_project, @board, @list, @card) do %>
+                <i class="fa fa-pencil"></i> Edit
+              <% end %>
+              <%=
+                link_to(
+                  project_board_list_card_path(current_project, @board, @list, @card),
+                  class: 'text-error',
+                  data: { confirm: "Are you sure?\n\nProceeding will delete this card from the task list." },
+                  method: :delete
+                ) do %>
+                  <i class="fa fa-trash"></i> Delete
+              <% end %> -
+              <%= render 'subscriptions/actions', subscribable: @card %>
+            </span>
+          </h3>
+
+          <div class="card-description">
+            <div class="content-textile">
+              <%= markup(@card.description) %>
+            </div>
+          </div>
+
+          <div class="card-due-date">
+            <h4>Due Date</h4>
+            <%= @card.due_date %>
+          </div>
+
+          <% if @card.assignees.any? %>
+            <div class="card-assignees clearfix">
+              <h4>Assignees</h4>
+              <% @card.assignees.each do |user| %>
+                <%= avatar_image(user, include_name: true, size: 30) %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+
+      </div> 
+      <div class="inner">
+        <%= render 'comments/feed' %>
+        <%= render 'subscriptions/feed', subscribable: @card %>
+      </div>
+    </div>
+
+    <% cache ['card-activity-tab', @card, @activities] do %>
+      <div class="tab-pane" id="activity-tab">
+        <div class="inner">
+          <h3>Recent activity</h3>
+          <%= render 'activities/feed', activities: @activities %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/cards.html.erb
+++ b/app/views/layouts/cards.html.erb
@@ -1,0 +1,9 @@
+<% content_for :sidebar do %>
+  <%= render "cards/sidebar" %>
+<% end %>
+
+<% content_for :content do %>
+  <%= yield %>
+<% end %>
+
+<%= render template: "layouts/snowcrash" %>

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -1,0 +1,213 @@
+require 'rails_helper'
+
+describe 'Card pages:' do
+  subject { page }
+
+  it 'should require authenticated users' do
+    project = create(:project)
+    @board = create(:board, project: project, node: project.methodology_library)
+    Configuration.create(name: 'admin:password', value: 'rspec_pass')
+    visit project_board_path(@board.project, @board)
+    expect(current_path).to eq(login_path)
+    expect(page).to have_content('Access denied.')
+  end
+
+  context 'as authenticated user' do
+    let(:add_users) do
+      @first_user  = create(:user)
+      @second_user = create(:user)
+    end
+
+    before do
+      login_to_project_as_user
+      @board = create(:board, project: current_project, node: current_project.methodology_library)
+      @list  = create(:list, board: @board)
+    end
+
+    describe 'when in new page' do
+      let(:submit_form) { click_button 'Create Card' }
+
+      describe 'submitting the form with valid information' do
+        before do
+          visit new_project_board_list_card_path(current_project, @board, @list)
+          fill_in :card_name, with: 'New Card'
+          fill_in :card_description, with: 'New Card Description'
+        end
+
+        it 'creates a new card in this list' do
+          expect{submit_form}.to change{Card.count}.by(1)
+          expect(page).to have_text('Task added.')
+          expect(current_path).to eq(project_board_list_card_path(current_project, @board, @list, Card.last))
+        end
+
+        include_examples 'creates an Activity', :create, Card
+      end
+
+      describe 'submitting the form with invalid information' do
+        before do
+          visit new_project_board_list_card_path(current_project, @board, @list)
+          fill_in :card_name, with: ''
+        end
+
+        it 'doesn\'t create a new card' do
+          expect{submit_form}.not_to(change{Card.count})
+        end
+
+        it 'shows the form again with an error message' do
+          submit_form
+          expect(page).to have_text("can't be blank")
+          expect(current_path).to eq(project_board_list_cards_path(current_project, @board, @list))
+        end
+
+        include_examples "doesn't create an Activity"
+      end
+
+      describe 'assigning users' do
+        before do
+          add_users
+          visit new_project_board_list_card_path(current_project, @board, @list)
+          fill_in :card_name, with: 'New Card'
+        end
+
+        it 'assigns selected users to the card' do
+          check @first_user.name
+          check @second_user.name
+
+          submit_form
+
+          expect(Card.last.assignees.count).to eq 2
+        end
+      end
+    end
+
+    describe 'when in edit page' do
+      let(:submit_form) { click_button 'Update Card' }
+
+      before do
+        @card = create(:card, list: @list)
+      end
+
+      describe 'submitting the form with valid information' do
+        before do
+          visit edit_project_board_list_card_path(current_project, @board, @list, @card)
+          fill_in :card_name, with: 'Edited Card'
+          fill_in :card_description, with: 'Edited Card Description'
+        end
+
+        it 'updates the card' do
+          expect do
+            submit_form
+            expect(page).to have_text('Task updated')
+            expect(page).to have_text('Edited Card')
+            expect(page).to have_text('Edited Card Description')
+            expect(current_path).to eq(project_board_list_card_path(current_project, @board, @list, @card))
+          end.not_to(change{ Card.count })
+        end
+
+        let(:model) { @card }
+        include_examples 'creates an Activity', :update
+      end
+
+      describe 'submitting the form with invalid information' do
+        before do
+          visit edit_project_board_list_card_path(current_project, @board, @list, @card)
+          fill_in :card_name, with: ''
+        end
+
+        it "doesn't update the card" do
+          expect{submit_form}.not_to(change{ @card.reload.name })
+        end
+
+        it 'shows the form again with an error message' do
+          submit_form
+          expect(page).to have_text("can't be blank")
+          expect(current_path).to eq(project_board_list_card_path(current_project, @board, @list, @card))
+        end
+
+        include_examples "doesn't create an Activity"
+      end
+
+      describe 'assigning users' do
+        before do
+          add_users
+          @card.assignees = [@first_user]
+          @card.save
+          visit edit_project_board_list_card_path(current_project, @board, @list, @card)
+        end
+
+        it 'displays assigned checked and unassigned unchecked' do
+          expect(page).to have_selector("input[type=checkbox][id=card_assignee_ids_#{@first_user.id}][checked=checked]")
+          expect(page).to have_selector("input[type=checkbox][id=card_assignee_ids_#{@second_user.id}]:not(checked)")
+        end
+
+        it 'assigns selected and unassigns unselected' do
+          uncheck @first_user.name
+          check @second_user.name
+
+          submit_form
+
+          expect(page).not_to have_text(@first_user.name)
+          expect(page).to have_text(@second_user.name)
+        end
+      end
+    end
+
+    describe 'when in show page' do
+      before do
+        @card = create(:card, list: @list)
+        @card2 = create(:card, list: @list, previous_id: @card.id)
+        @card3 = create(:card, list: @list, previous_id: @card2.id)
+        create_activities
+        create_comments
+        visit project_board_list_card_path(current_project, @board, @list, @card)
+      end
+
+      let(:create_activities) { nil }
+      let(:create_comments) { nil }
+
+      let(:trackable) { @card }
+      it_behaves_like 'a page with an activity feed'
+
+      let(:commentable) { @card }
+      it_behaves_like 'a page with a comments feed'
+
+      let(:subscribable) { @card }
+      it_behaves_like 'a page with subscribe/unsubscribe links'
+
+      it 'has a link to edit card' do
+        expect(page).to have_selector("a[href='#{edit_project_board_list_card_path(current_project, @board, @list, @card)}']")
+      end
+
+      it 'has a link to delete card' do
+        expect(page).to have_selector("a[href='#{project_board_list_card_path(current_project, @board, @list, @card)}'][data-method='delete']")
+      end
+
+      describe "clicking 'delete'" do
+        before { PaperTrail.enabled = true }
+        after  { PaperTrail.enabled = false }
+
+        let(:submit_form) { click_link 'Delete' }
+
+        it 'deletes the card' do
+          id = @card.id
+          submit_form
+          expect(Card.exists?(id)).to be false
+          expect(current_path).to eq project_board_path(current_project, @board)
+          expect(page).to have_text 'Task deleted'
+        end
+
+        it 'adjusts the list' do
+          id = @card2.id
+          submit_form
+          expect(Card.find(id).previous_id).to be_nil
+        end
+
+        let(:model) { @card }
+        let(:submit_form) { within('.note-text-inner') { click_link 'Delete' } }
+        let(:trackable) { @card }
+
+        include_examples 'creates an Activity', :destroy
+      end
+    end
+  end
+end

--- a/spec/features/card_recover_spec.rb
+++ b/spec/features/card_recover_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe 'Board recover', js: true do
+  subject { page }
+
+  describe 'when I delete a card' do
+    before do
+      PaperTrail.enabled = true
+
+      login_to_project_as_user
+
+      @board = create(:board, project: current_project, node: current_project.methodology_library)
+      @list = create(:list, board: @board)
+      @card = create(:card, list: @list)
+      @next_card = create(:card, list: @list, previous_id: @card.id)
+      visit(polymorphic_path([current_project, @board, @list, @card]))
+    end
+
+    after { PaperTrail.enabled = false }
+
+    let(:submit_form) do
+      accept_confirm { click_link 'Delete' }
+      expect(page).to have_text 'Task deleted'
+    end
+
+    let(:model) { @card }
+
+    include_examples 'deleted item is listed in Trash', :card
+    include_examples 'recover deleted item', :card
+
+    def version_link_xpath
+      version_id = model.versions.last.id
+      "//a[@href='#{recover_project_revision_path(current_project, id: version_id)}']"
+    end
+
+    it 'should be recovered as the first item of the list' do
+      submit_form
+      visit project_trash_path(current_project)
+      accept_confirm { find(:xpath, version_link_xpath).click }
+      expect(page).to have_text 'Card recovered'
+      expect(@list.first_item).to eq(@card)
+    end
+
+    context "when the card's list is deleted" do
+      before do
+        submit_form
+        @list.destroy
+
+        visit project_trash_path(current_project)
+        accept_confirm { find(:xpath, version_link_xpath).click }
+        expect(page).to have_text 'Card recovered'
+      end
+
+      it "should be inside the board's Recovered list" do
+        card = Card.find(@card.id)
+        expect(card).not_to be_nil
+        expect(card.list).to eq(@board.recovered_list)
+      end
+    end
+
+    context "when the card's board is deleted" do
+      before do
+        submit_form
+        @list.destroy
+        @board.destroy
+
+        visit project_trash_path(current_project)
+        accept_confirm { find(:xpath, version_link_xpath).click }
+        expect(page).to have_text 'Card recovered'
+      end
+
+      it "should be inside the project's Recovered board and list" do
+        card = Card.find(@card.id)
+        board = Board.find_by(name: 'Recovered')
+        expect(card).not_to be_nil
+        expect(card.board).to eq(board)
+        expect(card.list).to eq(board.recovered_list)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Spec
We should be able, when viewing a board see a list of our lists, with the ability to create, rename, remove, and move the lists.

**Proposed solution**
Port from Pro the desired functionality

### How to test

- Log into Dradis.
- Create a board with a list if you don't have one (not part of this scope)
- Assert you can add a task to the list
- Assert you can edit the task
- Assert you can move the card to another list, and after a refresh the card retains it's position
- Assert you can delete the card
- Assert you can restore the card


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~~- [ ] Added a CHANGELOG entry~~