### PR TITLE
Notifications email preferences

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   alias_attribute :name, :email
 
+  serialize :preferences, UserPreferences
+  validates_associated :preferences
+
   # -- Relationships --------------------------------------------------------
   has_many :activities
   has_many :comments, dependent: :nullify

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -71,7 +71,7 @@ class UserPreferences
 
   def initialize(args={})
     @tours = Hash.new { |hash, key| hash[key] = '0' }
-    @digest_frequency = :none
+    @digest_frequency = :daily
 
     args.each do |key, value|
       if key.to_s =~ /\Atour_([\w_]*)\z/

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -1,0 +1,116 @@
+# This class provides a flexible way to store user preferences using
+# ActiveRecord's @serialize@ technique.
+#
+# This class is a bit of sugar on top of a standard `serialize :prefs, Hash`
+# call as we can inspect the attributes and add additional logic without
+# bloating the User model.
+#
+# The Class methods deal with ActiveRecord dump() and load(), and the Instance
+# methods deal with user preferences.
+#
+# See:
+#   http://viget.com/extend/how-i-used-activerecord-serialize-with-a-custom-data-type
+#   http://ruby-journal.com/how-to-write-custom-serializer-for-activerecord-number-serialize/
+
+class UserPreferences
+  class InvalidTourException < Exception; end
+
+  VALID_TOURS = [:first_sign_in, :projects_show]
+
+  # -- Class Methods ----------------------------------------------------------
+  # Used for `serialize` method in ActiveRecord
+  def self.dump(obj)
+    return if obj.nil?
+
+    unless obj.is_a?(self)
+      raise ::ActiveRecord::SerializationTypeMismatch,
+        "Attribute was supposed to be a #{self}, but was a #{obj.class}. -- #{obj.inspect}"
+    end
+
+    # YAML.dump(obj.attributes)
+    YAML.dump(obj)
+  end
+
+  def self.load(yaml)
+    return self.new if self != Object && yaml.nil?
+    return yaml unless yaml.is_a?(String) && yaml =~ /^---/
+
+    obj = YAML.load(yaml)
+
+    unless obj.is_a?(self) || obj.nil?
+      raise SerializationTypeMismatch,
+        "Attribute was supposed to be a #{self}, but was a #{obj.class}"
+    end
+
+    obj ||= self.new if self != Object
+
+    # self.new(obj)
+    obj
+  end
+
+
+  # -- Instance Methods -------------------------------------------------------
+
+  # Preferences:
+  #   :tours - This setting stores a dictionary of all the tours this user has
+  #            seen. Since we can have multiple versions of each tour we need
+  #            to be able to track what was the last version we presented to
+  #            them. See TourRegistry class.
+  attr_accessor :tours
+
+  def initialize(args={})
+    @tours = Hash.new { |hash, key| hash[key] = '0' }
+
+    args.each do |key, value|
+      if key.to_s =~ /\Atour_([\w_]*)\z/
+        @tours[$1.to_sym] = value
+      end
+    end
+  end
+
+  # ----------------------------------------------------------------- YAML.load
+  # This deals with YAML.load and legacy preferences
+  def init_with(coder)
+    coder.map.each do |key, value|
+      # Move the legacy :last_tour preference under the tour registry
+      # Also, the legacy preferences don't have a :tours attribute
+      if key == 'last_tour'
+        @tours = Hash.new { |hash, key| hash[key] = '0' }
+        @tours[:projects_show] = value
+      elsif key == 'tour' && value == {}
+        @tours = Hash.new { |hash, key| hash[key] = '0' }
+      else
+        instance_variable_set(:"@#{key}", value)
+      end
+    end
+  end
+
+
+  def method_missing(method_sym, *arguments, &block)
+    if method_sym.to_s =~ /\Alast_([\w_]*)=?\z/
+      method = $1
+      raise InvalidTourException.new('Tour not found!') unless VALID_TOURS.include?(method.to_sym)
+
+      if method_sym.to_s.ends_with?('=')
+        @tours[method.to_sym] = arguments.first
+      else
+        @tours[method.to_sym]
+      end
+    else
+      super
+    end
+  end
+
+  def respond_to?(method_sym, include_private = false)
+    if method_sym.to_s =~ /\Alast_([\w_]*)\z/
+      method = $1
+      if VALID_TOURS.include?(method.to_sym)
+        true
+      else
+        false
+      end
+    else
+      super
+    end
+  end
+end

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -14,6 +14,7 @@
 
 class UserPreferences
   class InvalidTourException < Exception; end
+  include ActiveModel::Conversion
   include ActiveModel::Validations
 
   VALID_TOURS = %i[first_sign_in projects_show]
