### PR TITLE
Avatar fallback

### DIFF
--- a/app/assets/javascripts/snowcrash/behaviors.js.coffee
+++ b/app/assets/javascripts/snowcrash/behaviors.js.coffee
@@ -139,15 +139,6 @@ document.addEventListener "turbolinks:load", ->
   # $("[data-hide]").on 'click', ->
   #   $(this).closest("." + $(this).data('hide')).hide();
 
-  # Offline Gravatars
-  if $('.gravatar img').length
-    $('.gravatar img').each ->
-      $this = $(this)
-      img = new Image()
-      img.onerror = ->
-        $this.attr('src', $this.data('fallback-image'))
-      img.src = $this.attr('src')
-
   if ($poller = $("#activities-poller")).length
     unless ActivitiesPoller.initialized
       ActivitiesPoller.init($poller)

--- a/app/assets/javascripts/snowcrash/modules/mentions.js
+++ b/app/assets/javascripts/snowcrash/modules/mentions.js
@@ -1,10 +1,12 @@
 (function(window) {
   window.Mentions = {
     init: function(elements) {
+      fallbackImage = $('meta[name=mentionable-users]').data('fallback-image');
+
       tribute = new Tribute({
         allowSpaces: function() { return false },
         menuItemTemplate: function(item) {
-          return '<img src="' + item.original.avatar_url + '" width="24px" height="24px" > ' + item.string
+          return '<img src="' + item.original.avatar_url + '" width="24px" height="24px" onerror="this.src = \'' + fallbackImage + '\';"> ' + item.string
         },
         noMatchTemplate: function() { return '' },
         values: JSON.parse($('meta[name=mentionable-users]').attr('content'))

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -43,4 +43,14 @@ module AvatarHelper
         (opt[:include_name] ? " #{user.try(:name)}" : '')
     end
   end
+
+  def tribute_hash(users)
+    users.map do |user|
+      {
+        key: h(user.email),
+        value: user.email,
+        avatar_url: avatar_url(user)
+      }
+    end
+  end
 end

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -20,7 +20,6 @@ module AvatarHelper
       alt: I18n.t(user ? :alt : :removed, name: user.try(:name), scope: 'helpers.avatar_helper'),
       fallback_image: image_url(DEFAULT_PROFILE_IMAGE),
       include_name: false,
-      inline_onerror: false,
       size: DEFAULT_PROFILE_IMAGE_SIZE,
       title: user.try(:name)
     ).merge!( # Additive properties
@@ -32,12 +31,12 @@ module AvatarHelper
       alt: opt[:alt],
       data: { fallback_image: opt[:fallback_image] },
       height: opt[:size],
+      onerror: "this.src = '#{opt[:fallback_image]}';",
       style: opt[:style],
       title: opt[:title],
       width: opt[:size]
     }
 
-    img_properties.merge!(onerror: "this.src = '#{opt[:fallback_image]}';") if opt[:inline_onerror]
 
     content_tag :span, class: opt[:class] do
       image_tag(avatar_url(user, size: opt[:size]), img_properties) +

--- a/app/presenters/digest_presenter.rb
+++ b/app/presenters/digest_presenter.rb
@@ -8,7 +8,6 @@ class DigestPresenter < NotificationPresenter
   end
 
   def avatar_with_link(opts)
-    opts.merge!(inline_onerror: true)
     h.link_to(avatar_image(notification.actor, opts), 'javascript:void(0)')
   end
 

--- a/app/views/comments/_mentionable_users.html.erb
+++ b/app/views/comments/_mentionable_users.html.erb
@@ -1,10 +1,8 @@
 <%# this is picked up by javascripts/snowcrash/modules/comments.js.coffee %>
 <% cache(@mentionable_users) do %>
-  <meta name="mentionable-users" content="<%= @mentionable_users.map do |user|
-    {
-      key: h(user.email),
-      value: user.email,
-      avatar_url: avatar_url(user)
-    }
-  end.to_json %>" data-fallback-image="<%= image_url(AvatarHelper::DEFAULT_PROFILE_IMAGE) %>">
+  <%= content_tag :meta, '',
+    content: tribute_hash(@mentionable_users).to_json,
+    data: { fallback_image: image_url(AvatarHelper::DEFAULT_PROFILE_IMAGE) },
+    name: 'mentionable-users'
+  %>
 <% end %>

--- a/app/views/comments/_mentionable_users.html.erb
+++ b/app/views/comments/_mentionable_users.html.erb
@@ -6,5 +6,5 @@
       value: user.email,
       avatar_url: avatar_url(user)
     }
-  end.to_json %>">
+  end.to_json %>" data-fallback-image="<%= image_url(AvatarHelper::DEFAULT_PROFILE_IMAGE) %>">
 <% end %>


### PR DESCRIPTION
### Summary

Use the image inline onerror fallback for all avatars. This prevents issues with asynchronously loaded views such as comments or activities. Previously the fallback js was applied on pageload which meant async renders would not have the fallback applied. 

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
