### PR TITLE
Port Boards: Activity polling

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,6 +4,8 @@ class Activity < ApplicationRecord
 
   belongs_to :trackable, polymorphic: true, required: false
 
+  def project=(new_project); end
+
   # NOTE: when the project importer creates activities, it will try to match
   # them to existing users based on the 'user email' field in the XML. If it
   # can't find any users with the given address, it will save user_id as '-1'.

--- a/app/views/activities/_poll_methodologies.js.erb
+++ b/app/views/activities/_poll_methodologies.js.erb
@@ -1,0 +1,51 @@
+<%# Card activities %>
+<% if activity.trackable_type == 'Card' %>
+  <%# See comment above re: activity.trackable.nil? %>
+  <% if activity.action == 'destroy' || activity.trackable.nil? %>
+    ActivitiesPoller.deleteCard(<%= activity.trackable_id %>)
+  <% else %>
+    <% card = activity.trackable %>
+    <%# @board and @list must be initialized for the partial to work: %>
+    <% @board = card.board; @list = card.list %>
+    var template = '<%= j render(card) %>';
+    var cardId   = <%= card.id %>;
+    var listId   = <%= card.list.id %>;
+    var boardId  = <%= card.board.id %>;
+    var listName = '<%= card.list.name %>';
+    var cardPath = '<%= project_board_list_card_path(current_project, card.board, card.list, card) %>';
+
+    <% if activity.action == 'create' %>
+      ActivitiesPoller.addCard(listId, boardId, template)
+    <% elsif activity.action == 'update' %>
+      ActivitiesPoller.updateCard(cardId, listId, boardId, template)
+    <% end %>
+  <% end %>
+<% end # if activity.trackable_type == "Card" %>
+
+<%# List activities %>
+<% if activity.trackable_type == 'List' %>
+  <%# See comment above re: activity.trackable.nil? %>
+  <% if activity.action == 'destroy' || activity.trackable.nil? %>
+    ActivitiesPoller.deleteList(<%= activity.trackable_id %>)
+  <% elsif activity.action == 'update' %>
+    <% list = activity.trackable %>
+    ActivitiesPoller.updateList(<%= list.id %>, <%= list.board.id %>, '<%= list.name %>')
+  <% elsif activity.action == 'create' %>
+    <% list = activity.trackable %>
+    ActivitiesPoller.addList(<%= list.id %>, <%= list.board.id %>)
+  <% end %>
+<% end # if activity.trackable_type == "List" %>
+
+<%# Board activities %>
+<% if activity.trackable_type == 'Board' %>
+  <%# See comment above re: activity.trackable.nil? %>
+  <% if activity.action == 'destroy' || activity.trackable.nil? %>
+    ActivitiesPoller.deleteBoard(<%= activity.trackable_id %>)
+  <% elsif activity.action == 'update' %>
+    <% board = activity.trackable %>
+    ActivitiesPoller.updateBoard(<%= board.id %>, '<%= board.name %>')
+  <% elsif activity.action == 'create' %>
+    <% board = activity.trackable %>
+    ActivitiesPoller.addBoard(<%= board.id %>)
+  <% end %>
+<% end # if activity.trackable_type == "Board" %>

--- a/app/views/activities/_poller.html.erb
+++ b/app/views/activities/_poller.html.erb
@@ -2,10 +2,19 @@
 <%# is picked up by javascripts/snowcrash/modules/activities/poller.js   %>
 <div id="activities-poller"
   data-action="<%= controller.action_name %>"
+  data-board-id="<%= @board.try(:id) %>"
+  data-board-name="<%= @board.try(:name) %>"
+  data-board-path="<%= project_board_path(current_project, @board) unless @board.nil? %>"
+  data-boards-path="<%= main_app.project_boards_path(current_project) %>"
+  data-card-id="<%= @card.try(:id) %>"
+  data-card-path="<%= project_board_list_card_path(current_project, @card.board, @card.list, @card) if @card.try(:persisted?) %>",
   data-controller="<%= controller_name %>"
   data-id="<%= params[:id] %>"
   data-last-poll="<%= Time.now.to_i %>"
+  data-list-id="<%= @list.try(:id) %>"
+  data-list-name="<%= @list.try(:name) %>"
   data-node-id="<%= @node.try(:id) %>"
+  data-project-id="<%= current_project.id %>"
   data-url=<%= main_app.poll_project_activities_path(current_project, format: :js) %>
 >
 </div>

