### PR TITLE
Remove mysql2 gem dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ v3.15 (* 2019)
  - Fix page jump when issues list is collapsed.
  - Enhancement when adding new nodes to copy node label data between the single
    and multiple node forms.
+ - Remove mysql2 gem dependency
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ gem 'json', '1.8.6'
 gem 'nokogiri', '1.10.4'
 
 # MySQL backend
-gem 'mysql2', '~> 0.5.1'
+# gem 'mysql2', '~> 0.5.1'
 
 # actionpack depends on rails-html-sanitizer, which has an XSS vulnerability
 # before 1.0.4, so make sure we're using 1.0.4+:

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'json', '1.8.6'
 # XML manipulation
 gem 'nokogiri', '1.10.4'
 
-# MySQL backend
+# MySQL DB driver: Uncomment this gem to enable MySQL on your instance.
 # gem 'mysql2', '~> 0.5.1'
 
 # actionpack depends on rails-html-sanitizer, which has an XSS vulnerability
@@ -97,7 +97,7 @@ gem 'rinku'
 # html-pipeline dependency for html sanitization
 gem 'sanitize'
 
-# SQLite3 DB driver
+# SQLite3 DB driver: Uncomment this gem to enable SQLite on your instance.
 gem 'sqlite3'#,  '1.3.10'
 
 # --------------------------------------------------------- Dradis Professional

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,6 @@ GEM
     mono_logger (1.1.0)
     multi_json (1.13.1)
     mustermann (1.0.3)
-    mysql2 (0.5.2)
     nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.10.4)
@@ -422,7 +421,6 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   local_time (>= 2.0.0)
-  mysql2 (~> 0.5.1)
   nokogiri (= 1.10.4)
   paper_trail (~> 6.0)
   parslet (~> 1.6.0)


### PR DESCRIPTION
### Summary

We still have mysql2 gem as a dependency, but we use sqlite by default.
Commenting the dependency in the `Gemfile` will help us simplify installation.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry