### PR TITLE
Show author name instead of email in comment feed.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,8 @@ v3.17 (Month 2020)
   * Card improvements:
     - Activity Feed now shows board name and link
     - No mandatory due date
-  * Comments now show author's name instead of email
   * Comments can now have Textile markup
+  * Comments now show author's name instead of email
   * Link to Methodology from project summary chart
   * Navigation sidebar in projects can be kept open while navigating across views
   * Refactored dots-menu to make it available in any view

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v3.17 (Month 2020)
   * Card improvements:
     - Activity Feed now shows board name and link
     - No mandatory due date
+  * Comments now show author's name instead of email
   * Comments can now have Textile markup
   * Link to Methodology from project summary chart
   * Navigation sidebar in projects can be kept open while navigating across views

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -8,12 +8,12 @@
           <div class="col-12 p-0">
             <span class="user">
               <% if comment.user %>
-                <%= comment.user.email %>
+                <%= comment.user.name %>
               <% else %>
                 a user who has since been deleted
               <% end %>
             </span>
-          
+
 
             <div class="actions pull-right">
               <%= link_to edit_project_comment_path(current_project, comment), remote: true do %>

--- a/spec/support/comment_shared_examples.rb
+++ b/spec/support/comment_shared_examples.rb
@@ -24,6 +24,12 @@ shared_examples 'a page with a comments feed' do
     end
   end
 
+  it 'display user\'s name in comment row' do
+    within "div#comment_#{@comments[0].id}" do
+      expect(page).to have_selector('span.user', text: @logged_in_as.name)
+    end
+  end
+
   describe 'add comment', js: true do
     let(:submit_form) do
       within 'form[data-behavior~=add-comment]' do


### PR DESCRIPTION
### Summary

Display user's name instead of email in comment feed.

### How To Test

1. Create a comment.
2. It should show your profile's name instead of email.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
