### PR TITLE
Upgrade Nokogiri for CVE-2019-13117

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ v3.15 (* 2019)
  - Fixed elongated avatar images so they are round once again.
  - Added avatar images to mentions in comments.
  - Load gravatars for users who's email has been setup with gravatar.
+ - Upgraded Nokogiri as per suggested solution for CVE-2019-13117
 
 v3.14 (August 2019)
  - Highlight code snippets.

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'bcrypt',   '3.1.12'
 gem 'json', '1.8.6'
 
 # XML manipulation
-gem 'nokogiri', '1.10.4'
+gem 'nokogiri', '1.10.5'
 
 # MySQL backend
 gem 'mysql2', '~> 0.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
     mysql2 (0.5.2)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -423,7 +423,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   local_time (>= 2.0.0)
   mysql2 (~> 0.5.1)
-  nokogiri (= 1.10.4)
+  nokogiri (= 1.10.5)
   paper_trail (~> 6.0)
   parslet (~> 1.6.0)
   puma


### PR DESCRIPTION
### Summary
Bundler audit caught raised a CVE advisory. This upgrades nokogiri as per the cve solution.

``` 
Updated ruby-advisory-db
ruby-advisory-db: 421 advisories
Name: nokogiri
Version: 1.10.4
Advisory: CVE-2019-13117
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1943
Title: Nokogiri gem, via libxslt, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.10.5
```

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
