### PR TITLE
Link methodology names inside project summary charts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.17 (Month 2020)
   * Adjusted Uploads layout to provide more visibility to the output console.
+  * Link to Methodology from project summary chart.
   * Refactored dots-menu to make it available in any view.
   * Remove tag color from issue titles in issue summary.
   * Use shared noscript partial

--- a/app/assets/javascripts/shared/charts.js.coffee
+++ b/app/assets/javascripts/shared/charts.js.coffee
@@ -37,7 +37,9 @@ class @DonutChart
     @_createCenter = ->
       donuts = @container.selectAll('.donut')
 
-      donuts.append("svg:circle")
+      donuts.append("a")
+        .attr("xlink:href", @$container.data('url'))
+        .append("svg:circle")
         .attr("r", @chart_r * 0.6)
         .style("fill", "#E7E7E7")
         # .on(eventObj);

--- a/app/assets/javascripts/shared/charts.js.coffee
+++ b/app/assets/javascripts/shared/charts.js.coffee
@@ -42,7 +42,10 @@ class @DonutChart
         .style("fill", "#E7E7E7")
         # .on(eventObj);
 
-      textElement = donuts.append('text')
+      textElement = donuts
+        .append("a")
+        .attr("xlink:href", @$container.data('url'))
+        .append('text')
         .attr('class', 'center-txt type')
         .attr('y', @chart_r * -0.16)
         .attr('text-anchor', 'middle')

--- a/app/assets/javascripts/tylium/pages/projects/boards_summary.js
+++ b/app/assets/javascripts/tylium/pages/projects/boards_summary.js
@@ -23,7 +23,8 @@ document.addEventListener('turbolinks:load', function(){
               id: 'methodology-board-' + board.id,
               class: 'pie-chart',
               'data-behavior': 'interactive-pie-chart',
-              'data-stats': JSON.stringify(stats)
+              'data-stats': JSON.stringify(stats),
+              'data-url': board.url
             });
             $boardChart.appendTo($boardsSummary);
           });

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -90,7 +90,12 @@ class BoardsController < AuthenticatedController
   def build_methodology_params
     @boards.map do |board|
       next if board.lists.empty?
-      board_data = { id: board.id, name: board.name, total: board.cards.count }
+      board_data = {
+        id: board.id,
+        name: board.name,
+        total: board.cards.count,
+        url: project_board_path(current_project, board)
+      }
       lists = board.lists.map do |list|
         { category: list.name, value: list.cards.count }
       end


### PR DESCRIPTION
This PR adds an `<a>` element to the methodology charts of Projects#show so you can go straight to the relevant board form the summary.


### Check List

- [x] Added a CHANGELOG entry
