### PR TITLE
When copying attachments url from a node attachments box, insert blank lines by default

### DIFF
--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -6,7 +6,7 @@
     <div class="header-inner">
       <div class="options">
         <div class="dropdown">
-          <%= link_to 'javascript:void(0)', 
+          <%= link_to 'javascript:void(0)',
             data: { toggle: 'collapse', target: '#attachment-box', behavior: 'collapse-collection' } do %>
             <i class="fa fa-chevron-up" data-behavior="toggle-chevron"></i>
           <% end %>
@@ -46,7 +46,7 @@
 
                 <button
                   class="btn btn-transparent js-attachment-url-copy"
-                  data-clipboard-text="!<%= project_node_attachment_path(node.project, node, attachment.filename) %>!"
+                  data-clipboard-text="!<%= "\n!" + project_node_attachment_path(node.project, node, attachment.filename) + "!\n" %>!"
                 >
                   <i class="fa fa-link"></i>
                 </button>


### PR DESCRIPTION
### Specs
We introduced in Pro the screenshot validator some time ago.
That validator ensures that when copying over an attachment textile link, blank lines are present before and after the textile link.
But when we copy the attachment url with the mouse, these lines are still not present.

**Proposed solution** 
Add these extra lines by default when clicking the "copy url" link icon, so when pasted on the text area we don't have to add them manually.
 
### How to test
Add an attachment
Copy it from the link icon in the attachments box an paste it into an issue
Assert that when copied, it contains blank lines before and after the textile link.

### Check List

- [ ] Added a CHANGELOG entry

-----

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
