### PR TITLE
Fix export download button

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ v3.17 ([MMM’YY])
   * Upgraded gems: puma, sass-rails
   * Bugs fixed:
     - Long project names interfering with search bar expansion.
+    - Report 'Download' button becoming a disabled 'Processing...' button once clicked.
     - Set :author when creating Evidence from an Issue.
     - Bug tracker items: #N, #M, #O, ...
   * New integrations:

--- a/app/assets/javascripts/tylium/behaviors.js.coffee
+++ b/app/assets/javascripts/tylium/behaviors.js.coffee
@@ -121,7 +121,8 @@ document.addEventListener "turbolinks:load", ->
 
   # Disable form buttons after submitting them.
   $('form').submit (ev)->
-    $('input[type=submit]', this).attr('disabled', 'disabled').val('Processing...')
+    if !$('input[type=submit]', this).is('[data-behavior~=skip-auto-disable]')
+      $('input[type=submit]', this).attr('disabled', 'disabled').val('Processing...')
 
   # Search form
   $('[data-behavior~=form-search]').hover ->


### PR DESCRIPTION
### Summary

Currently, once a report is downloaded once, the download button becomes a disabled processing button preventing the user from re-downloading the report. This PR add the ability to skip this functionality by using data-behavior="skip-auto-disable" on the input element.

### Check List

- [x] Added a CHANGELOG entry
