### PR TITLE
Notifications mentions avatars

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ v3.15 (* 2019)
    scrolled.
  - Fix bug that prevents the mentions dialog from appearing after navigating
    through the app.
+ - Fixed elongated avatar images so they are round once again.
+ - Added avatar images to mentions in comments.
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -136,6 +136,10 @@
   img {
     @include rounded(50%)
   }
+
+  &.gravatar-inline {
+    margin-bottom: -3px;
+  }
 }
 
 table.table-ajax-inputs {

--- a/app/assets/stylesheets/snowcrash/modules.scss
+++ b/app/assets/stylesheets/snowcrash/modules.scss
@@ -138,7 +138,9 @@
   }
 
   &.gravatar-inline {
-    margin-bottom: -3px;
+    margin: 0 0 -3px 0;
+    float: none;
+    white-space: nowrap;
   }
 }
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -3,6 +3,7 @@
 
 class ActivitiesController < AuthenticatedController
   include ProjectScoped
+  include Commented
 
   def poll
     @this_poll  = Time.now.to_i

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < AuthenticatedController
   include ActivityTracking
   include ProjectScoped
+  include Commented
 
   load_and_authorize_resource
 
@@ -25,6 +26,11 @@ class CommentsController < AuthenticatedController
   end
 
   private
+
+  # This is cheeky code to make mentions work from concerns/commented
+  def comments
+    [@comment]
+  end
 
   def comment_params
     params.require(:comment).permit(:content, :commentable_type, :commentable_id)

--- a/app/controllers/concerns/commented.rb
+++ b/app/controllers/concerns/commented.rb
@@ -2,7 +2,8 @@ module Commented
   extend ActiveSupport::Concern
 
   included do
-    helper_method :commentable, :comments
+    helper_method :commentable, :comments,
+                  :mentioned_users_replacement_rules, :mentioned_users_matcher
   end
 
   def commentable
@@ -11,5 +12,26 @@ module Commented
 
   def comments
     @comments ||= commentable.comments.includes(:user)
+  end
+
+  def mentioned_users
+    @mentioned_users ||= begin
+      # Match any non whitespace that starts with an @ has another @
+      emails = comments.inject([]) do |collection, comment|
+        (collection + comment.content.scan(/@(\S*@\S*)/)).flatten.uniq
+      end
+
+      current_project.authors.where(email: emails)
+    end
+  end
+
+  def mentioned_users_matcher
+    @mentioned_users_matcher ||= /#{mentioned_users.map { |user| '@' + user.email }.join('|')}/
+  end
+
+  def mentioned_users_replacement_rules
+    @mentioned_users_replacement_rules ||= mentioned_users.each_with_object({}) do |user, hash|
+      hash['@' + user.email] = view_context.avatar_image(user, size: 20, include_name: true, class: 'gravatar gravatar-inline')
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,28 +1,4 @@
 module ApplicationHelper # :nodoc:
-  def avatar_url(user, options = {})
-    # The arguments are a noop here for CE-Pro parity.
-    image_path('profile.jpg')
-  end
-
-  def avatar_image(user, options = {})
-    alt            = options.fetch(:alt, "#{user.email}'s avatar")
-    fallback_image = options.fetch(:fallback_image, image_path('logo_small.png'))
-    include_name   = options.fetch(:include_name, false)
-    size           = options.fetch(:size, 73)
-    title          = options.fetch(:title, user.email)
-
-    content_tag :span, class: 'gravatar' do
-      image_tag(
-        avatar_url(user, size: size),
-        alt: alt,
-        data: { fallback_image: fallback_image },
-        title: title,
-        height: size,
-        width: size
-      ) + (include_name ? ' ' + user.email : '')
-    end
-  end
-
   def markup(text)
     return unless text.present?
 

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -19,7 +19,8 @@ module AvatarHelper
         data: { fallback_image: fallback_image },
         title: title,
         height: size,
-        width: size
+        width: size,
+        style: "width: #{size}px; height: #{size}px"
       ) + (include_name ? ' ' + user.email : '')
     end
   end
@@ -38,6 +39,6 @@ module AvatarHelper
   end
 
   def comment_formatter(comment)
-    simple_format(comment_avatars(h(comment)))
+    comment_avatars(simple_format(h(comment))).html_safe
   end
 end

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -26,16 +26,7 @@ module AvatarHelper
   end
 
   def comment_avatars(comment)
-    # Match any string that starts with an @ has another @ and ends with whitespace
-    emails = comment.scan(/@(\S*@\S*)\s/).flatten.uniq
-    users = current_project.authors.where(email: emails)
-
-    replacement_rules = users.each_with_object({}) do |user, hash|
-      hash['@' + user.email] = avatar_image(user, size: 20, include_name: true, class: 'gravatar gravatar-inline')
-    end
-
-    matcher = /#{users.map { |user| '@' + user.email }.join('|')}/
-    comment.gsub(matcher, replacement_rules)
+    comment.gsub(mentioned_users_matcher, mentioned_users_replacement_rules)
   end
 
   def comment_formatter(comment)

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -23,4 +23,11 @@ module AvatarHelper
       ) + (include_name ? ' ' + user.email : '')
     end
   end
