### PR TITLE
Copy node label in creation forms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@ v3.15 (* 2019)
  - Fix overflow issue where content would expand out of view.
  - Fix hamburger dropdown menu functionality.
  - Fix page jump when issues list is collapsed.
+ - Enhancement when adding new nodes to copy node label data between the single
+   and multiple node forms.
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/assets/javascripts/snowcrash.js
+++ b/app/assets/javascripts/snowcrash.js
@@ -45,6 +45,7 @@
 
 //= require snowcrash/pages/boards
 //= require snowcrash/pages/methodologies
+//= require snowcrash/pages/nodes/new_form
 //= require snowcrash/pages/nodes/tables
 //= require snowcrash/pages/projects/boards_summary
 //= require snowcrash/pages/projects/issues_chart

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,8 +1,8 @@
 (function() {
-  var copyOver = function($to, from, typeTo, typeFrom) {
+  var copyOver = function($to, from, $typeTo, $typeFrom) {
     if ($to.val() === '' && from !== '') {
       $to.val(from.split('\n')[0] + '\n');
-      $(typeTo).val($(typeFrom).val());
+      $typeTo.val($typeFrom.val());
 
       // The click function we're in actually takes focus when clicked. If
       // we called focus within the function it gets cancelled out. We give
@@ -17,16 +17,19 @@
   document.addEventListener("turbolinks:load", function() {
     if ($('[data-behavior~=copy-node-label]').length) {
       $('[data-behavior~=copy-node-label]').click(function(eventData) {
-        var $multi = $('#nodes_list');
-        var $label = $('#node_label');
+        var $nodeType = $('#node_type_id'),
+            $nodesType = $('#nodes_type_id'),
 
-        var multiVal = $multi.val();
-        var labelVal = $label.val();
+            $multi = $('#nodes_list'),
+            $label = $('#node_label'),
+
+            multiVal = $multi.val(),
+            labelVal = $label.val();
 
         if ($(this).find('input').val() === 'one') {
-          copyOver($label, multiVal, '#node_type_id', '#nodes_type_id');
+          copyOver($label, multiVal, $nodeType, $nodesType);
         } else {
-          copyOver($multi, labelVal, '#nodes_type_id', '#node_type_id');
+          copyOver($multi, labelVal, $nodesType, $nodeType);
         }
       });
     }

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -14,7 +14,7 @@
     }
   }
 
-  document.addEventListener("turbolinks:load", function() {
+  document.addEventListener('turbolinks:load', function() {
     if ($('[data-behavior~=copy-node-label]').length) {
       $('[data-behavior~=copy-node-label]').click(function(eventData) {
         var $modal = $(this).parents('.modal'),

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,43 +1,32 @@
 (function() {
-  document.addEventListener("turbolinks:load", function() {
-    if ($('[data-behavior~=multi-node]').length) {
-      $('[data-behavior~=multi-node]').click(function() {
-        var $multi = $('#nodes_list');
-        var labelVal = $('#node_label').val();
+  var copyOver = function($to, from, typeTo, typeFrom) {
+    if ($to.val() === '' && from !== '') {
+      $to.val(from.split('\n')[0] + '\n');
+      $(typeTo).val($(typeFrom).val());
 
-        if ($multi.val() === '' && labelVal !== '') {
-          $multi.val(labelVal + '\n');
-
-          $('#nodes_type_id').val($('#node_type_id').val());
-
-          // The click function we're in actually takes focus when clicked. If
-          // we called focus within the fucntion it gets cancelled out. We give
-          // it a brief timout to allow it to occur after this function ends,
-          // but seemingly at the same time.
-          setTimeout(function() {
-            $multi.focus();
-          }, 0);
-        }
-      });
+      // The click function we're in actually takes focus when clicked. If
+      // we called focus within the function it gets cancelled out. We give
+      // it a brief timout to allow it to occur after this function ends
+      // but seemingly at the same time.
+      setTimeout(function() {
+        $to.focus();
+      }, 0);
     }
+  }
 
-    if ($('[data-behavior~=one-node]').length) {
-      $('[data-behavior~=one-node]').click(function() {
-        var multiVal = $('#nodes_list').val();
+  document.addEventListener("turbolinks:load", function() {
+    if ($('[data-behavior~=copy-node-label]').length) {
+      $('[data-behavior~=copy-node-label]').click(function(eventData) {
+        var $multi = $('#nodes_list');
         var $label = $('#node_label');
 
-        if ($label.val() === '' && multiVal !== '') {
-          $label.val(multiVal.split('\n')[0]);
+        var multiVal = $multi.val();
+        var labelVal = $label.val();
 
-          $('#node_type_id').val($('#nodes_type_id').val());
-
-          // The click function we're in actually takes focus when clicked. If
-          // we called focus within the fucntion it gets cancelled out. We give
-          // it a brief timout to allow it to occur after this function ends,
-          // but seemingly at the same time.
-          setTimeout(function() {
-            $label.focus();
-          }, 0);
+        if ($(this).find('input').val() === 'one') {
+          copyOver($label, multiVal, '#node_type_id', '#nodes_type_id');
+        } else {
+          copyOver($multi, labelVal, '#nodes_type_id', '#node_type_id');
         }
       });
     }

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,0 +1,24 @@
+(function() {
+  document.addEventListener("turbolinks:load", function() {
+    if ($('[data-behavior~=new-node]').length) {
+      $('[data-behavior~=new-node]').click(function() {
+        var $multi = $('#nodes_list');
+        var labelVal = $('#node_label').val();
+
+        if ($multi.val() === '' && labelVal !== '') {
+          $multi.val(labelVal + '\r');
+
+          $('#nodes_type_id').val($('#node_type_id').val());
+
+          // The click function we're in actually takes focus when clicked. If
+          // we called focus within the fucntion it gets cancelled out. We give
+          // it a brief timout to allow it to occur after this function ends,
+          // but seemingly at the same time.
+          setTimeout(function() {
+            $multi.focus();
+          }, 0);
+        }
+      });
+    }
+  });
+}).call(this);

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,7 +1,7 @@
 (function() {
   var copyOver = function($to, from, $typeTo, $typeFrom) {
     if ($to.val() === '' && from !== '') {
-      $to.val(from.split('\n')[0] + '\n');
+      $to.val(from.trim().split('\n')[0] + '\n');
       $typeTo.val($typeFrom.val());
 
       // The click function we're in actually takes focus when clicked. If

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -16,7 +16,7 @@
 
   document.addEventListener('turbolinks:load', function() {
     if ($('[data-behavior~=copy-node-label]').length) {
-      $('[data-behavior~=copy-node-label]').click(function(eventData) {
+      $('[data-behavior~=copy-node-label]').click(function() {
         var $modal = $(this).parents('.modal'),
             $nodeType = $modal.find('#node_type_id'),
             $nodesType = $modal.find('#nodes_type_id'),
@@ -35,4 +35,4 @@
       });
     }
   });
-}).call(this);
+})();

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,20 +1,20 @@
 (function() {
-  var copyOver = function($to, fromVal, $typeTo, typeFromVal) {
-    if ($to.val() === '' && fromVal !== '') {
-      $to.val(fromVal.trim().split('\n')[0] + '\n');
-      $typeTo.val(typeFromVal);
-
-      // The click function we're in actually takes focus when clicked. If
-      // we called focus within the function it gets cancelled out. We give
-      // it a brief timout to allow it to occur after this function ends
-      // but seemingly at the same time.
-      setTimeout(function() {
-        $to.focus();
-      }, 0);
-    }
-  }
-
   document.addEventListener('turbolinks:load', function() {
+    var copyOver = function($to, fromVal, $typeTo, typeFromVal) {
+      if ($to.val() === '' && fromVal !== '') {
+        $to.val(fromVal.trim().split('\n')[0] + '\n');
+        $typeTo.val(typeFromVal);
+
+        // The click function we're in actually takes focus when clicked. If
+        // we called focus within the function it gets cancelled out. We give
+        // it a brief timout to allow it to occur after this function ends
+        // but seemingly at the same time.
+        setTimeout(function() {
+          $to.focus();
+        }, 0);
+      }
+    }
+
     if ($('[data-behavior~=copy-node-label]').length) {
       $('[data-behavior~=copy-node-label]').click(function() {
         var $modal = $(this).parents('.modal'),

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -17,11 +17,12 @@
   document.addEventListener("turbolinks:load", function() {
     if ($('[data-behavior~=copy-node-label]').length) {
       $('[data-behavior~=copy-node-label]').click(function(eventData) {
-        var $nodeType = $('#node_type_id'),
-            $nodesType = $('#nodes_type_id'),
+        var $modal = $(this).parents('.modal'),
+            $nodeType = $modal.find('#node_type_id'),
+            $nodesType = $modal.find('#nodes_type_id'),
 
-            $multi = $('#nodes_list'),
-            $label = $('#node_label'),
+            $multi = $modal.find('#nodes_list'),
+            $label = $modal.find('#node_label'),
 
             multiVal = $multi.val(),
             labelVal = $label.val();

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,8 +1,8 @@
 (function() {
-  var copyOver = function($to, from, $typeTo, $typeFrom) {
-    if ($to.val() === '' && from !== '') {
-      $to.val(from.trim().split('\n')[0] + '\n');
-      $typeTo.val($typeFrom.val());
+  var copyOver = function($to, fromVal, $typeTo, typeFromVal) {
+    if ($to.val() === '' && fromVal !== '') {
+      $to.val(fromVal.trim().split('\n')[0] + '\n');
+      $typeTo.val(typeFromVal);
 
       // The click function we're in actually takes focus when clicked. If
       // we called focus within the function it gets cancelled out. We give
@@ -20,17 +20,13 @@
         var $modal = $(this).parents('.modal'),
             $nodeType = $modal.find('#node_type_id'),
             $nodesType = $modal.find('#nodes_type_id'),
-
             $multi = $modal.find('#nodes_list'),
-            $label = $modal.find('#node_label'),
-
-            multiVal = $multi.val(),
-            labelVal = $label.val();
+            $label = $modal.find('#node_label');
 
         if ($(this).find('input').val() === 'one') {
-          copyOver($label, multiVal, $nodeType, $nodesType);
+          copyOver($label, $multi.val(), $nodeType, $nodesType.val());
         } else {
-          copyOver($multi, labelVal, $nodesType, $nodeType);
+          copyOver($multi, $label.val(), $nodesType, $nodeType.val());
         }
       });
     }

--- a/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
+++ b/app/assets/javascripts/snowcrash/pages/nodes/new_form.js
@@ -1,12 +1,12 @@
 (function() {
   document.addEventListener("turbolinks:load", function() {
-    if ($('[data-behavior~=new-node]').length) {
-      $('[data-behavior~=new-node]').click(function() {
+    if ($('[data-behavior~=multi-node]').length) {
+      $('[data-behavior~=multi-node]').click(function() {
         var $multi = $('#nodes_list');
         var labelVal = $('#node_label').val();
 
         if ($multi.val() === '' && labelVal !== '') {
-          $multi.val(labelVal + '\r');
+          $multi.val(labelVal + '\n');
 
           $('#nodes_type_id').val($('#node_type_id').val());
 
@@ -16,6 +16,27 @@
           // but seemingly at the same time.
           setTimeout(function() {
             $multi.focus();
+          }, 0);
+        }
+      });
+    }
+
+    if ($('[data-behavior~=one-node]').length) {
+      $('[data-behavior~=one-node]').click(function() {
+        var multiVal = $('#nodes_list').val();
+        var $label = $('#node_label');
+
+        if ($label.val() === '' && multiVal !== '') {
+          $label.val(multiVal.split('\n')[0]);
+
+          $('#node_type_id').val($('#nodes_type_id').val());
+
+          // The click function we're in actually takes focus when clicked. If
+          // we called focus within the fucntion it gets cancelled out. We give
+          // it a brief timout to allow it to occur after this function ends,
+          // but seemingly at the same time.
+          setTimeout(function() {
+            $label.focus();
           }, 0);
         }
       });

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -21,7 +21,7 @@
     <%# we need to scope the names of the radio buttons to this specific modal
       # so that clicking a radio in the 'add child' modal won't deselect the
       # radios in the 'add branch' modal %>
-    <div class="radio">
+    <div class="radio" data-behavior="one-node">
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",
@@ -32,7 +32,7 @@
       </label>
     </div>
 
-    <div class="radio" data-behavior="new-node">
+    <div class="radio" data-behavior="multi-node">
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -32,7 +32,7 @@
       </label>
     </div>
 
-    <div class="radio">
+    <div class="radio" data-behavior="new-node">
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -21,7 +21,7 @@
     <%# we need to scope the names of the radio buttons to this specific modal
       # so that clicking a radio in the 'add child' modal won't deselect the
       # radios in the 'add branch' modal %>
-    <div class="radio" data-behavior="one-node">
+    <div class="radio" data-behavior="copy-node-label">
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",
@@ -32,7 +32,7 @@
       </label>
     </div>
 
-    <div class="radio" data-behavior="multi-node">
+    <div class="radio" data-behavior="copy-node-label">
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -21,7 +21,7 @@
     <%# we need to scope the names of the radio buttons to this specific modal
       # so that clicking a radio in the 'add child' modal won't deselect the
       # radios in the 'add branch' modal %>
-    <div class="radio" data-behavior="copy-node-label">
+    <div class='radio' data-behavior='copy-node-label'>
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",
@@ -32,7 +32,7 @@
       </label>
     </div>
 
-    <div class="radio" data-behavior="copy-node-label">
+    <div class='radio' data-behavior='copy-node-label'>
       <label>
         <%= radio_button_tag(
           "add_#{type}_node",


### PR DESCRIPTION
### Summary

Multiple times I've clicked to create new nodes, begun typing in the add one field, and mid-label realized I wanted multiple nodes. I then select Add Multiple but have to retype the label I already typed (or copy paste). Instead, it would be a nice Quality of Life feature to copy the contents of the Add one box over to the Add multiple magically. So I may be delighted that it is already present.

### Proposed solution
On the click of the Add Multiple select. If the multiple box currently have no value, copy the contents (if any) of the Add one box into the multiple box. Have the cursor positioned in the second line ready for typing.

### How to test
Conditions for delight:

One to Multiple

- Click the new nodes + sign
- Leave the select as Add one
- Add a label name
- Then select Add multiple
- See that the label you type in Add one is now present in the textarea
- See the cursor is positioned on the second line.

Multiple to One

- Click the new nodes + sign
- Select as Add multiple
- Add a two label names
- Select the icon
- Reselect Add one
- See that the first label from the textarea is now the only label
- See the icon has been selected

Ensuring no frustration:

- Click the new nodes + sign
- Select Add multiple
- Add a label name or two
- Then select Add one
- Type a single label name
- Reselect Add multiple
- See that the contents you originally typed are unchanged

### Note
This should apply to the sub-nodes form as well.

### Examples

One to multiple:
![nodes-one-to-multiple-sm](https://user-images.githubusercontent.com/179134/65691850-db7f7380-e071-11e9-9552-3a123d5447cf.gif)

Multiple to one:
![nodes-multiple-to-one-sm](https://user-images.githubusercontent.com/179134/65691867-e0dcbe00-e071-11e9-8350-c1b98704b93e.gif)


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
