### PR TITLE
CHANGELOG - fix bin/setup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ v3.17 ([MMM’YY])
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked.
     - Set :author when creating Evidence from an Issue.
     - Stop bin/setup from creating folders outside dradis-ce/
+    - bin/setup will not error if the attachments directory already exists
     - Bug tracker items: #560
   * New integrations:
     - [new integration #1]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,8 @@ v3.17 ([MMM’YY])
     - Long project names interfering with search bar expansion.
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked.
     - Set :author when creating Evidence from an Issue.
-    - Bug tracker items: #N, #M, #O, ...
+    - Stop bin/setup from creating folders outside dradis-ce/
+    - Bug tracker items: #560
   * New integrations:
     - [new integration #1]
   * Integration enhancements:

--- a/app/models/methodology.rb
+++ b/app/models/methodology.rb
@@ -43,7 +43,7 @@ class Methodology
   # 'admin:paths:templates:methodologies' setting
   def self.pwd
     @pwd ||= begin
-      conf = Configuration.create_with(value: Rails.root.join('../../shared/templates/methodologies/').to_s).
+      conf = Configuration.create_with(value: Rails.root.join('templates', 'methodologies').to_s).
         find_or_create_by(name: 'admin:paths:templates:methodologies')
       Pathname.new(conf.value)
     end

--- a/lib/tasks/thor/setup.rb
+++ b/lib/tasks/thor/setup.rb
@@ -89,7 +89,7 @@ class DradisTasks < Thor
       # dradis:reset:database truncates the tables and resets the :id column so
       # we know the right node ID we're going to get based on the project.xml
       # structure.
-      Dir.mkdir(Attachment.pwd.join('5'))
+      FileUtils.mkdir_p(Attachment.pwd.join('5'))
       template 'command-01.png', Attachment.pwd.join('5/command-01.png')
     end
   end


### PR DESCRIPTION
### Summary

There are a couple of issues with `./bin/setup` before this PR:

- A Methodology template it's trying to create a folder outside the dradis-ce/ folder.
- If run twice, the initial attachment setup would fail, as an attempt to re-create an already existing directory was made.

This PR solves the first problem by adjusting the `Methodology.pwd` setting and the second by using `.mkdir_p` instead of `mkdir`.

It also closes #560

### Check List

- [x] Added a CHANGELOG entry
