### PR TITLE
Use POST for preview endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ v3.17 (Month 2020)
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked.
     - Set :author when creating Evidence from an Issue.
     - Bug tracker items: #N, #M, #O, ...
+    - Fix textile preview not showing on issues with very long text.
   * New integrations:
     - [new integration #1]
   * Integration enhancements:

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,9 +7,6 @@ class HomeController < AuthenticatedController
   
   # Returns the Textile version of a text passed as parameter
   def textilize
-    respond_to do |format|
-      format.html { head :method_not_allowed }
-      format.json
-    end
+    render layout: false
   end
 end

--- a/app/views/home/textilize.html.erb
+++ b/app/views/home/textilize.html.erb
@@ -1,0 +1,1 @@
+<%= markup params[:text] %>

--- a/app/views/home/textilize.json.erb
+++ b/app/views/home/textilize.json.erb
@@ -1,1 +1,0 @@
-<%= { html: markup(params[:text]) }.to_json.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,7 @@ Rails.application.routes.draw do
 
   # -------------------------------------------------------------- Static pages
   # jQuery Textile URLs
-  get '/preview' => 'home#textilize',  as: :preview, defaults: { format: 'json' }
+  post '/preview' => 'home#textilize',  as: :preview, defaults: { format: 'json' }
   get '/markup-help' => 'home#markup_help', as: :markup
 
   root to: 'projects#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,7 @@ Rails.application.routes.draw do
 
   # -------------------------------------------------------------- Static pages
   # jQuery Textile URLs
-  post '/preview' => 'home#textilize',  as: :preview, defaults: { format: 'json' }
+  post '/preview' => 'home#textilize',  as: :preview
   get '/markup-help' => 'home#markup_help', as: :markup
 
   root to: 'projects#index'

--- a/vendor/assets/javascripts/jquery.textile.js
+++ b/vendor/assets/javascripts/jquery.textile.js
@@ -120,10 +120,16 @@
       this.options.$preview.addClass('loading-indicator').text('Loading...');
 
       var that = this;
-      $.getJSON( this.$element.data('preview-url'), {text: this.$element.val()}, function(result){
-        that.options.$preview.removeClass('loading-indicator')
-          .html(result.html);
-        that._previewRendered = true;
+      $.ajax({
+        dataType: 'json',
+        method: 'POST',
+        url: this.$element.data('preview-url'),
+        data: {text: this.$element.val()},
+        success: function(result){
+          that.options.$preview.removeClass('loading-indicator')
+            .html(result.html);
+          that._previewRendered = true;
+        }
       });
     },
     // Ajax help

--- a/vendor/assets/javascripts/jquery.textile.js
+++ b/vendor/assets/javascripts/jquery.textile.js
@@ -121,13 +121,12 @@
 
       var that = this;
       $.ajax({
-        dataType: 'json',
         method: 'POST',
         url: this.$element.data('preview-url'),
-        data: {text: this.$element.val()},
+        data: { text: this.$element.val() },
         success: function(result){
           that.options.$preview.removeClass('loading-indicator')
-            .html(result.html);
+            .html(result);
           that._previewRendered = true;
         }
       });

--- a/vendor/assets/javascripts/jquery.textile.js
+++ b/vendor/assets/javascripts/jquery.textile.js
@@ -120,16 +120,14 @@
       this.options.$preview.addClass('loading-indicator').text('Loading...');
 
       var that = this;
-      $.ajax({
-        method: 'POST',
-        url: this.$element.data('preview-url'),
-        data: { text: this.$element.val() },
-        success: function(result){
+      $.post(this.$element.data('preview-url'),
+        { text: this.$element.val() },
+        function(result) {
           that.options.$preview.removeClass('loading-indicator')
             .html(result);
           that._previewRendered = true;
         }
-      });
+      );
     },
     // Ajax help
     _loadHelp: function() {


### PR DESCRIPTION
### Spec
The textile preview endpoint has a character limit because we are using GET and we pass the text in the url query.

**Proposed solution**
Use POST in the endpoint instead.

### How to test
1. Add a new issue
2. Add around 8k bytes or more of text in the text area
3. Click Preview (or view the preview on the side)
4. Confirm that the preview is showing correctly.
