### PR TITLE
Return if a user isn't found

### DIFF
--- a/lib/html/pipeline/dradis_mentions_filter.rb
+++ b/lib/html/pipeline/dradis_mentions_filter.rb
@@ -11,6 +11,8 @@ module HTML
     class DradisMentionsFilter < HTML::Pipeline::MentionFilter
       def link_to_mentioned_user(login)
         user = context[:mentionable_users].find { |u| u.email == login }
+        return unless user
+
         result[:mentioned_usernames] |= [login]
 
         context[:view_context].avatar_image(user, size: 20, include_name: true, class: 'gravatar gravatar-inline')


### PR DESCRIPTION
Otherwise we render the eqivlant of a "deleted user" avatar.

This bug introduction happened when the code moved into the html pipeline

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
