### PR TITLE
Port Boards: add upsell to boards

### DIFF
--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -103,6 +103,8 @@ document.addEventListener "turbolinks:load", ->
         when 'try-pro' then 'Upgrade to Dradis Pro'
         when 'word-reports' then '[<span>Dradis Pro feature</span>] Custom Word reports'
         when 'excel-reports' then '[<span>Dradis Pro feature</span>] Custom Excel reports'
+        when 'multiple-boards' then '[<span>Dradis Pro feature</span>] Multiple methodologies'
+        when 'node-boards' then '[<span>Dradis Pro feature</span>] Node-level methodologies'
 
       $modal.find('.modal-header h3').html(title)
     else

--- a/app/views/nodes/show.html.erb
+++ b/app/views/nodes/show.html.erb
@@ -6,8 +6,8 @@
   <li <%= "class=active" if params[:tab] == 'notes-tab' %>>
     <a href="#notes-tab" data-toggle="tab"><i class="fa fa-file-text-o"></i> Notes</a>
   </li>
-  <li <%= "class=active" if params[:tab] == 'methodology-tab' %>>
-    <a href="#methodology-tab" data-toggle="tab"><i class="fa fa-trello"></i> Methodology</a>
+  <li>
+    <a class="js-try-pro" href="javascript:void(0)" data-term="node-boards" data-url="http://drad.is/l/try-pro-consistency"><i class="fa fa-trello"></i> Methodology</a>
   </li>
   <li <%= "class=active" if !params[:tab] || params[:tab] == 'properties-tab' %>>
     <a href="#properties-tab" data-toggle="tab">
@@ -92,11 +92,6 @@
     <div class="inner">
       <%= render partial: 'activity' %>
     </div>
-  </div>
-
-  <div class="tab-pane inner <%= "active" if params[:tab] == "methodology-tab" %>" id="methodology-tab">
-    <h3>Methodology</h3>
-    <%= render 'nodes/show/empty_board' %>
   </div>
 
   <%= render 'console/console' %>

--- a/app/views/nodes/show.html.erb
+++ b/app/views/nodes/show.html.erb
@@ -6,6 +6,9 @@
   <li <%= "class=active" if params[:tab] == 'notes-tab' %>>
     <a href="#notes-tab" data-toggle="tab"><i class="fa fa-file-text-o"></i> Notes</a>
   </li>
+  <li <%= "class=active" if params[:tab] == 'methodology-tab' %>>
+    <a href="#methodology-tab" data-toggle="tab"><i class="fa fa-trello"></i> Methodology</a>
+  </li>
   <li <%= "class=active" if !params[:tab] || params[:tab] == 'properties-tab' %>>
     <a href="#properties-tab" data-toggle="tab">
     <% if @node.type_id == Node::Types::HOST %>
@@ -89,6 +92,11 @@
     <div class="inner">
       <%= render partial: 'activity' %>
     </div>
+  </div>
+
+  <div class="tab-pane inner <%= "active" if params[:tab] == "methodology-tab" %>" id="methodology-tab">
+    <h3>Methodology</h3>
+    <%= render 'nodes/show/empty_board' %>
   </div>
 
   <%= render 'console/console' %>

--- a/app/views/nodes/show/_empty_board.html.erb
+++ b/app/views/nodes/show/_empty_board.html.erb
@@ -3,7 +3,7 @@
 
   <p>Add one by clicking on the button below</p>
 
-  <a class="btn js-try-pro" href="javascript:void(0)" data-term="boards" data-url="http://drad.is/l/try-pro-consistency">
+  <a class="btn js-try-pro" href="javascript:void(0)" data-term="node-boards" data-url="http://drad.is/l/try-pro-consistency">
     <i class="fa fa-plus"> </i> Add methodology
   </a>
 </div>

--- a/app/views/nodes/show/_empty_board.html.erb
+++ b/app/views/nodes/show/_empty_board.html.erb
@@ -1,0 +1,9 @@
+<div class="text-center">
+  <h1>This node doesn't have a methodology yet</h1>
+
+  <p>Add one by clicking on the button below</p>
+
+  <a class="btn" href="#">
+    <i class="fa fa-plus"> </i> Add methodology
+  </a>
+</div>

--- a/app/views/nodes/show/_empty_board.html.erb
+++ b/app/views/nodes/show/_empty_board.html.erb
@@ -3,7 +3,7 @@
 
   <p>Add one by clicking on the button below</p>
 
-  <a class="btn" href="#">
+  <a class="btn js-try-pro" href="javascript:void(0)" data-term="boards" data-url="http://drad.is/l/try-pro-consistency">
     <i class="fa fa-plus"> </i> Add methodology
   </a>
 </div>

--- a/app/views/nodes/show/_empty_board.html.erb
+++ b/app/views/nodes/show/_empty_board.html.erb
@@ -1,9 +1,0 @@
-<div class="text-center">
-  <h1>This node doesn't have a methodology yet</h1>
-
-  <p>Add one by clicking on the button below</p>
-
-  <a class="btn js-try-pro" href="javascript:void(0)" data-term="node-boards" data-url="http://drad.is/l/try-pro-consistency">
-    <i class="fa fa-plus"> </i> Add methodology
-  </a>
-</div>


### PR DESCRIPTION
**Spec**
The user should only be able to add a single project level board.

**Proposed solution**
Show an upsell modal when the user tries to add another board or a node level board

**How to test**
Log into Dradis.
Create a board if you don't have one
Click 'create new methodology' after a board has already been created.
Assert that the upsell model appears
Create a node if one does not already exist
Navigate to the methodologies tab
Assert that the upsell model appears

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
