### PR TITLE
Use textile in item tables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ v3.15 (* 2019)
  - Fixed elongated avatar images so they are round once again.
  - Added avatar images to mentions in comments.
  - Load gravatars for users who's email has been setup with gravatar.
+ - Use textile in item tables columns
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -32,7 +32,7 @@
             when 'Updated'
               local_time_ago(issue.updated_at)
             else
-              issue.fields.fetch(column, '')
+              markup(issue.fields.fetch(column, ''))
             end
             %>
           </td>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -32,7 +32,7 @@
             when 'Updated'
               local_time_ago(item.updated_at)
             else
-              item.fields.fetch(column, '')
+              markup(item.fields.fetch(column, ''))
             end
             %>
           </td>


### PR DESCRIPTION
### Summary

Currently, when an issue, note etc have a link in the following format:
`"Link text":http://linkaddress.com`
The link displays as expected in textile div's. For example the above would look like:
[Link text](http://google.com)

But when viewing issues summary or any other view that uses items_table the links are displayed like this:
﻿
<img width="227" alt="preview-full-Screen Shot 2019-10-24 at 8 16 46 PM" src="https://user-images.githubusercontent.com/85766/68214272-047e1700-ffd5-11e9-8572-e3fdf3214a40.png">
﻿
**Proposed solution**
Use textile in the table columns too.

### How to test

1. Add an issue with a Description field that contains links, images, code blocks
2. Visit the issue index page, and make the Description column appear in the table
3. Does it look ok ?

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry