### PR TITLE
Fix settings migration

### DIFF
--- a/db/migrate/20120903184931_settings_add_project_and_methodology_paths.rb
+++ b/db/migrate/20120903184931_settings_add_project_and_methodology_paths.rb
@@ -3,7 +3,7 @@
 
 class SettingsAddProjectAndMethodologyPaths < ActiveRecord::Migration[5.1]
   def up
-    new_value = Rails.root.join('templates', 'projects').to_s
+    new_value = Rails.root.join('../../shared/templates/projects/').to_s
 
     # If there was an old setting, honor it.
     if (old_setting = Configuration.find_by_name('admin:paths:methodologies'))


### PR DESCRIPTION
### Spec
Currently in production, the default Project Templates path is being set to the 'current' directory. The default value fails when the instance is migrated.

**Proposed solution**
Update the migration to use the 'shared' directory.

### How to test

1. Clone a new dradis instance (or drop the database of a current one)
2. Run rails db:create & rails db:migrate
3. Confirm that the correct configuration is set: Configuration.where(name: 'admin:paths:templates:projects').first