### PR TITLE
change jquery selector

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ v3.15 (* 2019)
  - Limit project name length when viewing a project
  - Removed bullet style in node modals.
  - Fix overflow issue where content would expand out of view.
+ - Fix page jump when issues list is collapsed.
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -179,5 +179,5 @@ document.addEventListener "turbolinks:load", ->
     $('[data-behavior~=collapse-collection]').click ->
       $this = $(this)
       $this.find('[data-behavior~=toggle-chevron]').toggleClass('fa-chevron-down fa-chevron-up')
-      if $('[data-behavior~=import-box]').length
+      if $this.hasClass('import-toggle')
         $('[data-behavior~=import-box]').find("input[type='text']:first").focus()

--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -179,5 +179,6 @@ document.addEventListener "turbolinks:load", ->
     $('[data-behavior~=collapse-collection]').click ->
       $this = $(this)
       $this.find('[data-behavior~=toggle-chevron]').toggleClass('fa-chevron-down fa-chevron-up')
-      if $this.hasClass('import-toggle')
-        $('[data-behavior~=import-box]').find("input[type='text']:first").focus()
+
+      if $this.is('[data-behavior~=import-box]')
+        $($this.data('target')).find("input[type='text']:first").focus()

--- a/app/views/issues/_import_box.html.erb
+++ b/app/views/issues/_import_box.html.erb
@@ -5,7 +5,7 @@
 
         <%= link_to 'javascript:void(0)', 
           class: 'import-toggle', 
-          data: { toggle: 'collapse', target: '#import-box', behavior: 'collapse-collection' } do %>
+          data: { toggle: 'collapse', target: '#import-box', behavior: 'collapse-collection import-box' } do %>
           <i class="fa fa-chevron-down" data-behavior="toggle-chevron"></i>
         <% end %>
       </div>
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<%= content_tag :div, class: 'import-box collapse', id: 'import-box', data: { behavior: 'import-box' } do %>
+<%= content_tag :div, class: 'import-box collapse', id: 'import-box' do %>
   <% if Dradis::Plugins::with_feature(:import).empty? %>
     <p>
       Connect Dradis to a library of issue descriptions so you don't have to


### PR DESCRIPTION
**Spec**
Currently, if there is a long list of issues and the collapse chevron is clicked, the page jumps down.

This PR fixes the jump which was caused by focusing on the import box element every time any chevron is clicked.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
