### PR TITLE
Add tags CRUD function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ v3.16 (February 2020)
     - Fix errors on content overwrite flash messages
     - Fail and redirect to login instead of raising an error when attempting to log in as a user that has been removed.
   * Integration enhancements:
-    -
+    - Add tags CRUD functions
   * REST/JSON API enhancements:
     -
   * Security Fixes:

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -6,7 +6,7 @@ class TagsController < ApplicationController
 
   def create
     respond_to do |format|
-      if @tag.update(tag_params)
+      if @tag.save
         track_created(@tag)
 
         format.html { redirect_to project_issues_path(current_project), notice: 'Tag added.' }
@@ -45,11 +45,11 @@ class TagsController < ApplicationController
     if params[:id]
       @tag = Tag.find(params[:id])
     else
-      @tag = Tag.new(name: '!555555_tag')
+      @tag = Tag.new(tag_params)
     end
   end
 
   def tag_params
-    params.require(:tag).permit(:display_name, :color)
+    params.require(:tag).permit(:name)
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,55 @@
+class TagsController < ApplicationController
+  include ActivityTracking
+  include ProjectScoped
+
+  before_action :set_or_initialize_tag
+
+  def create
+    respond_to do |format|
+      if @tag.update(tag_params)
+        track_created(@tag)
+
+        format.html { redirect_to project_issues_path(current_project), notice: 'Tag added.' }
+      else
+        format.html { redirect_to project_issues_path(current_project), alert: "Tag couldn't be added. #{@tag.errors.full_messages.join("\n")}" }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @tag.update(tag_params)
+        @modified = true
+        track_updated(@tag)
+        format.html { redirect_to project_issues_path(current_project), notice: 'Tag updated' }
+      else
+        format.html { redirect_to project_issues_path(current_project), alert: "Error while updating tag: #{@tag.errors.full_messages.join("\n")}" }
+      end
+    end
+  end
+
+  def destroy
+    respond_to do |format|
+      if @tag.destroy
+        track_destroyed(@tag)
+        format.html { redirect_to project_issues_path(current_project), notice: "Tag deleted." }
+      else
+        format.html { redirect_to project_issues_path(current_project), notice: "Error while deleting tag: #{@tag.errors.full_messages.join("\n")}" }
+      end
+    end
+  end
+
+  private
+
+  def set_or_initialize_tag
+    if params[:id]
+      @tag = Tag.find(params[:id])
+    else
+      @tag = Tag.new(name: '!555555_tag')
+    end
+  end
+
+  def tag_params
+    params.require(:tag).permit(:display_name, :color)
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -22,8 +22,7 @@ class Tag < ApplicationRecord
   before_save :normalize_name
 
   # -- Validations ------------------------------------------------------------
-  validates :name, presence: true, uniqueness: { case_sensitive: false },
-    format: { with: /\A(!\h{6}(_([[:word:]]+))?|#[[:word:]]|@[[:word:]])\z/ }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   # -- Scopes -----------------------------------------------------------------
 
@@ -49,20 +48,10 @@ class Tag < ApplicationRecord
     return out.titleize
   end
 
-  def display_name=(new_display_name)
-    self.name.gsub!(/\A!(\h{6})_[[:word:]]+?\z/, "!\\1_#{new_display_name}")
-  end
-
   # Strips the tag's name and returns the color details if present
   # if no color information is found, returns a default value of #ccc
   def color()
     name[/\A(!\h{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || '#cccccc'
-  end
-
-  def color=(new_color)
-    new_color = new_color.tr('#', '')
-
-    self.name.gsub!(/\A!(\h{6})_([[:word:]]+)?\z/, "!#{new_color}_\\2")
   end
 
   private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -22,7 +22,8 @@ class Tag < ApplicationRecord
   before_save :normalize_name
 
   # -- Validations ------------------------------------------------------------
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false },
+    format: { with: /\A(!\h{6}(_([[:word:]]+))?|#[[:word:]]|@[[:word:]])\z/ }
 
   # -- Scopes -----------------------------------------------------------------
 
@@ -48,10 +49,20 @@ class Tag < ApplicationRecord
     return out.titleize
   end
 
+  def display_name=(new_display_name)
+    self.name.gsub!(/\A!(\h{6})_[[:word:]]+?\z/, "!\\1_#{new_display_name}")
+  end
+
   # Strips the tag's name and returns the color details if present
   # if no color information is found, returns a default value of #ccc
   def color()
-    name[/\A(!\h{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || "#555"
+    name[/\A(!\h{6})_[[:word:]]+?\z/,1].try(:gsub, "!", "#") || '#cccccc'
+  end
+
+  def color=(new_color)
+    new_color = new_color.tr('#', '')
+
+    self.name.gsub!(/\A!(\h{6})_([[:word:]]+)?\z/, "!#{new_color}_\\2")
   end
 
   private

--- a/app/views/activities/_tag.html.erb
+++ b/app/views/activities/_tag.html.erb
@@ -1,0 +1,9 @@
+<% if tag %>
+  <%= presenter.verb %> the <%= link_to (tag.display_name ? tag.display_name : tag.name), project_issues_path(current_project) %> Tag.
+<% else %>
+  <% if activity.action == 'destroy' %>
+    deleted a tag.
+  <% else %>
+    <%= presenter.verb %> a tag which has since been deleted.
+  <% end %>
+<% end %>

--- a/app/views/issues/_sidebar.html.erb
+++ b/app/views/issues/_sidebar.html.erb
@@ -14,3 +14,5 @@
   category_id: nil
 %>
 <%= render 'import_box' %>
+
+<%= render 'tags' %>

--- a/app/views/issues/_tag_edit_form.html.erb
+++ b/app/views/issues/_tag_edit_form.html.erb
@@ -1,0 +1,16 @@
+<%= content_tag :div, id: tag.persisted? ? "tag-#{tag.id}" : 'new-tag', class: 'dropdown-menu' do %>
+  <%= form_for [current_project, tag] do |f| %>
+      <%= f.label :display_name %>
+      <%= f.text_field :display_name, class: 'form-control' %>
+      <%= f.label :color %>
+      <%= f.text_field :color, class: 'form-control' %>
+
+    <% if tag.persisted? %>
+      <%= f.hidden_field :original_updated_at, value: tag.updated_at.to_i %>
+    <% end %>
+
+    <div class="form-actions">
+      <%= f.submit class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/issues/_tag_edit_form.html.erb
+++ b/app/views/issues/_tag_edit_form.html.erb
@@ -1,13 +1,7 @@
 <%= content_tag :div, id: tag.persisted? ? "tag-#{tag.id}" : 'new-tag', class: 'dropdown-menu' do %>
   <%= form_for [current_project, tag] do |f| %>
-      <%= f.label :display_name %>
-      <%= f.text_field :display_name, class: 'form-control' %>
-      <%= f.label :color %>
-      <%= f.text_field :color, class: 'form-control' %>
-
-    <% if tag.persisted? %>
-      <%= f.hidden_field :original_updated_at, value: tag.updated_at.to_i %>
-    <% end %>
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control' %>
 
     <div class="form-actions">
       <%= f.submit class: 'btn btn-primary' %>

--- a/app/views/issues/_tags.html.erb
+++ b/app/views/issues/_tags.html.erb
@@ -1,0 +1,48 @@
+<div class="header">
+  <div class="header-inner">
+    <div class="options">
+
+<div class="dropdown <%= local_assigns.fetch(:dropdown_class, '') %>">
+  <%= link_to 'javascript:void(0)',
+    class: local_assigns.fetch(:button_class, '') + ' dropdown-toggle',
+    data: { name: "new-tag", toggle: 'dropdown' } do %>
+    <i class="fa fa-plus"> </i> <%= local_assigns.fetch(:text, '') %>
+  <% end %>
+
+  <%= link_to 'javascript:void(0)', data: { toggle: 'collapse', target: "#tags", behavior: 'collapse-collection' }, class: local_assigns.fetch(:collapse_class, '') do %>
+    <i class="fa fa-chevron-up" data-behavior="toggle-chevron"></i>
+  <% end %>
+
+    <%= render partial: 'tag_edit_form', locals: { tag: Tag.new(name: "!555555_tag") } %>
+</div>
+
+    </div>
+    <h5 class="header-underline header-name">Tags</h5>
+  </div>
+</div>
+
+<%= content_tag :div, class: 'note-list collapse show', id: 'tags' do %>
+  <% @tags.each do |tag| %>
+    <%= content_tag :div, id: "#{dom_id(tag)}_link", class: 'list-item' do %>
+      <span data-tag-id="<%= tag.id %>" style="color: <%= tag.color %>">
+        <i class="icon fa fa-tag"></i>
+        <%= h(tag.display_name) %>
+      </span>
+
+      <div class="list-item-actions dropdown">
+        <%= link_to 'javascript:void(0)',
+          class: local_assigns.fetch(:button_class, '') + ' dropdown-toggle',
+          data: { id: "#modal-tag-edit-#{tag.id}", toggle: 'dropdown' } do %>
+          <i class="fa fa-pencil"></i> Edit
+        <% end %>
+        <%= link_to main_app.project_tag_path(current_project, tag),
+          method: :delete,
+          data: { confirm: "Are you sure?\n\nProceeding will delete this tag." },
+          class: 'list-item-action-delete' do %>
+          <i class="fa fa-trash"></i> Delete
+        <% end %>
+        <%= render partial: 'tag_edit_form', locals: { tag: tag } %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,8 @@ Rails.application.routes.draw do
     end
 
     resources :subscriptions, only: [:create, :destroy]
+    resources :tags, only: [:create, :update, :destroy] do
+    end
 
     get 'search' => 'search#index'
     get 'trash' => 'revisions#trash'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,8 +95,7 @@ Rails.application.routes.draw do
     end
 
     resources :subscriptions, only: [:create, :destroy]
-    resources :tags, only: [:create, :update, :destroy] do
-    end
+    resources :tags, only: [:create, :update, :destroy]
 
     get 'search' => 'search#index'
     get 'trash' => 'revisions#trash'

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe "tag requests" do
+  let(:tag) { Tag.create!(name: tag_name) }
+  let(:tag_name) { 'tag_name' }
+  let(:new_tag_name) { 'new_tag_name' }
+
+  before do
+    @project = Project.new
+    # login as admin
+    Configuration.create(name: 'admin:password', value: ::BCrypt::Password.create('rspec_pass'))
+    @user = create(:user, :admin)
+    post session_path, params: { login: @user.email, password: 'rspec_pass' }
+  end
+
+  describe "POST #create" do
+    let(:send_request) do
+      post project_tags_path(@project), params: { tag: { name: tag_name } }
+    end
+
+    it "creates a tag" do
+      expect { send_request }.to change { Tag.count }.by(1)
+      expect(Tag.last.name).to eq(tag_name)
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:send_request) do
+      patch project_tag_path(@project, tag), params: { tag: { name: new_tag_name } }
+    end
+
+    it "updates a tag" do
+      tag # create tag
+      expect { send_request }.not_to change { Tag.count }
+      expect(Tag.last.name).to eq(new_tag_name)
+    end
+  end
+
+  describe "DELETE #update" do
+    let(:send_request) do
+      delete project_tag_path(@project, tag), params: { project_id: @project.id, id: tag.id }
+    end
+
+    it "deletes a tag" do
+      tag # create tag
+      expect { send_request }.to change { Tag.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

When working on a project, I want to be able to CRUD the list of Tags that are available, so I can change Tag colours and names through the UI.

<img width="254" alt="Screen Shot 2020-02-15 at 19 45 02" src="https://user-images.githubusercontent.com/284865/74587296-c3fa5480-502b-11ea-9c9f-de3cabf5e888.png">

### Other Information

A basic CRUD controller could be used to manage the list of Tags for the project. Maybe a link from the Tags dropdown menu (Issues#index) would be the best way to access TagsController.

The controller should let you perform basic CRUD on the Tag model.


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
