### PR TITLE
Use find_by_id in warden initializer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.16 (Mmm'YY)
   * Fix errors on content overwrite flash messages
+  * Fail and redirect to login instead of raising an error when attempting to log in as a user that has been removed.
   * Bugs fixed:
     -
   * Integration enhancements:

--- a/config/initializers/warden_00_authentication.rb
+++ b/config/initializers/warden_00_authentication.rb
@@ -8,13 +8,7 @@ Warden::Manager.serialize_into_session do |user|
 end
 
 Warden::Manager.serialize_from_session do |id|
-  User.find(id)
-end
-
-
-Rails.configuration.middleware.use Warden::Manager do |manager|
-  manager.default_strategies :shared_password
-  manager.failure_app = ->(env) { SessionsController.action(:failure).call(env) }
+  User.find_by_id(id)
 end
 
 # A simple db-backed strategy that uses the User.authenticate() method.
@@ -34,4 +28,23 @@ Warden::Strategies.add(:shared_password) do
       fail 'Invalid credentials.'
     end
   end
+end
+
+# A simple db-backed strategy that uses the User.authenticate() method.
+Warden::Strategies.add(:db) do
+  def valid?
+    params['login'] || params['password']
+  end
+  def authenticate!
+    if (user = User.enabled.authenticate(params['login'], params['password']))
+      success!(user)
+    else
+      fail! 'Invalid credentials.'
+    end
+  end
+end
+
+Rails.configuration.middleware.use Warden::Manager do |manager|
+  manager.default_strategies :shared_password
+  manager.failure_app = ->(env) { SessionsController.action(:failure).call(env) }
 end

--- a/config/initializers/warden_00_shared_password.rb
+++ b/config/initializers/warden_00_shared_password.rb
@@ -11,6 +11,12 @@ Warden::Manager.serialize_from_session do |id|
   User.find_by_id(id)
 end
 
+
+Rails.configuration.middleware.use Warden::Manager do |manager|
+  manager.default_strategies :shared_password
+  manager.failure_app = ->(env) { SessionsController.action(:failure).call(env) }
+end
+
 # A simple db-backed strategy that uses the User.authenticate() method.
 Warden::Strategies.add(:shared_password) do
   def valid?
@@ -28,23 +34,4 @@ Warden::Strategies.add(:shared_password) do
       fail 'Invalid credentials.'
     end
   end
-end
-
-# A simple db-backed strategy that uses the User.authenticate() method.
-Warden::Strategies.add(:db) do
-  def valid?
-    params['login'] || params['password']
-  end
-  def authenticate!
-    if (user = User.enabled.authenticate(params['login'], params['password']))
-      success!(user)
-    else
-      fail! 'Invalid credentials.'
-    end
-  end
-end
-
-Rails.configuration.middleware.use Warden::Manager do |manager|
-  manager.default_strategies :shared_password
-  manager.failure_app = ->(env) { SessionsController.action(:failure).call(env) }
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:email){ |n| "user-#{n}@example.com" }
+    password_hash 'test'
     trait :admin do
     end
     trait :author do

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -9,13 +9,18 @@ describe 'Sessions' do
       name: 'admin:password',
       value: ::BCrypt::Password.create('rspec_pass')
     )
+    @user = create(
+      :user,
+      :author,
+      password_hash: ::BCrypt::Password.create('rspec_pass')
+    )
   end
 
   let(:password) { 'rspec_pass' }
 
   let(:login) do
     visit login_path
-    fill_in 'login', with: 'rspec_user'
+    fill_in 'login', with: @user.email
     fill_in 'password', with: password
     click_button 'Let me in!'
   end
@@ -57,7 +62,7 @@ describe 'Sessions' do
       login
 
       @user.destroy
-      visit projects_path
+      visit project_path(Project.find(1))
 
       expect(current_path).to eq(login_path)
       expect(page).to have_content('Access denied')

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -51,4 +51,16 @@ describe 'Sessions' do
       end
     end
   end
+
+  context 'when the user is deleted' do
+    it 'forces a logout' do
+      login
+
+      @user.destroy
+      visit projects_path
+
+      expect(current_path).to eq(login_path)
+      expect(page).to have_content('Access denied')
+    end
+  end
 end


### PR DESCRIPTION
### Spec
Currently, when a user is deleted, their session is still treated by the server as valid. This returns an error for the logged-in user.

**Proposed solution**
Use `find_by` instead so as to not throw an error.

### How to test

1. Login using an author account
2. Using the rails console, delete the user.
3. In the browser, try accessing any link
4. Confirm that the session was logged out