@@ -71,14 +72,19 @@ class UserPreferences
   attr_accessor :tours, :digest_frequency
 
   def initialize(args={})
+    @digest_frequency = args[:digest_frequency] || DIGEST_FREQUENCY_DEFAULT
     @tours = Hash.new { |hash, key| hash[key] = '0' }
-    @digest_frequency = DIGEST_FREQUENCY_DEFAULT
 
     args.each do |key, value|
       if key.to_s =~ /\Atour_([\w_]*)\z/
         @tours[$1.to_sym] = value
       end
     end
+  end
+
+  # Needed for active model conversions, to work with form_with
+  def persisted?
+    true
   end
 
   # ----------------------------------------------------------------- YAML.load

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -17,7 +17,7 @@ class UserPreferences
   include ActiveModel::Validations
 
   VALID_TOURS = %i[first_sign_in projects_show]
-  DIGEST_FREQUENCIES = %i[none instant daily].freeze
+  DIGEST_FREQUENCIES = %w[none instant daily].freeze
 
   validates :digest_frequency,
     inclusion: {
@@ -71,7 +71,7 @@ class UserPreferences
 
   def initialize(args={})
     @tours = Hash.new { |hash, key| hash[key] = '0' }
-    @digest_frequency = :daily
+    @digest_frequency = 'daily'
 
     args.each do |key, value|
       if key.to_s =~ /\Atour_([\w_]*)\z/

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -14,8 +14,16 @@
 
 class UserPreferences
   class InvalidTourException < Exception; end
+  include ActiveModel::Validations
 
-  VALID_TOURS = [:first_sign_in, :projects_show]
+  VALID_TOURS = %i[first_sign_in projects_show]
+  DIGEST_FREQUENCIES = %i[none instant daily].freeze
+
+  validates :digest_frequency,
+    inclusion: {
+      in: DIGEST_FREQUENCIES,
+      digest_frequencies: "'#{DIGEST_FREQUENCIES.join("', '")}'"
+    }
 
   # -- Class Methods ----------------------------------------------------------
   # Used for `serialize` method in ActiveRecord
@@ -52,14 +60,18 @@ class UserPreferences
   # -- Instance Methods -------------------------------------------------------
 
   # Preferences:
-  #   :tours - This setting stores a dictionary of all the tours this user has
-  #            seen. Since we can have multiple versions of each tour we need
-  #            to be able to track what was the last version we presented to
-  #            them. See TourRegistry class.
-  attr_accessor :tours
+  #   tours - This setting stores a dictionary of all the tours this user has
+  #           seen. Since we can have multiple versions of each tour we need
+  #           to be able to track what was the last version we presented to
+  #           them. See TourRegistry class.
+  #
+  #   digest_frequency - A user preference for how often they wish to receive
+  #                      notification emails.
+  attr_accessor :tours, :digest_frequency
 
   def initialize(args={})
     @tours = Hash.new { |hash, key| hash[key] = '0' }
+    @digest_frequency = :none
 
     args.each do |key, value|
       if key.to_s =~ /\Atour_([\w_]*)\z/

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -37,7 +37,6 @@ class UserPreferences
         "Attribute was supposed to be a #{self}, but was a #{obj.class}. -- #{obj.inspect}"
     end
 
-    # YAML.dump(obj.attributes)
     YAML.dump(obj)
   end
 
@@ -58,7 +57,6 @@ class UserPreferences
     obj
   end
 
-
   # -- Instance Methods -------------------------------------------------------
 
   # Preferences:
@@ -69,7 +67,12 @@ class UserPreferences
   #
   #   digest_frequency - A user preference for how often they wish to receive
   #                      notification emails.
-  attr_accessor :tours, :digest_frequency
+  ATTRIBUTES = %i[digest_frequency tours]
+  attr_accessor *ATTRIBUTES
+
+  def to_yaml_properties
+    ATTRIBUTES.map { |attr| :"@#{attr}" }
+  end
 
   def initialize(args={})
     @digest_frequency = args[:digest_frequency] || DIGEST_FREQUENCY_DEFAULT

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -18,6 +18,7 @@ class UserPreferences
 
   VALID_TOURS = %i[first_sign_in projects_show]
   DIGEST_FREQUENCIES = %w[none instant daily].freeze
+  DIGEST_FREQUENCY_DEFAULT = 'instant'.freeze
 
   validates :digest_frequency,
     inclusion: {
@@ -71,7 +72,7 @@ class UserPreferences
 
   def initialize(args={})
     @tours = Hash.new { |hash, key| hash[key] = '0' }
-    @digest_frequency = 'daily'
+    @digest_frequency = DIGEST_FREQUENCY_DEFAULT
 
     args.each do |key, value|
       if key.to_s =~ /\Atour_([\w_]*)\z/

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -99,7 +99,7 @@ class UserPreferences
       if key == 'last_tour'
         @tours = Hash.new { |hash, key| hash[key] = '0' }
         @tours[:projects_show] = value
-      elsif key == 'tour' && value == {}
+      elsif (key == 'tour' || key == 'tours') && value == {}
         @tours = Hash.new { |hash, key| hash[key] = '0' }
       else
         instance_variable_set(:"@#{key}", value)

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -60,13 +60,13 @@ class UserPreferences
   # -- Instance Methods -------------------------------------------------------
 
   # Preferences:
+  #   digest_frequency - A user preference for how often they wish to receive
+  #                      notification emails.
+  #
   #   tours - This setting stores a dictionary of all the tours this user has
   #           seen. Since we can have multiple versions of each tour we need
   #           to be able to track what was the last version we presented to
   #           them. See TourRegistry class.
-  #
-  #   digest_frequency - A user preference for how often they wish to receive
-  #                      notification emails.
   ATTRIBUTES = %i[digest_frequency tours]
   attr_accessor *ATTRIBUTES
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,24 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   activemodel:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activemodel:
+    errors:
+      models:
+        user_preferences:
+          attributes:
+            digest_frequency:
+              inclusion: "'%{value}' is not a valid digest frequency. Valid values are %{digest_frequencies}"

--- a/db/migrate/20140821113937_add_preferences_to_user.rb
+++ b/db/migrate/20140821113937_add_preferences_to_user.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :preferences, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180705112109) do
+ActiveRecord::Schema.define(version: 20190627061318) do
 
   create_table "activities", force: :cascade do |t|
     t.string "user", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,6 +177,7 @@ ActiveRecord::Schema.define(version: 20180705112109) do
     t.string "password_hash"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "preferences"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+describe UserPreferences do
+  it "provides an empty set of preferences with defaults if none have been initialized" do
+    subject.class::VALID_TOURS << :tour_rspec1
+
+    up1 = UserPreferences.new
+    expect(up1.last_tour_rspec1).to eq('0')
+
+    up1 = UserPreferences.new(tour_tour_rspec1: '1')
+    expect(up1.last_tour_rspec1).to eq('1')
+  end
+
+  # UPGRADE: this is the right place to test
+  context "loading from YAML" do
+    # context "valid tour name" do
+    #   it "returns 0 for a fresh set of preferences for a valid tour" do
+    #     subject.class::VALID_TOURS << :tour_rspec4
+    #
+    #     preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours: {}\n"
+    #
+    #     expect do
+    #       preferences.last_tour_rspec4
+    #     end.not_to raise_error
+    #
+    #     expect(preferences.last_tour_rspec4).to eq('0')
+    #   end
+    #
+    #   it "returns the last tour version of XXX type that was visited for a valid tour" do
+    #     subject.class::VALID_TOURS << :tour_rspec5
+    #
+    #     preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours:\n :tour_rspec5: 2.0.0\n"
+    #
+    #     expect do
+    #       preferences.last_tour_rspec5
+    #     end.not_to raise_error
+    #
+    #     expect(preferences.last_tour_rspec5).to eq('2.0.0')
+    #   end
+    # end
+  end
+
+
+  context "#last_tour_XXX" do
+    context "invalid tour name" do
+      it "raises an exception if the tour name isn't valid" do
+        expect do
+          subject.last_tour_rspec2
+        end.to raise_error(UserPreferences::InvalidTourException)
+      end
+    end
+
+    context "valid tour name" do
+      it "returns 0 for a fresh set of preferences for a valid tour" do
+        subject.class::VALID_TOURS << :tour_rspec3
+        expect do
+          subject.last_tour_rspec3
+        end.not_to raise_error
+        expect(subject.last_tour_rspec3).to eq('0')
+      end
+
+      it "returns the last tour version of XXX type that was visited for a valid tour" do
+        subject.class::VALID_TOURS << :tour_rspec3
+        subject.tours[:tour_rspec3] = '1'
+
+        expect do
+          subject.last_tour_rspec3
+        end.not_to raise_error
+        expect(subject.last_tour_rspec3).to eq('1')
+      end
+    end
+  end
+
+  context "#last_tour_XXX=" do
+    it "sets the new tour value" do
+      subject.class::VALID_TOURS << :tour_rspec4
+
+      expect do
+        subject.last_tour_rspec4 = '2'
+      end.not_to raise_error
+
+      expect(subject.last_tour_rspec4).to eq('2')
+    end
+  end
+end

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -13,35 +13,37 @@ describe UserPreferences do
     expect(up1.digest_frequency).to eq 'daily'
   end
 
-  # UPGRADE: this is the right place to test
   context "loading from YAML" do
-    # context "valid tour name" do
-    #   it "returns 0 for a fresh set of preferences for a valid tour" do
-    #     subject.class::VALID_TOURS << :tour_rspec4
-    #
-    #     preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours: {}\n"
-    #
-    #     expect do
-    #       preferences.last_tour_rspec4
-    #     end.not_to raise_error
-    #
-    #     expect(preferences.last_tour_rspec4).to eq('0')
-    #   end
-    #
-    #   it "returns the last tour version of XXX type that was visited for a valid tour" do
-    #     subject.class::VALID_TOURS << :tour_rspec5
-    #
-    #     preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours:\n :tour_rspec5: 2.0.0\n"
-    #
-    #     expect do
-    #       preferences.last_tour_rspec5
-    #     end.not_to raise_error
-    #
-    #     expect(preferences.last_tour_rspec5).to eq('2.0.0')
-    #   end
-    # end
-  end
+    context "valid tour name" do
+      it "returns 0 for a fresh set of preferences for a valid tour" do
+        preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours: {}\n"
 
+        expect do
+          preferences.last_first_sign_in
+        end.not_to raise_error
+
+        expect(preferences.last_first_sign_in).to eq('0')
+      end
+
+      it "returns the last tour version of XXX type that was visited for a valid tour" do
+        preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours:\n :first_sign_in: '2.0.0'\n"
+
+        expect do
+          preferences.last_first_sign_in
+        end.not_to raise_error
+
+        expect(preferences.last_first_sign_in).to eq('2.0.0')
+      end
+    end
+
+    it "only serializes designated attributes" do
+      preferences = UserPreferences.new
+      yaml = UserPreferences.dump(preferences)
+
+      expect(yaml).to eq "--- !ruby/object:UserPreferences\ndigest_frequency: instant\ntours: {}\n"
+      expect(yaml).not_to include 'errors'
+    end
+  end
 
   context "#last_tour_XXX" do
     context "invalid tour name" do

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -6,9 +6,11 @@ describe UserPreferences do
 
     up1 = UserPreferences.new
     expect(up1.last_tour_rspec1).to eq('0')
+    expect(up1.digest_frequency).to eq 'instant'
 
-    up1 = UserPreferences.new(tour_tour_rspec1: '1')
+    up1 = UserPreferences.new(tour_tour_rspec1: '1', digest_frequency: 'daily')
     expect(up1.last_tour_rspec1).to eq('1')
+    expect(up1.digest_frequency).to eq 'daily'
   end
 
   # UPGRADE: this is the right place to test
@@ -84,23 +86,14 @@ describe UserPreferences do
   end
 
   context '#digest_frequency' do
-    it 'is valid with pre-defined values' do
-      described_class::DIGEST_FREQUENCIES.each do |setting|
-        subject.digest_frequency = setting
-        expect(subject).to be_valid
-      end
+    it do
+      should validate_inclusion_of(:digest_frequency).
+        in_array(described_class::DIGEST_FREQUENCIES)
     end
 
-    it 'is not valid with non-defined values' do
-      subject.digest_frequency = 'notvalid'
-      expect(subject).to be_invalid
-    end
-
-    it 'does not accept pre-defined values symbols' do
-      described_class::DIGEST_FREQUENCIES.each do |setting|
-        subject.digest_frequency = setting.to_sym
-        expect(subject).to be_invalid
-      end
+    it 'does not accept values as symbols' do
+      should_not validate_inclusion_of(:digest_frequency).
+        in_array(described_class::DIGEST_FREQUENCIES.map(&:to_sym))
     end
   end
 end

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -82,4 +82,25 @@ describe UserPreferences do
       expect(subject.last_tour_rspec4).to eq('2')
     end
   end
+
+  context '#digest_frequency' do
+    it 'is valid with pre-defined values' do
+      described_class::DIGEST_FREQUENCIES.each do |setting|
+        subject.digest_frequency = setting
+        expect(subject).to be_valid
+      end
+    end
+
+    it 'is not valid with non-defined values' do
+      subject.digest_frequency = 'notvalid'
+      expect(subject).to be_invalid
+    end
+
+    it 'does not accept pre-defined values symbols' do
+      described_class::DIGEST_FREQUENCIES.each do |setting|
+        subject.digest_frequency = setting.to_sym
+        expect(subject).to be_invalid
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Spec
I want to manage my notification settings, so I can choose between getting notifications in instant intervals, once a day, or not at all.

Once notifications have been implemented users would receive both instant digests and daily digests.

# Proposed solution
We will create notification settings to allow users to decide between having no notifications, instant digests, or digests. These settings will be available through the console only.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
