### PR TITLE
Use rubygems as dradis-plugins and dradis-projects source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,13 +206,13 @@ end
 #
 
 # Base framework classes required by other plugins
-gem 'dradis-plugins', '~> 3.15', github: 'dradis/dradis-plugins', branch: 'release-3.15'
+gem 'dradis-plugins', '~> 3.15'
 
 
 gem 'dradis-api', path: 'engines/dradis-api'
 
 # Import / export project data
-gem 'dradis-projects', '~> 3.15', github: 'dradis/dradis-projects', branch: 'release-3.15'
+gem 'dradis-projects', '~> 3.15'
 
 plugins_file = 'Gemfile.plugins'
 if File.exists?(plugins_file)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,3 @@
-GIT
-  remote: https://github.com/dradis/dradis-plugins.git
-  revision: 4c6ba6fc11de0b4b60ff67b81b156529e60c473d
-  branch: release-3.15
-  specs:
-    dradis-plugins (3.15.0)
-
-GIT
-  remote: https://github.com/dradis/dradis-projects.git
-  revision: e707a8f3f208d2c2fdb95caf5a75223c43edb24c
-  branch: release-3.15
-  specs:
-    dradis-projects (3.15.0)
-      dradis-plugins (~> 3.7)
-      rubyzip
-
 PATH
   remote: engines/dradis-api
   specs:
@@ -106,6 +90,10 @@ GEM
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     differ (0.1.2)
+    dradis-plugins (3.15.0)
+    dradis-projects (3.15.0)
+      dradis-plugins (~> 3.7)
+      rubyzip
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -405,8 +393,8 @@ DEPENDENCIES
   database_cleaner
   differ (~> 0.1.2)
   dradis-api!
-  dradis-plugins (~> 3.15)!
-  dradis-projects (~> 3.15)!
+  dradis-plugins (~> 3.15)
+  dradis-projects (~> 3.15)
   factory_bot_rails
   font-awesome-sass (~> 4.7.0)
   foreman
@@ -459,4 +447,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Update the `Gemfile` to make `dradis-plugins` and `dradis-projects` use rubygems instead.