--- a/app/views/activities/poll.js.erb
+++ b/app/views/activities/poll.js.erb
@@ -108,6 +108,8 @@
 
   <% end # if activity.trackable_type == "Node" %>
 
+  <%= render 'poll_methodologies', activity: activity %>
+
 <% end %>
 
 ActivitiesPoller.lastPoll = <%= @this_poll %>;

--- a/spec/features/board_pages/polling_spec.rb
+++ b/spec/features/board_pages/polling_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'board pages', js: true do
+  include ActivityMacros
+
+  subject { page }
+
+  before do
+    login_to_project_as_user
+    @other_user = create(:user)
+    @board      = create(:board, project: current_project, node: current_project.methodology_library)
+    @list       = create(:list, board: @board)
+    @other_list = create(:list, board: @board, previous_id: @list.id)
+    @card       = create(:card, list: @list)
+  end
+
+  describe 'when I am viewing a board' do
+    before { visit project_board_path(current_project, @board) }
+
+    it_behaves_like 'a board page with poller'
+  end
+
+  describe 'when I am viewing the boards index' do
+    before { visit project_boards_path(current_project) }
+
+    describe 'when someone else updates a board' do
+      before do
+        @board.update_attributes(name: 'whatever')
+        create(:activity, action: :update, trackable: @board, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'updates that board name' do
+        expect(page).to have_text 'whatever'
+      end
+    end
+
+    describe 'when someone else removes a board' do
+      before do
+        PaperTrail.enabled = true
+
+        @board.destroy
+        create(:activity, action: :destroy, trackable: @board, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      after { PaperTrail.enabled = false }
+
+      it 'removes that board' do
+        expect(page).not_to \
+          have_selector "li.board-list-item[data-board-id='#{@board.id}']"
+      end
+    end
+
+    describe 'when someone else creates a board' do
+      before do
+        @other_board = create(:board, project: current_project, node: current_project.methodology_library)
+        create(:activity, action: :create, trackable: @other_board, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'adds the board' do
+        expect(page).to \
+          have_selector 'span.board-tile-details-name', text: @board.name
+      end
+    end
+  end
+end

--- a/spec/features/card_pages/polling_spec.rb
+++ b/spec/features/card_pages/polling_spec.rb
@@ -1,0 +1,186 @@
+require 'rails_helper'
+
+describe 'card pages', js: true do
+  include ActivityMacros
+
+  subject { page }
+
+  shared_examples 'a card page with poller' do
+
+    describe 'when someone else adds a card' do
+      before do
+        @new_card = create(:card, list: @card.list)
+        create(:activity, action: :create, trackable: @new_card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'adds a link' do
+        expect(page).to have_selector "#card_#{@new_card.id}_link"
+      end
+    end
+
+    describe 'when someone else updates that card' do
+      before do
+        @card.update_attributes(name: 'whatever')
+        create(:activity, action: :update, trackable: @card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'updates card on show and warns on edit' do
+        if action == :edit
+          expect(page).to have_selector '#card-updated-alert'
+        elsif action == :show
+          expect(page).to have_selector '#js-card h3', text: 'whatever'
+        end
+      end
+    end
+
+    describe 'when someone else updates another card' do
+      before do
+        @other_card.update_attributes(name: 'updated card')
+        create(:activity, action: :update, trackable: @other_card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'updates the link' do
+        within "#card_#{@other_card.id}_link" do
+          expect(page).to have_text 'updated card'
+        end
+      end
+    end
+
+    describe 'when someone else deletes that card' do
+      before do
+        @card.destroy
+        create(:activity, action: :destroy, trackable: @card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'displays a warning' do
+        expect(page).to have_selector '#card-deleted-alert'
+      end
+    end
+
+    describe 'when someone else deletes another card' do
+      before do
+        @other_card.destroy
+        create(:activity, action: :destroy, trackable: @other_card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'removes the link' do
+        expect(page).not_to have_selector "#card_#{@other_card.id}_link"
+      end
+    end
+
+    describe 'when someone else moves that card' do
+      before do
+        @card.update_attributes(list_id: @other_list.id)
+        create(:activity, action: :update, trackable: @card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'updates card on show and warns on edit' do
+        if action == :edit
+          expect(page).to have_selector '#card-updated-alert'
+        elsif action == :show
+          expect(page).to\
+            have_selector(
+              'ul.breadcrumb li:nth-child(2) a',
+              text: "#{@board.name} - #{@other_list.name}"
+            )
+        end
+      end
+    end
+
+    describe 'when someone else moves (out) another card' do
+      before do
+        @other_card.update_attributes(list_id: @other_list.id)
+        create(:activity, action: :update, trackable: @other_card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'removes the link' do
+        expect(page).not_to have_selector "#card_#{@other_card.id}_link"
+      end
+    end
+
+    describe 'when someone else moves (in) another card' do
+      before do
+        @moved_card = create(:card, list: @list, previous_id: @other_card.id)
+        create(:activity, action: :update, trackable: @moved_card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'adds the link' do
+        expect(page).to have_selector "#card_#{@moved_card.id}_link"
+      end
+    end
+
+    describe 'and someone updates then deletes that card' do
+      before do
+        @card.update_attributes(name: 'whatever')
+        create(:activity, action: :update, trackable: @card, user: @other_user, project: current_project)
+        @card.destroy
+        create(:activity, action: :destroy, trackable: @card, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'displays a warning' do
+        # Make sure the 'update' actions pointing to a no-longer-existent
+        # Card don't crash the poller!
+        should have_selector '#card-deleted-alert'
+      end
+    end
+
+    describe 'when someone else deletes that list' do
+      before do
+        @list.destroy
+        create(:activity, action: :destroy, trackable: @list, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'displays a warning' do
+        expect(page).to have_selector '#list-deleted-alert'
+      end
+    end
+
+    describe 'when someone else deletes that board' do
+      before do
+        @board.destroy
+        create(:activity, action: :destroy, trackable: @board, user: @other_user, project: current_project)
+        call_poller
+      end
+
+      it 'displays a warning' do
+        expect(page).to have_selector '#board-deleted-alert'
+      end
+    end
+  end
+
+  before do
+    PaperTrail.enabled = true
+
+    login_to_project_as_user
+    @other_user = create(:user)
+    @board      = create(:board, project: current_project)
+    @list       = create(:list, board: @board)
+    @other_list = create(:list, board: @board)
+    @card       = create(:card, list: @list)
+    @other_card = create(:card, list: @list, previous_id: @card.id)
+  end
+
+  after { PaperTrail.enabled = false }
+
+  describe 'when I am viewing a card' do
+    before { visit project_board_list_card_path(current_project, @board, @list, @card) }
+    let(:action) { :show }
+    it_behaves_like 'a card page with poller'
+  end
+
+  describe 'when I am editing a card' do
+    before { visit edit_project_board_list_card_path(current_project, @board, @list, @card) }
+    let(:action) { :edit }
+    it_behaves_like 'a card page with poller'
+  end
+end

--- a/spec/support/board_shared_examples.rb
+++ b/spec/support/board_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This shared shared_example needs the folowing *let* variables:
 # - board:
 #   how to create a board (project level or node level)
@@ -88,7 +90,7 @@ shared_examples 'managing boards' do
             submit_form
             expect(page).to have_text('Methodology added')
             expect(page).to have_current_path(board_path)
-          end.to change{Board.count}.by(1)
+          end.to change { Board.count }.by(1)
         end
 
         include_examples 'creates an Activity', :create, Board
@@ -187,7 +189,7 @@ shared_examples 'managing boards' do
           expect(page).to have_text('Methodology renamed')
           expect(page).to have_text('New Board Name')
           expect(page).to have_current_path board_path
-        end.not_to(change{Board.count})
+        end.not_to(change { Board.count })
       end
 
       include_examples 'creates an Activity', :update, @b


### PR DESCRIPTION
### Spec
When using boards/lists/cards and another user modifies them, we should see those changes.

### How to test
Log in with user A in one browser. Log in with user B in another browser.

**In the boards index with both users (/projects/1/boards):**
Add a board with one user, the other must see it.
Rename the board with one user, the other must see it.
Delete the board with one user, the other must see it.

**Inside the same board with both users (/projects/1/boards/X):**
Add a list with one user, the other must see it.
Rename the list with one user, the other must see it.
Delete the list with one user, the other must see it.
Add a task with one user, the other must see it.
Rename the task with one user, the other must see it.
Delete the task with one user, the other must see it.
Delete the board with 1 user, the other must see a warning

**Inside the same card with both users (/projects/1/boards/X/lists/Y/cards/Z):**
Edit the card with one user, the other must see it.
Delete the task with one user, the other must see a warning.

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~~- [ ] Added a CHANGELOG entry~~
