### PR TITLE
Task assignee notification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ v3.17 (Month 2020)
   * Adjusted Uploads layout to provide more visibility to the output console
   * Card improvements:
     - Activity Feed now shows board name and link
+    - New Assignees will now receive notification
     - No mandatory due date
   * Comments can now have Textile markup
   * Link to Methodology from project summary chart
@@ -11,7 +12,6 @@ v3.17 (Month 2020)
   * Use shared noscript partial
   * Use user model reference for activities instead of user email
   * Upgraded gems: puma, sass-rails
-  * Card assignees now receive notification
   * Bugs fixed:
     - Long project names interfering with search bar expansion
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ v3.17 (Month 2020)
   * Use shared noscript partial
   * Use user model reference for activities instead of user email
   * Upgraded gems: puma, sass-rails
+  * Card assignees now receive notification
   * Bugs fixed:
     - Long project names interfering with search bar expansion
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,18 +2,8 @@ class NotificationsController < AuthenticatedController
   include ProjectScoped
 
   def index
-    # Eager loading multiple polymorphic associations
-    # https://stackoverflow.com/questions/42773318/eager-load-depending-on-type-of-association-in-ruby-on-rails
     notifications = current_user.notifications.newest
-
-    ActiveRecord::Associations::Preloader.new.preload(
-      notifications.select { |notification| notification.notifiable_type == 'Card' },
-      [:actor, :notifiable]
-    )
-    ActiveRecord::Associations::Preloader.new.preload(
-      notifications.select { |notification| notification.notifiable_type == 'Comment' },
-      [:actor, notifiable: [:user, :commentable]]
-    )
+    Notification.preload_objects(notifications)
 
     respond_to do |format|
       format.html do

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,7 +3,7 @@ class NotificationsController < AuthenticatedController
 
   def index
     notifications = current_user.notifications.newest.includes(
-      :actor, :notifiable
+      :actor, notifiable: [:user, :commentable]
     )
     respond_to do |format|
       format.html do

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,7 +3,7 @@ class NotificationsController < AuthenticatedController
 
   def index
     notifications = current_user.notifications.newest.includes(
-      :actor, notifiable: [:user, :commentable]
+      :actor, :notifiable
     )
     respond_to do |format|
       format.html do

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,9 +2,19 @@ class NotificationsController < AuthenticatedController
   include ProjectScoped
 
   def index
-    notifications = current_user.notifications.newest.includes(
-      :actor, :notifiable
+    # Eager loading multiple polymorphic associations
+    # https://stackoverflow.com/questions/42773318/eager-load-depending-on-type-of-association-in-ruby-on-rails
+    notifications = current_user.notifications.newest
+
+    ActiveRecord::Associations::Preloader.new.preload(
+      notifications.select { |notification| notification.notifiable_type == 'Card' },
+      [:actor, :notifiable]
     )
+    ActiveRecord::Associations::Preloader.new.preload(
+      notifications.select { |notification| notification.notifiable_type == 'Comment' },
+      [:actor, notifiable: [:user, :commentable]]
+    )
+
     respond_to do |format|
       format.html do
         @notifications = notifications.page(params[:page])

--- a/app/jobs/notifications_reader_job.rb
+++ b/app/jobs/notifications_reader_job.rb
@@ -9,6 +9,11 @@ class NotificationsReaderJob < ApplicationJob
         where(recipient_id: user_id).
         mark_all_as_read!
 
+      notifications_by_card(id: commentable_id).
+        unread.
+        where(recipient_id: user_id).
+        mark_all_as_read!
+
       if Notification.unread.where(recipient_id: user_id).count == 0
         NotificationsChannel.broadcast_to(User.find(user_id), 'all_read')
       end
@@ -26,5 +31,10 @@ class NotificationsReaderJob < ApplicationJob
         type,
         id
       )
