### PR TITLE
Fix tribute avatar rendering

### DIFF
--- a/app/assets/stylesheets/snowcrash/modules/_comments.scss
+++ b/app/assets/stylesheets/snowcrash/modules/_comments.scss
@@ -75,3 +75,6 @@
 .tribute-container .menu-highlighted {
   font-weight: bold;
 }
+.tribute-container img {
+  border-radius: 50%;
+}


### PR DESCRIPTION
### Summary

The tribute avatar renders square, and it should be round. Add style to change that.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.