### PR TITLE
Add template key to new Card/Evidence/Note/issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ v3.17 (Month 2020)
   * Improve current implementation of persisting data when creating and editing Card, Evidence, Issue, and Note
     - Data now persists for the whole form instead of only the textarea
     - Data will be cleared when the "Cancel" link is clicked
+    - Extend functionality to work with templates
     - Removed prompt to restore data
   * Link to Methodology from project summary chart
   * Navigation sidebar in projects can be kept open while navigating across views

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -2,7 +2,7 @@
   html: {
     data: {
       behavior: 'local-auto-save',
-      auto_save_key: @card.new_record? ? "#{@list.id}-card" : "card-#{@card.id}"
+      auto_save_key: @card.new_record? ? "#{@list.id}-card#{"-#{params[:template]}" if params[:template]}" : "card-#{@card.id}"
     }
   } do |f| %>
 

--- a/app/views/evidence/_form.html.erb
+++ b/app/views/evidence/_form.html.erb
@@ -2,7 +2,7 @@
   html: {
     data: {
       behavior: 'local-auto-save',
-      auto_save_key: @evidence.new_record? ? "project-#{current_project.id}-node-#{@node.id}-evidence" : "evidence-#{@evidence.id}"
+      auto_save_key: @evidence.new_record? ? "project-#{current_project.id}-node-#{@node.id}-evidence#{"-#{params[:template]}" if params[:template]}" : "evidence-#{@evidence.id}"
     }
   } do |f| %>
 

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -2,7 +2,7 @@
   html: {
     data: {
       behavior: 'local-auto-save',
-      auto_save_key: @issue.new_record? ? "project-#{current_project.id}-issue" : "issue-#{@issue.id}"
+      auto_save_key: @issue.new_record? ? "project-#{current_project.id}-issue#{"-#{params[:template]}" if params[:template]}" : "issue-#{@issue.id}"
     }
   } do |f| %>
 

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -2,7 +2,7 @@
   html: {
     data: {
       behavior: 'local-auto-save',
-      auto_save_key: @note.new_record? ? "project-#{current_project.id}-node-#{@node.id}-note" : "note-#{@note.id}"
+      auto_save_key: @note.new_record? ? "project-#{current_project.id}-node-#{@node.id}-note#{"-#{params[:template]}" if params[:template]}" : "note-#{@note.id}"
     }
   } do |f| %>
 

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -98,6 +98,14 @@ describe 'Card pages:' do
           ]
         end
 
+        let(:model_attributes_for_template) do
+          [
+            { name: :name, value: 'New Card Template' },
+            { name: :description, value: 'New Description Template' },
+            { name: :due_date, value: Date.today + 5.day }
+          ]
+        end
+
         include_examples 'a form with local auto save', Card, :new
       end
     end

--- a/spec/features/evidence_spec.rb
+++ b/spec/features/evidence_spec.rb
@@ -244,6 +244,7 @@ describe 'evidence' do
     describe 'local caching' do
       let(:model_path) { new_project_node_evidence_path(current_project, @node) }
       let(:model_attributes) { [{ name: :content, value: 'New Evidence' }] }
+      let(:model_attributes_for_template) { [{ name: :content, value: 'New Evidence Template' }] }
 
       include_examples 'a form with local auto save', Evidence, :new
     end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -148,6 +148,7 @@ describe 'Issues pages' do
 
           let(:model_path) { new_project_issue_path(current_project) }
           let(:model_attributes) { [{ name: :text, value: 'New Issue' }] }
+          let(:model_attributes_for_template) { [{ name: :text, value: 'New Issue Template' }] }
 
           include_examples 'a form with local auto save', Issue, :new
         end

--- a/spec/features/note_pages_spec.rb
+++ b/spec/features/note_pages_spec.rb
@@ -261,6 +261,7 @@ describe "note pages" do
 
       let(:model_path) { new_project_node_note_path(current_project, @node) }
       let(:model_attributes) { [{ name: :text, value: 'New Note' }] }
+      let(:model_attributes_for_template) { [{ name: :text, value: 'New Note Template' }] }
 
       include_examples 'a form with local auto save', Note, :new
     end


### PR DESCRIPTION
### Summary
This PR adds local caching for templates for Card, Evidence, Issue, and Note.

### How to Test
### Card
#### Scenario 1
1. Create new card with template
2. Enter something in form
3. Navigate away then back to the same board and create a new card with same template
4. Ensure the data persist in the form
#### Scenario 2
1. Create new card with template
2. Enter something in form
3. Go to create new blank card
4. Ensure form in the new blank card is not filled in
#### Scenario 3
1. Create new blank card
2. Enter something in form
3. Go to create new card with template
4. Ensure form in the new card with template is not filled in

### Issue
#### Scenario 1
1. Create new issue with template
2. Enter something in form
3. Navigate away then back to the same node and create new issue with template
4. Ensure the data persist in the form
#### Scenario 2
1. Create new issue with template
2. Enter something in form
3. Go to create new blank issue
4. Ensure form in the new blank issue is not filled in
#### Scenario 3
1. Create new blank issue
2. Enter something in form
3. Go to create new issue with template
4. Ensure form in the new issue with template is not filled in

### Note
#### Scenario 1
1. Create new note with template
2. Enter something in form
3. Navigate away then back to the same node and create new note with template
4. Ensure the data persist in the form
#### Scenario 2
1. Create new note with template
2. Enter something in form
3. Go to create new blank note
4. Ensure form in the new blank note is not filled in
#### Scenario 3
1. Create new blank note
2. Enter something in form
3. Go to create new note with template
4. Ensure form in the new note with template is not filled in

### Evidence
#### Scenario 1
1. Create new evidence with template
2. Enter something in form
3. Navigate away then back to the same node and create new evidence with template
4. Ensure the data persist in the form
#### Scenario 2
1. Create new evidence with template
2. Enter something in form
3. Go to create new blank evidence
4. Ensure form in the new blank evidence is not filled in
#### Scenario 3
1. Create new blank evidence
2. Enter something in form
3. Go to create new evidence with template
4. Ensure form in the new evidence with template is not filled in

- [x] Added a CHANGELOG entry