### PR TITLE
Add word-break to textile wrap

### DIFF
--- a/app/assets/stylesheets/snowcrash/overrides/_jquery-textile_and_override.scss
+++ b/app/assets/stylesheets/snowcrash/overrides/_jquery-textile_and_override.scss
@@ -4,6 +4,7 @@
 
 .textile-wrap {
   background-color: #fff;
+  word-break: break-word;
 
   ul.textile-toolbar {
     background: #fff;


### PR DESCRIPTION
### Spec
The preview view is overflowing if the issue text is too long.

**Proposed solution**
Apply word break to the preview view.

### How to test
1. Create a new issue with a long line: 
```
#[Description]#
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```

2. Click on Preview on the toolbar.
3. Confirm that the text displays correctly