### PR TITLE
Use a dash for pre-release information in version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ v3.17 (Month 2020)
   * Bugs fixed:
     - Long project names interfering with search bar expansion
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked
+    - SemVer pre-release appending character
     - Set :author when creating Evidence from an Issue
     - Sidebar items not showing active state
     - Stop bin/setup from creating folders outside dradis-ce/

--- a/lib/dradis/ce/version.rb
+++ b/lib/dradis/ce/version.rb
@@ -6,7 +6,7 @@ module Dradis
       TINY  = 0
       PRE = nil
 
-      STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+      STRING = [[MAJOR, MINOR, TINY].join('.'), PRE].compact.join('-')
     end
   end
 end


### PR DESCRIPTION
To follow SemVer we should use a dash and not a period.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

- [x] Added a CHANGELOG entry