+  end
+
+  def notifications_by_card(id:)
+    Notification.
+      where(notifiable_type: 'Card', notifiable_id: id)
   end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -42,8 +42,9 @@ class Card < ApplicationRecord
   def assignee_ids=(ids)
     # 1.
     self.touch if self.persisted?
-    # 2.
-    @new_assignees = ids - (assignee_ids + [''])
+    # 2. Convert assignee_ids to string as ids will be an array of
+    # string numbers.
+    @new_assignees = ids - (assignee_ids.map(&:to_s) + [''])
 
     super(ids)
   end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -80,12 +80,11 @@ class Card < ApplicationRecord
 
   def subscribe_new_assignees
     @new_assignees ||= []
-
     # FIXME: subscribe all of them in a single query
     @new_assignees.each do |user_id|
       Subscription.subscribe(user: User.find(user_id), to: self)
 
-      actor = User.where(email: versions.last.whodunnit).first
+      actor = User.where(email: versions.last&.whodunnit).first
 
       # Don't notify yourself if assigned to yourself
       Notification.create(

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -84,6 +84,16 @@ class Card < ApplicationRecord
     # FIXME: subscribe all of them in a single query
     @new_assignees.each do |user_id|
       Subscription.subscribe(user: User.find(user_id), to: self)
+
+      actor = User.where(email: versions.last.whodunnit).first
+
+      # Don't notify yourself if assigned to yourself
+      Notification.create(
+        action: :assigned,
+        actor: actor,
+        notifiable: self,
+        recipient_id: user_id
+      ) if actor&.id != user_id.to_i
     end
 
     @new_assignees = []

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -33,6 +33,20 @@ class Notification < ApplicationRecord
     NotificationGroup.new(since(interval).includes(notifiable: :commentable))
   end
 
+  def self.preload_objects(notifications)
+    # Eager loading multiple polymorphic associations
+    # https://stackoverflow.com/questions/42773318/eager-load-depending-on-type-of-association-in-ruby-on-rails
+
+    ActiveRecord::Associations::Preloader.new.preload(
+      notifications.select { |notification| notification.notifiable_type == 'Card' },
+      [:actor, :notifiable]
+    )
+    ActiveRecord::Associations::Preloader.new.preload(
+      notifications.select { |notification| notification.notifiable_type == 'Comment' },
+      [:actor, notifiable: [:user, :commentable]]
+    )
+  end
+
   # -- Instance Methods -----------------------------------------------------
   def read?
     self.read_at

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -13,6 +13,13 @@ class NotificationPresenter < BasePresenter
     )
   end
 
+  def card_path
+    card = notification.notifiable
+    polymorphic_path(
+      [current_project, card.board, card.list, card]
+    )
+  end
+
   def created_at_ago
     h.local_time_ago(notification.created_at)
   end
@@ -22,6 +29,8 @@ class NotificationPresenter < BasePresenter
     icon_css << case notification.notifiable_type
                 when 'Comment'
                   'fa-comment'
+                when 'Card'
+                 'fa-tasks'
                 else
                   ''
                 end

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -30,7 +30,7 @@ class NotificationPresenter < BasePresenter
                 when 'Comment'
                   'fa-comment'
                 when 'Card'
-                 'fa-tasks'
+                  'fa-tasks'
                 else
                   ''
                 end

--- a/app/views/notifications/_card.html.erb
+++ b/app/views/notifications/_card.html.erb
@@ -1,0 +1,3 @@
+assigned
+<%= link_to card.title, presenter.card_path %>
+Card to you.


### PR DESCRIPTION
### Summary

Currently, assignees are not notified when they are assigned a card. This PR notifies users when they are assigned to a card.

### How To Test

1. Log in your account.
2. Find a card and assign yourself and someone else.
3. Save the card.
4. You should not get a notification.
5. Log out your account or open a private browsing session on your browser (Incognito for Chrome,  Private Browsing for Firefox) and log in to the user which you have assigned earlier.
6. The assigned user should receive a notification similar to "[User 1] has assigned [Card name] Card to you.".

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
