### PR TITLE
Headers in comments

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -4,7 +4,7 @@ module CommentsHelper
   def comment_formatter(comment)
     @comment_pipeline ||= HTML::Pipeline.new [
       HTML::Pipeline::DradisFieldableFilter,
-      HTML::Pipeline::TextileFilter,
+      HTML::Pipeline::DradisTextileFilter,
       HTML::Pipeline::SanitizationFilter,
       HTML::Pipeline::AutolinkFilter,
       HTML::Pipeline::DradisMentionsFilter,

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -2,8 +2,9 @@
 
 module CommentsHelper
   def comment_formatter(comment)
+    # We don't use Dradis Style headers in comments as the comment doesn't use
+    # the fieldable module or have the concept of fields.
     @comment_pipeline ||= HTML::Pipeline.new [
-      HTML::Pipeline::DradisFieldableFilter,
       HTML::Pipeline::DradisTextileFilter,
       HTML::Pipeline::SanitizationFilter,
       HTML::Pipeline::AutolinkFilter,

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -3,6 +3,7 @@
 module CommentsHelper
   def comment_formatter(comment)
     @comment_pipeline ||= HTML::Pipeline.new [
+      HTML::Pipeline::DradisFieldableFilter,
       HTML::Pipeline::TextileFilter,
       HTML::Pipeline::SanitizationFilter,
       HTML::Pipeline::AutolinkFilter,


### PR DESCRIPTION
### Summary
Add the missing headers formatter for rendering in comments.
Use our own textile formatter for consistency. 

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry (piggy back off the original comments changelog entry)
