### PR TITLE
Fix cards revisions

### DIFF
--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -71,7 +71,7 @@
             </div>         
           </div>
 
-          <% cache ['card-activity-tab', @card, @activities] do %>
+          <% cache ['card-activity-tab', @card, @card.list, @activities] do %>
             <div class="tab-pane" id="activity-tab">
               <h4 class="header-underline">
                 Recent activity

--- a/app/views/revisions/show.html.erb
+++ b/app/views/revisions/show.html.erb
@@ -55,14 +55,16 @@
   <div class="col-12 col-xl-4 col-xxl-3 p-0">
     <div class="sticky-top">
 
-      <div class="content-container mt-0 mt-xl-3 ml-xl-3">
-        <h4 class="header-underline">Previous revision</h4>
-        <ul>
-          <li><strong>Author:</strong> <%= @diffed_revision.previous_author %></li>
-          <li><strong>Action:</strong> <%= @diffed_revision.previous_action.capitalize %></li>
-          <li><strong>When:</strong> <%= @diffed_revision.last_updated_at %></li>
-        </ul>
-      </div>
+      <% if @revision.previous %>
+        <div class="content-container mt-0 mt-xl-3 ml-xl-3">
+          <h4 class="header-underline">Previous revision</h4>
+          <ul>
+            <li><strong>Author:</strong> <%= @diffed_revision.previous_author %></li>
+            <li><strong>Action:</strong> <%= @diffed_revision.previous_action.capitalize %></li>
+            <li><strong>When:</strong> <%= @diffed_revision.last_updated_at %></li>
+          </ul>
+        </div>
+      <% end %>
 
       <div class="content-container ml-xl-3">
         <h4 class="header-underline">This revision</h4>


### PR DESCRIPTION
### Spec
Currently, the app assumes that every created item in dradis has a revision for "create". Unfortunately, this assumption fails for projects/cards created before the revision history was implemented.

**Proposed Solution**
hide the "Previous Revision" section for such scenario.