### PR TITLE
Fix sidebar active states

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ v3.17 (Month 2020)
     - Long project names interfering with search bar expansion.
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked.
     - Set :author when creating Evidence from an Issue.
+    - Sidebar items not showing active state.
     - Bug tracker items: #N, #M, #O, ...
   * New integrations:
     - [new integration #1]

--- a/app/assets/stylesheets/tylium/modules/_secondary_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_secondary_sidebar.scss
@@ -96,6 +96,10 @@
         a {
           color: $lightColor;
         }
+
+        &.active a {
+          color: $white;
+        }
     
         .list-item-actions {
           padding-top: 0.3rem;
@@ -148,6 +152,7 @@
       .summary-link {
         color: $lightColor;
 
+        &.active,
         &:hover {
           color: $white;
         }

--- a/app/views/layouts/tylium/_sidebar.html.erb
+++ b/app/views/layouts/tylium/_sidebar.html.erb
@@ -13,7 +13,7 @@
         <i class="fa fa-bug sidebar-link-icon"></i> <span class="sidebar-link-label">All issues</span>
       <% end %>
     <% end %>
-    <%= content_tag :li, :class => controller_name == 'boards' ? 'active' : '' do %>
+    <%= content_tag :li, :class => controller_name == 'boards' || controller_name == 'cards' ? 'active' : '' do %>
       <%= link_to main_app.project_boards_path(current_project), class: 'sidebar-link', data: { behavior: 'sidebar-link' } do %>
         <i class="fa fa-trello sidebar-link-icon"></i> <span class="sidebar-link-label">Methodologies</span>
       <% end %>


### PR DESCRIPTION
**Spec**
Currently, when a user is looking at a task, issue, evidence, note, etc the secondary-sidebar has no indication of which one the user is looking at.

**Solution**
Fixed css nesting

### Check List

- [x] Added a CHANGELOG entry