+
+  def comment_avatars(comment)
+    comment.gsub(/@\w*@\w*\.\w*/) do |capture|
+      user = User.find_by(email: capture[1..-1])
+      user ? avatar_image(user, size: 20, include_name: true) : capture
+    end
+  end
 end

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -26,7 +26,11 @@ module AvatarHelper
   end
 
   def comment_avatars(comment)
-    comment.gsub(mentioned_users_matcher, mentioned_users_replacement_rules)
+    # Support both concers/commented Comments collection for most views
+    # as well as rendering 1-off's for polling and ajax requests.
+    collection = comments ? comments.map(&:content) : Array(comment)
+    matcher, rules = mentions_builder(collection)
+    comment.gsub(matcher, rules)
   end
 
   def comment_formatter(comment)

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,0 +1,26 @@
+module AvatarHelper
+  def avatar_url(user, options = {})
+    # The arguments are a noop here for CE-Pro parity.
+    image_path('profile.jpg')
+  end
+
+  def avatar_image(user, options = {})
+    alt            = options.fetch(:alt, "#{user.email}'s avatar")
+    fallback_image = options.fetch(:fallback_image, image_path('logo_small.png'))
+    include_name   = options.fetch(:include_name, false)
+    size           = options.fetch(:size, 73)
+    title          = options.fetch(:title, user.email)
+    klass          = options.fetch(:class, 'gravatar')
+
+    content_tag :span, class: klass do
+      image_tag(
+        avatar_url(user, size: size),
+        alt: alt,
+        data: { fallback_image: fallback_image },
+        title: title,
+        height: size,
+        width: size
+      ) + (include_name ? ' ' + user.email : '')
+    end
+  end
+end

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -30,7 +30,7 @@ module AvatarHelper
     users = current_project.authors.where(email: emails)
 
     replacement_rules = users.each_with_object({}) do |user, hash|
-      hash['@' + user.email] = avatar_image(user, size: 20, include_name: true)
+      hash['@' + user.email] = avatar_image(user, size: 20, include_name: true, class: 'gravatar gravatar-inline')
     end
 
     matcher = /#{users.map { |user| '@' + user.email }.join('|')}/

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -36,4 +36,8 @@ module AvatarHelper
     matcher = /#{users.map { |user| '@' + user.email }.join('|')}/
     comment.gsub(matcher, replacement_rules)
   end
+
+  def comment_formatter(comment)
+    simple_format(comment_avatars(h(comment)))
+  end
 end

--- a/app/presenters/activity_presenter.rb
+++ b/app/presenters/activity_presenter.rb
@@ -88,7 +88,8 @@ class ActivityPresenter < BasePresenter
         class: 'gravatar',
         data: { fallback_image: image_path('logo_small.png') },
         title: activity.user,
-        width: size
+        width: size,
+        style: "width: #{size}px; height: #{size}px"
       )
     else
       h.image_tag 'logo_small.png', width: size, alt: 'This user has been deleted from the system'

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -59,7 +59,8 @@ class NotificationPresenter < BasePresenter
         class: 'gravatar',
         data: { fallback_image: image_path('logo_small.png') },
         title: notification.actor.email,
-        width: size
+        width: size,
+        style: "width: #{size}px; height: #{size}px"
       )
     else
       h.image_tag 'logo_small.png', width: size, alt: 'This user has been deleted from the system'

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="content">
-      <%= simple_format(comment_avatars(h(comment.content))) %>
+      <%= comment_formatter(comment.content) %>
     </div>
   </div>
 <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="content">
-      <%= simple_format(h(comment.content)) %>
+      <%= simple_format(comment_avatars(h(comment.content))) %>
     </div>
   </div>
 <% end %>

--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,3 +1,3 @@
 $('#<%= dom_id(@comment) %> form').hide();
-$('#<%= dom_id(@comment) %> .content').html("<%= j(simple_format(h(@comment.content))) %>");
+$('#<%= dom_id(@comment) %> .content').html("<%= j(comment_formatter(@comment.content)) %>");
 $('#<%= dom_id(@comment) %> .content').show();


### PR DESCRIPTION
## Spec
I want to see recognizable avatars beside users names/emails when they have been mentioned in comments.

Currently when a user is mentioned in a comment their email will show up as @user@company.com In the comment. Instead we want it to show the name (pro), or email (ce) alongside their avatar.

Proposed solution
Update the comment formatters to provide the avatars and present the username/email better.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
