### PR TITLE
Evidence#create_multiple - assign :author field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,8 +3,7 @@ v3.17 ([MMM’YY])
   * [feature #2]
   * [feature ...]
   * Bugs fixed:
-    - [bug fixed #1]
-    - [bug fixed ...]
+    - Set :author when creating Evidence from an Issue.
     - Bug tracker items: #N, #M, #O, ...
   * New integrations:
     - [new integration #1]

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -51,9 +51,10 @@ class EvidenceController < NestedNodeResourceController
       params[:evidence][:node_ids].reject(&:blank?).each do |node_id|
         node = current_project.nodes.find(node_id)
         evidence = Evidence.create!(
+          author: cirrent_user.email,
+          content: evidence_params[:content],
           issue_id: issue.id,
-          node_id: node.id,
-          content: evidence_params[:content]
+          node_id: node.id
         )
         track_created(evidence)
       end
@@ -73,9 +74,10 @@ class EvidenceController < NestedNodeResourceController
         end
 
         evidence = Evidence.create!(
+          author: current_user.email,
+          content: evidence_params[:content],
           issue_id: issue.id,
-          node_id: node.id,
-          content: evidence_params[:content]
+          node_id: node.id
         )
         track_created(evidence)
       end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -51,7 +51,7 @@ class EvidenceController < NestedNodeResourceController
       params[:evidence][:node_ids].reject(&:blank?).each do |node_id|
         node = current_project.nodes.find(node_id)
         evidence = Evidence.create!(
-          author: cirrent_user.email,
+          author: current_user.email,
           content: evidence_params[:content],
           issue_id: issue.id,
           node_id: node.id

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -359,6 +359,14 @@ describe 'Issues pages' do
               match_array(%w[Evidence Evidence Node])
           end
 
+          it 'assigns the current user as the evidence author' do
+            find('.js-add-evidence').click
+            check('192.168.0.1')
+            select('Simple Note', from: 'evidence_content')
+            expect { click_button('Save Evidence') }.to change { Evidence.count }.by(1)
+            expect(@node.reload.evidence.last.author).to eq(@logged_in_as.email)
+          end
+
           # we need to filter by job class because a NotificationsReaderJob
           # will also be enqueued
           def enqueued_activity_tracking_jobs


### PR DESCRIPTION
Before this PR using the Issue#show > Add Evidence form resulted in new evidence created w/o an :author field being set. This PR amends that.

