### PR TITLE
Remove tag color from issue title in issue summary

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 v3.17 ([MMM’YY])
+  * Remove tag color from issue titles in issue summary.
   * Use shared noscript partial
   * Bugs fixed:
     - [bug fixed #1]

--- a/app/assets/stylesheets/tylium/modules/projects.scss
+++ b/app/assets/stylesheets/tylium/modules/projects.scss
@@ -40,6 +40,10 @@ body.projects {
             &:hover {
               background-color: darken($primaryBgColor, 3%);
             }
+
+            li {
+              transition: color 0.2s ease-in-out;
+            }
           }
         }
 

--- a/app/views/projects/_issue_summary.html.erb
+++ b/app/views/projects/_issue_summary.html.erb
@@ -17,7 +17,7 @@
                 <ul class="list-group">
                   <% @issues_by_tag[tag.name].each do |issue| %>
                     <%= link_to [current_project, issue], class: 'list-group-item'  do %>
-                      <li style="color: <%= tag.color %>"><%= issue.title %></li>
+                      <li><i class="fa fa-bug mr-2" style="color: <%= tag.color %>"></i><%= issue.title %></li>
                     <% end %>
                   <% end %>
                 </ul>
@@ -39,7 +39,7 @@
               <ul class="list-group">
                 <% @issues_by_tag[:unassigned].each do |issue| %>
                   <%= link_to [current_project, issue], class: 'list-group-item'  do %>
-                    <li><%= issue.title %></li>
+                    <li><i class="fa fa-bug mr-2"></i><%= issue.title %></li>
                   <% end %>
                 <% end %>
               </ul>


### PR DESCRIPTION
### Summary

Custom tag colors prevent some issue titles from being visible with appropriate contrast.

### Solution
Remove tag color from issue titles

### Check List

- [X] Added a CHANGELOG entry
