### PR TITLE
fix responsive width calc to accomodate pro navbar

### DIFF
--- a/app/assets/stylesheets/snowcrash/base.scss
+++ b/app/assets/stylesheets/snowcrash/base.scss
@@ -46,14 +46,19 @@ body {
     margin: 0;
     text-shadow: 0 0 0;
     letter-spacing: -0.4px;
-    min-width: 180px;
-    width: calc(100% - 775px);
+    min-width: 145px;
+    width: calc(100% - 795px);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 
     @media screen and (max-width: 767px) {
       padding-left: 20px;
+      width: calc(100% - 80px);
+    }
+
+    @media screen and (min-width: 768px) and (max-width: 979px) {
+      width: calc(100% - 65px);
     }
   }
 


### PR DESCRIPTION
**Spec**
Currently, if the project name is long and the view is narrowed in a Pro instance, the navbar overflows into the main content.

**Solution**
This PR calculates the width of the project name based on the wider pro navbar and re-calculates based on the responsive breakpoints.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~