### PR TITLE
Auto Save revision collapsing

### DIFF
--- a/app/channels/editor_channel.rb
+++ b/app/channels/editor_channel.rb
@@ -12,7 +12,7 @@ class EditorChannel < ApplicationCable::Channel
 
   attr_accessor :resource
 
-  AUTOSAVE_EVENT = 'auto-save'.freeze
+  AUTOSAVE_EVENT = Activity::VALID_ACTIONS[:autosave].freeze
 
   def subscribed
     reject and return unless find_resource

--- a/app/channels/editor_channel.rb
+++ b/app/channels/editor_channel.rb
@@ -24,6 +24,7 @@ class EditorChannel < ApplicationCable::Channel
     resource.paper_trail_event = AUTOSAVE_EVENT
 
     if resource.update_attributes resource_params(params)
+      RevisionCollapser.call(resource)
       self.class.broadcast_to([current_user, current_project, resource], resource.reload.updated_at.to_i)
     end
   end

--- a/app/channels/editor_channel.rb
+++ b/app/channels/editor_channel.rb
@@ -22,7 +22,7 @@ class EditorChannel < ApplicationCable::Channel
     resource.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave]
 
     if resource.update_attributes resource_params(params)
-      RevisionCollapser.collapse(resource)
+      RevisionCollapser.collapse(resource, RevisionTracking::REVISABLE_EVENTS[:autosave])
       self.class.broadcast_to([current_user, current_project, resource], resource.reload.updated_at.to_i)
     end
   end

--- a/app/channels/editor_channel.rb
+++ b/app/channels/editor_channel.rb
@@ -9,6 +9,7 @@
 # of changes from other users.
 class EditorChannel < ApplicationCable::Channel
   include ProjectScopedChannels
+  include RevisionCollapsing
 
   attr_accessor :resource
 
@@ -22,7 +23,7 @@ class EditorChannel < ApplicationCable::Channel
     resource.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave]
 
     if resource.update_attributes resource_params(params)
-      RevisionCollapser.collapse(resource, RevisionTracking::REVISABLE_EVENTS[:autosave])
+      collapse_revisions(resource, RevisionTracking::REVISABLE_EVENTS[:autosave])
       self.class.broadcast_to([current_user, current_project, resource], resource.reload.updated_at.to_i)
     end
   end

--- a/app/channels/editor_channel.rb
+++ b/app/channels/editor_channel.rb
@@ -22,7 +22,7 @@ class EditorChannel < ApplicationCable::Channel
     resource.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave]
 
     if resource.update_attributes resource_params(params)
-      RevisionCollapser.call(resource)
+      RevisionCollapser.collapse(resource)
       self.class.broadcast_to([current_user, current_project, resource], resource.reload.updated_at.to_i)
     end
   end

--- a/app/channels/editor_channel.rb
+++ b/app/channels/editor_channel.rb
@@ -12,8 +12,6 @@ class EditorChannel < ApplicationCable::Channel
 
   attr_accessor :resource
 
-  AUTOSAVE_EVENT = Activity::VALID_ACTIONS[:autosave].freeze
-
   def subscribed
     reject and return unless find_resource
 
@@ -21,7 +19,7 @@ class EditorChannel < ApplicationCable::Channel
   end
 
   def save(params)
-    resource.paper_trail_event = AUTOSAVE_EVENT
+    resource.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave]
 
     if resource.update_attributes resource_params(params)
       RevisionCollapser.call(resource)

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -43,6 +43,7 @@ class CardsController < AuthenticatedController
 
   def update
     if @card.update_attributes(card_params)
+      RevisionCollapser.call(@card)
       track_updated(@card)
       redirect_to [current_project, @board, @list, @card], notice: 'Task updated.'
     else
@@ -85,7 +86,7 @@ class CardsController < AuthenticatedController
   private
 
   def card_params
-    params.require(:card).permit(:name, :description, :due_date, assignee_ids: [])
+    params.require(:card).permit(:name, :description, :due_date, assignee_ids: []).merge(updated_at: Time.now)
   end
 
   def initialize_sidebar

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -43,7 +43,7 @@ class CardsController < AuthenticatedController
 
   def update
     if @card.update_attributes(card_params)
-      RevisionCollapser.call(@card)
+      RevisionCollapser.collapse(@card)
       track_updated(@card)
       redirect_to [current_project, @board, @list, @card], notice: 'Task updated.'
     else

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -87,7 +87,7 @@ class CardsController < AuthenticatedController
   private
 
   def card_params
-    params.require(:card).permit(:name, :description, :due_date, assignee_ids: []).merge(updated_at: Time.now)
+    params.require(:card).permit(:name, :description, :due_date, assignee_ids: [])
   end
 
   def initialize_sidebar

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,6 +5,7 @@ class CardsController < AuthenticatedController
   include ProjectScoped
   include Mentioned
   include NotificationsReader
+  include RevisionCollapsing
 
   # Not sorted because we need the Board and List first!
   before_action :set_current_board_and_list
@@ -43,7 +44,7 @@ class CardsController < AuthenticatedController
 
   def update
     if @card.update_attributes(card_params)
-      RevisionCollapser.collapse(@card)
+      collapse_revisions(@card)
       track_updated(@card)
       redirect_to [current_project, @board, @list, @card], notice: 'Task updated.'
     else

--- a/app/controllers/concerns/revision_collapsing.rb
+++ b/app/controllers/concerns/revision_collapsing.rb
@@ -1,0 +1,8 @@
+# Module to execute revision collapsing on a resource
+module RevisionCollapsing
+  extend ActiveSupport::Concern
+
+  def collapse_revisions(resource)
+    RevisionCollapser.collapse(resource)
+  end
+end

--- a/app/controllers/concerns/revision_collapsing.rb
+++ b/app/controllers/concerns/revision_collapsing.rb
@@ -2,7 +2,7 @@
 module RevisionCollapsing
   extend ActiveSupport::Concern
 
-  def collapse_revisions(resource)
-    RevisionCollapserJob.perform_later resource
+  def collapse_revisions(resource, event = RevisionTracking::REVISABLE_EVENTS[:update])
+    RevisionCollapserJob.perform_later resource, event
   end
 end

--- a/app/controllers/concerns/revision_collapsing.rb
+++ b/app/controllers/concerns/revision_collapsing.rb
@@ -3,6 +3,6 @@ module RevisionCollapsing
   extend ActiveSupport::Concern
 
   def collapse_revisions(resource)
-    RevisionCollapser.collapse(resource)
+    RevisionCollapserJob.perform_later resource
   end
 end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -5,6 +5,7 @@ class EvidenceController < NestedNodeResourceController
   include MultipleDestroy
   include NodesSidebar
   include NotificationsReader
+  include RevisionCollapsing
 
   before_action :set_or_initialize_evidence, except: [ :index, :create_multiple ]
   before_action :initialize_nodes_sidebar, only: [ :edit, :new, :show ]
@@ -28,7 +29,7 @@ class EvidenceController < NestedNodeResourceController
 
     respond_to do |format|
       if @evidence.save
-        RevisionCollapser.collapse(@evidence)
+        collapse_revisions(@evidence)
         track_created(@evidence)
         format.html {
           redirect_to [current_project, @evidence.node, @evidence],

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -28,6 +28,7 @@ class EvidenceController < NestedNodeResourceController
 
     respond_to do |format|
       if @evidence.save
+        RevisionCollapser.call(@evidence)
         track_created(@evidence)
         format.html {
           redirect_to [current_project, @evidence.node, @evidence],
@@ -152,6 +153,7 @@ class EvidenceController < NestedNodeResourceController
     elsif params[:evidence]
       @evidence = Evidence.new(evidence_params) do |e|
         e.node = @node
+        e.updated_at = Time.now
       end
     else
       @evidence = Evidence.new(node: @node)

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -154,7 +154,6 @@ class EvidenceController < NestedNodeResourceController
     elsif params[:evidence]
       @evidence = Evidence.new(evidence_params) do |e|
         e.node = @node
-        e.updated_at = Time.now
       end
     else
       @evidence = Evidence.new(node: @node)

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -28,7 +28,7 @@ class EvidenceController < NestedNodeResourceController
 
     respond_to do |format|
       if @evidence.save
-        RevisionCollapser.call(@evidence)
+        RevisionCollapser.collapse(@evidence)
         track_created(@evidence)
         format.html {
           redirect_to [current_project, @evidence.node, @evidence],

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -83,7 +83,7 @@ class IssuesController < AuthenticatedController
       updated_at_before_save = @issue.updated_at.to_i
 
       if @issue.update_attributes(issue_params)
-        RevisionCollapser.call(@issue)
+        RevisionCollapser.collapse(@issue)
         @modified = true
         check_for_edit_conflicts(@issue, updated_at_before_save)
         track_updated(@issue)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -82,7 +82,8 @@ class IssuesController < AuthenticatedController
     respond_to do |format|
       updated_at_before_save = @issue.updated_at.to_i
 
-      if @issue.update_attributes(issue_params)
+      if @issue.update_attributes(issue_params.merge(updated_at: Time.now))
+        RevisionCollapser.call(@issue)
         @modified = true
         check_for_edit_conflicts(@issue, updated_at_before_save)
         track_updated(@issue)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -157,7 +157,7 @@ class IssuesController < AuthenticatedController
   end
 
   def issue_params
-    params.require(:issue).permit(:tag_list, :text).merge(updated_at: Time.now)
+    params.require(:issue).permit(:tag_list, :text)
   end
 
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,12 +1,13 @@
 class IssuesController < AuthenticatedController
   include ActivityTracking
   include Commented
-  include ContentFromTemplate
   include ConflictResolver
+  include ContentFromTemplate
   include Mentioned
   include MultipleDestroy
   include NotificationsReader
   include ProjectScoped
+  include RevisionCollapsing
 
   before_action :set_issuelib
   before_action :set_issues, except: [:destroy]
@@ -83,7 +84,7 @@ class IssuesController < AuthenticatedController
       updated_at_before_save = @issue.updated_at.to_i
 
       if @issue.update_attributes(issue_params)
-        RevisionCollapser.collapse(@issue)
+        collapse_revisions(@issue)
         @modified = true
         check_for_edit_conflicts(@issue, updated_at_before_save)
         track_updated(@issue)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -82,7 +82,7 @@ class IssuesController < AuthenticatedController
     respond_to do |format|
       updated_at_before_save = @issue.updated_at.to_i
 
-      if @issue.update_attributes(issue_params.merge(updated_at: Time.now))
+      if @issue.update_attributes(issue_params)
         RevisionCollapser.call(@issue)
         @modified = true
         check_for_edit_conflicts(@issue, updated_at_before_save)
@@ -156,7 +156,7 @@ class IssuesController < AuthenticatedController
   end
 
   def issue_params
-    params.require(:issue).permit(:tag_list, :text)
+    params.require(:issue).permit(:tag_list, :text).merge(updated_at: Time.now)
   end
 
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -86,6 +86,6 @@ class NotesController < NestedNodeResourceController
   end
 
   def note_params
-    params.require(:note).permit(:category_id, :text, :node_id).merge(updated_at: Time.now)
+    params.require(:note).permit(:category_id, :text, :node_id)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -47,7 +47,7 @@ class NotesController < NestedNodeResourceController
   def update
     updated_at_before_save = @note.updated_at.to_i
     if @note.update_attributes(note_params)
-      RevisionCollapser.call(@note)
+      RevisionCollapser.collapse(@note)
       track_updated(@note)
       check_for_edit_conflicts(@note, updated_at_before_save)
       # if the note has just been moved to another node, we must reload

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -7,6 +7,7 @@ class NotesController < NestedNodeResourceController
   include MultipleDestroy
   include NodesSidebar
   include NotificationsReader
+  include RevisionCollapsing
 
   before_action :find_or_initialize_note, except: [:index, :new, :multiple_destroy]
   before_action :initialize_nodes_sidebar, only: [:edit, :new, :show]
@@ -47,7 +48,7 @@ class NotesController < NestedNodeResourceController
   def update
     updated_at_before_save = @note.updated_at.to_i
     if @note.update_attributes(note_params)
-      RevisionCollapser.collapse(@note)
+      collapse_revisions(@note)
       track_updated(@note)
       check_for_edit_conflicts(@note, updated_at_before_save)
       # if the note has just been moved to another node, we must reload

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -47,6 +47,7 @@ class NotesController < NestedNodeResourceController
   def update
     updated_at_before_save = @note.updated_at.to_i
     if @note.update_attributes(note_params)
+      RevisionCollapser.call(@note)
       track_updated(@note)
       check_for_edit_conflicts(@note, updated_at_before_save)
       # if the note has just been moved to another node, we must reload
@@ -84,6 +85,6 @@ class NotesController < NestedNodeResourceController
   end
 
   def note_params
-    params.require(:note).permit(:category_id, :text, :node_id)
+    params.require(:note).permit(:category_id, :text, :node_id).merge(updated_at: Time.now)
   end
 end

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -35,6 +35,14 @@ class RevisionsController < AuthenticatedController
     redirect_to project_trash_path(current_project)
   end
 
+  def destroy
+    RevisionCollapser.discard_and_revert(@record)
+
+    # This is cheeky because either board and list won't be present or node
+    # won't be present and removing nils makes valid paths.
+    redirect_to polymorphic_path([current_project, @board, @list, @node, @record].concat)
+  end
+
   private
 
   def load_list

--- a/app/jobs/revision_collapser_job.rb
+++ b/app/jobs/revision_collapser_job.rb
@@ -1,7 +1,7 @@
 class RevisionCollapserJob < ApplicationJob
   queue_as :dradis_project
 
-  def perform(resource)
-    RevisionCollapser.collapse(resource, RevisionTracking::REVISABLE_EVENTS[:update])
+  def perform(resource, event)
+    RevisionCollapser.collapse(resource, event)
   end
 end

--- a/app/jobs/revision_collapser_job.rb
+++ b/app/jobs/revision_collapser_job.rb
@@ -2,6 +2,6 @@ class RevisionCollapserJob < ApplicationJob
   queue_as :dradis_project
 
   def perform(resource)
-    RevisionCollapser.collapse(resource)
+    RevisionCollapser.collapse(resource, RevisionTracking::REVISABLE_EVENTS[:update])
   end
 end

--- a/app/jobs/revision_collapser_job.rb
+++ b/app/jobs/revision_collapser_job.rb
@@ -1,0 +1,7 @@
+class RevisionCollapserJob < ApplicationJob
+  queue_as :dradis_project
+
+  def perform(resource)
+    RevisionCollapser.collapse(resource)
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -16,15 +16,9 @@ class Activity < ApplicationRecord
 
   validates_presence_of :action, :trackable_id, :trackable_type, :user
 
-  VALID_ACTIONS = {
-    autosave: 'auto-save',
-    create: 'create',
-    destroy: 'destroy',
-    recover: 'recover',
-    update: 'update'
-  }.freeze
+  VALID_ACTIONS = %w[auto-save create update destroy recover]
 
-  validates_inclusion_of :action, in: VALID_ACTIONS.values
+  validates_inclusion_of :action, in: VALID_ACTIONS
 
   # -- Scopes ---------------------------------------------------------------
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -19,9 +19,9 @@ class Activity < ApplicationRecord
   VALID_ACTIONS = {
     autosave: 'auto-save',
     create: 'create',
-    update: 'update',
     destroy: 'destroy',
-    recover: 'recover'
+    recover: 'recover',
+    update: 'update'
   }.freeze
 
   validates_inclusion_of :action, in: VALID_ACTIONS.values

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -16,9 +16,15 @@ class Activity < ApplicationRecord
 
   validates_presence_of :action, :trackable_id, :trackable_type, :user
 
-  VALID_ACTIONS = %w[auto-save create update destroy recover]
+  VALID_ACTIONS = {
+    autosave: 'auto-save',
+    create: 'create',
+    update: 'update',
+    destroy: 'destroy',
+    recover: 'recover'
+  }.freeze
 
-  validates_inclusion_of :action, in: VALID_ACTIONS
+  validates_inclusion_of :action, in: VALID_ACTIONS.values
 
   # -- Scopes ---------------------------------------------------------------
 

--- a/app/models/concerns/revision_tracking.rb
+++ b/app/models/concerns/revision_tracking.rb
@@ -1,17 +1,17 @@
 module RevisionTracking
   extend ActiveSupport::Concern
 
-  REVISABLE_EVENTS = [
-    Activity::VALID_ACTIONS[:autosave],
-    Activity::VALID_ACTIONS[:update]
-  ].freeze
+  REVISABLE_EVENTS = {
+    autosave: 'auto-save',
+    update: 'update'
+  }.freeze
 
   included do
     has_paper_trail
   end
 
   def revisable_versions
-    versions.where(event: REVISABLE_EVENTS)
+    versions.where(event: REVISABLE_EVENTS.values)
   end
 
   def has_revision_history?

--- a/app/models/concerns/revision_tracking.rb
+++ b/app/models/concerns/revision_tracking.rb
@@ -1,7 +1,10 @@
 module RevisionTracking
   extend ActiveSupport::Concern
 
-  REVISABLE_EVENTS = %w[auto-save update]
+  REVISABLE_EVENTS = [
+    Activity::VALID_ACTIONS[:autosave],
+    Activity::VALID_ACTIONS[:update]
+  ].freeze
 
   included do
     has_paper_trail

--- a/app/models/diffed_revision.rb
+++ b/app/models/diffed_revision.rb
@@ -3,7 +3,7 @@
 class DiffedRevision
 
   def initialize(revision, record)
-    raise 'undiffable revision' unless record.class::REVISABLE_EVENTS.include? revision.event
+    raise 'undiffable revision' unless record.class::REVISABLE_EVENTS.values.include? revision.event
     @revision = revision
     @record   = record
   end

--- a/app/presenters/revision_presenter.rb
+++ b/app/presenters/revision_presenter.rb
@@ -16,6 +16,6 @@ class RevisionPresenter < BasePresenter
   end
 
   def revisable?
-    revision.item.class::REVISABLE_EVENTS.include? revision.event
+    revision.item.class::REVISABLE_EVENTS.values.include? revision.event
   end
 end

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -1,16 +1,33 @@
 # Revisions get collapsed in three instances:
-# - A user has auto-saved: We clean up old auto-saves
-# - A user has saved: We collapse previous auto-saves
+# - A user has auto-saved: We clean previous old auto-saves
+# - A user has saved: We clean up all auto-saves
 # - A user has discarded changes: We revert the resource and remove old
 #   auto-saves
-# "Collapse" is how we refer to removing multiple revisions of auto save. In
-# practice it may mean we simply remove old versions and don't infact handle
-# any kind of multi-revision-merging at the moment.
+#
+# "Collapse" is how we refer to removing multiple revisions of auto save while
+# persisting the cumulative changes. In practice it may mean we simply remove
+# old versions and persist the original state.
+#
+# Papertrail saves the *original* state of the record. When we compare
+# it in a diff, we want to compare the current state whether it's an autosave or
+# update to the original state before auto-save started. The incremental changes
+# can be discarded with out concern. Orignal <=> Current is what's important.
+# Because of that anytime the previous revision was an autosave we want to carry
+# the original state forward. This happens when the new revision is an update,
+# or autosave.
 class RevisionCollapser
   def self.call(resource)
-    last_revision = resource.versions.reorder('created_at DESC').select(:created_at, :event).last
-    latest_timestamp = last_revision.event == Activity::VALID_ACTIONS[:autosave] ? last_revision.created_at : resource.updated_at
+    return unless resource.versions.any? # Lots of specs run without versioning
 
-    resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).where('created_at < ?', latest_timestamp).destroy_all
+    last_revision = resource.versions.reorder('created_at DESC').first
+    # Just in case there is more than a single autosave take the oldest.
+    previous_autosave = resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).
+                                 where.not(id: last_revision).reorder('created_at ASC').first
+
+    if resource.class::REVISABLE_EVENTS.include?(last_revision.event) && previous_autosave
+      last_revision.update(object: previous_autosave.object)
+    end
+
+    resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).where('created_at < ?', last_revision.created_at).destroy_all
   end
 end

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -1,0 +1,16 @@
+# Revisions get collapsed in three instances:
+# - A user has auto-saved: We clean up old auto-saves
+# - A user has saved: We collapse previous auto-saves
+# - A user has discarded changes: We revert the resource and remove old
+#   auto-saves
+# "Collapse" is how we refer to removing multiple revisions of auto save. In
+# practice it may mean we simply remove old versions and don't infact handle
+# any kind of multi-revision-merging at the moment.
+class RevisionCollapser
+  def self.call(resource)
+    last_revision = resource.versions.reorder('created_at DESC').select(:created_at, :event).last
+    latest_timestamp = last_revision.event == Activity::VALID_ACTIONS[:autosave] ? last_revision.created_at : resource.updated_at
+
+    resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).where('created_at < ?', latest_timestamp).destroy_all
+  end
+end

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -12,9 +12,9 @@
 # it in a diff, we want to compare the current state whether it's an autosave or
 # update to the original state before auto-save started. The incremental changes
 # can be discarded with out concern. Orignal <=> Current is what's important.
-# Because of that anytime the previous revision was an autosave we want to carry
-# the original state forward. This happens when the new revision is an update,
-# or autosave.
+# Anytime the previous revision is an auto-save we want to carry the original
+# state forward so we can always have it accessible to compare against. This
+# happens when the new revision is an update, or autosave.
 class RevisionCollapser
   def self.call(resource)
     return unless resource.versions.any? # Lots of specs run without versioning

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -16,7 +16,7 @@
 # state forward so we can always have it accessible to compare against. This
 # happens when the new revision is an update, or autosave.
 class RevisionCollapser
-  def self.collapse(resource)
+  def self.collapse(resource, event = RevisionTracking::REVISABLE_EVENTS[:update])
     return unless resource.versions.any? # Lots of specs run without versioning
 
     last_revision = resource.versions.reorder('created_at DESC').first
@@ -25,7 +25,9 @@ class RevisionCollapser
                                  where.not(id: last_revision).reorder('created_at ASC').first
 
     if RevisionTracking::REVISABLE_EVENTS.values.include?(last_revision.event) && previous_autosave
-      last_revision.update(object: previous_autosave.object)
+      last_revision.update(object: previous_autosave.object, event: event)
+    elsif event == RevisionTracking::REVISABLE_EVENTS[:update] && last_revision.event == RevisionTracking::REVISABLE_EVENTS[:autosave]
+      last_revision.update(event: event)
     end
 
     resource.versions.

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -16,7 +16,7 @@
 # state forward so we can always have it accessible to compare against. This
 # happens when the new revision is an update, or autosave.
 class RevisionCollapser
-  def self.call(resource)
+  def self.collapse(resource)
     return unless resource.versions.any? # Lots of specs run without versioning
 
     last_revision = resource.versions.reorder('created_at DESC').first

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -28,6 +28,8 @@ class RevisionCollapser
       last_revision.update(object: previous_autosave.object)
     end
 
-    resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).where('created_at < ?', last_revision.created_at).destroy_all
+    resource.versions.
+      where(event: Activity::VALID_ACTIONS[:autosave]).
+      where('created_at < ?', last_revision.created_at).destroy_all
   end
 end

--- a/app/services/revision_collapser.rb
+++ b/app/services/revision_collapser.rb
@@ -22,7 +22,7 @@ class RevisionCollapser
     last_revision = resource.versions.reorder('created_at DESC').first
     # Just in case there is more than a single autosave take the oldest.
     previous_autosave = resource.versions.where(event: RevisionTracking::REVISABLE_EVENTS[:autosave]).
-                                 where.not(id: last_revision).reorder('created_at ASC').first
+                                 where.not(id: last_revision).first
 
     if RevisionTracking::REVISABLE_EVENTS.values.include?(last_revision.event) && previous_autosave
       last_revision.update(object: previous_autosave.object, event: event)
@@ -38,7 +38,7 @@ class RevisionCollapser
   def self.discard_and_revert(resource)
     return unless resource.versions.any? # Lots of specs run without versioning
 
-    last_revision = resource.versions.reorder('created_at DESC').first
+    last_revision = resource.versions.last
 
     if last_revision.event == RevisionTracking::REVISABLE_EVENTS[:autosave]
       # Turn papertrail off so it doesn't create a new revision when we restore

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -41,10 +41,11 @@
 
   <div class="form-actions">
     <%= f.button :submit, nil, class: 'btn btn-primary' %> or
-    <%=
-      link_to 'Cancel',
-        @card.persisted? ? [current_project, @board, @list, @card] : [current_project, @board],
-        class: 'cancel-link'
-    %>
+
+    <% if @card.new_record? %>
+      <%= link_to 'Discard changes', project_board_path(current_project, @board), class: 'cancel-link' %>
+    <% else %>
+      <%= link_to 'Discard changes', project_board_list_card_revision_path(current_project, @board, @list, @card), method: :delete, class: 'cancel-link' %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/evidence/_form.html.erb
+++ b/app/views/evidence/_form.html.erb
@@ -32,6 +32,10 @@
   <div class="form-actions">
     <%= hidden_field_tag :back_to, :issue if params[:back_to] == 'issue' %>
     <%= f.button :submit, nil, class: 'btn btn-primary' %> or
-    <%= link_to 'Cancel', project_node_path(@node.project, @node) %>
+    <% if @evidence.new_record? %>
+      <%= link_to 'Discard changes', project_node_path(current_project, @node), class: 'cancel-link' %>
+    <% else %>
+      <%= link_to 'Discard changes', project_node_evidence_revision_path(current_project, @node, @evidence), method: :delete, class: 'cancel-link' %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -31,6 +31,11 @@
 
   <div class="form-actions">
     <%= f.button :submit, nil, class: 'btn btn-primary' %> or
-    <%= link_to 'Cancel', @issue.new_record? ? project_issues_path(current_project) : [current_project, @issue], class: 'cancel-link' %>
+
+    <% if @issue.new_record? %>
+      <%= link_to 'Discard changes', project_issues_path(current_project), class: 'cancel-link' %>
+    <% else %>
+      <%= link_to 'Discard changes', project_issue_revision_path(current_project, @issue), method: :delete, class: 'cancel-link' %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -28,10 +28,10 @@
 
   <div class="form-actions">
     <%= f.button :submit, class: 'btn btn-primary' %> or
-    <% if @note.persisted? %>
-      <%= link_to 'Cancel', project_node_note_path(@node.project, @node, @note), class: 'cancel-link' %>
+    <% if @note.new_record? %>
+      <%= link_to 'Discard changes', project_node_path(@node.project, @node), class: 'cancel-link' %>
     <% else %>
-      <%= link_to 'Cancel', project_node_path(@node.project, @node), class: 'cancel-link' %>
+      <%= link_to 'Discard changes', project_node_note_revision_path(@node.project, @node, @note), method: :delete, class: 'cancel-link' %>
     <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
         member { post :move }
         resources :cards, except: [:index] do
           member { post :move }
-          resources :revisions, only: [:index, :show]
+          resources :revisions, only: [:destroy, :index, :show]
         end
       end
     end
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
       end
 
       resources :nodes, only: [:show], controller: 'issues/nodes'
-      resources :revisions, only: [:index, :show]
+      resources :revisions, only: [:destroy, :index, :show]
     end
 
     resources :methodologies do
@@ -76,11 +76,11 @@ Rails.application.routes.draw do
       resource :merge, only: [:create], controller: 'nodes/merge'
 
       resources :notes, concerns: :multiple_destroy do
-        resources :revisions, only: [:index, :show]
+        resources :revisions, only: [:destroy, :index, :show]
       end
 
       resources :evidence, except: :index, concerns: :multiple_destroy do
-        resources :revisions, only: [:index, :show]
+        resources :revisions, only: [:destroy, :index, :show]
       end
 
       constraints(filename: /.*/) do

--- a/spec/features/evidence_spec.rb
+++ b/spec/features/evidence_spec.rb
@@ -105,7 +105,6 @@ describe 'evidence' do
       let(:autosaveable) { create(:evidence, node: @node) }
       let(:path_params) { [current_project, @node, autosaveable] }
       it_behaves_like 'an editor with server side auto-save'
-      it_behaves_like 'a record with auto-save revisions'
     end
 
     describe 'textile form view' do

--- a/spec/features/evidence_spec.rb
+++ b/spec/features/evidence_spec.rb
@@ -101,9 +101,12 @@ describe 'evidence' do
 
     it_behaves_like 'a form with a help button'
 
-    let(:autosaveable) { @evidence }
-    let(:path_params) { [current_project, @node, @evidence] }
-    it_behaves_like 'an editor with server side auto-save'
+    describe 'auto-save' do
+      let(:autosaveable) { create(:evidence, node: @node) }
+      let(:path_params) { [current_project, @node, autosaveable] }
+      it_behaves_like 'an editor with server side auto-save'
+      it_behaves_like 'a record with auto-save revisions'
+    end
 
     describe 'textile form view' do
       let(:action_path) { edit_project_node_evidence_path(current_project, @node, @evidence) }

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -148,9 +148,12 @@ describe 'Issues pages' do
         let(:item) { @issue }
         it_behaves_like 'a textile form view', Issue
 
-        let(:autosaveable) { @issue }
-        let(:path_params) { [current_project, @issue] }
-        it_behaves_like 'an editor with server side auto-save'
+        describe 'auto-save' do
+          let(:autosaveable) { create(:issue) }
+          let(:path_params) { [current_project, autosaveable] }
+          it_behaves_like 'an editor with server side auto-save'
+          it_behaves_like 'a record with auto-save revisions'
+        end
 
         before do
           issuelib = current_project.issue_library

--- a/spec/features/note_pages_spec.rb
+++ b/spec/features/note_pages_spec.rb
@@ -99,9 +99,12 @@ describe "note pages" do
 
     it_behaves_like "a form with a help button"
 
-    let(:autosaveable) { @note }
-    let(:path_params) { [current_project, @node, @note] }
-    it_behaves_like 'an editor with server side auto-save'
+    describe 'auto-save' do
+      let(:autosaveable) { create(:note, node: @node) }
+      let(:path_params) { [current_project, @node, autosaveable] }
+      it_behaves_like 'an editor with server side auto-save'
+      it_behaves_like 'a record with auto-save revisions'
+    end
 
     describe 'textile form view' do
       let(:action_path) { edit_project_node_note_path(current_project, @node, @note) }

--- a/spec/features/note_pages_spec.rb
+++ b/spec/features/note_pages_spec.rb
@@ -88,7 +88,6 @@ describe "note pages" do
     end
 
     let(:submit_form) { click_button "Update Note" }
-    let(:cancel_form) { click_link "Cancel" }
 
     it "has a form to edit the note" do
       should have_field :note_text
@@ -155,17 +154,9 @@ describe "note pages" do
       include_examples "doesn't create an Activity"
     end
 
-    describe "cancel button" do
-      it "returns to the note page" do
-        cancel_form
-        expect(current_path).to eq project_node_note_path(current_project, @node, @note)
-      end
-    end
-
     let(:model) { @note }
     include_examples 'nodes pages breadcrumbs', :edit, Note
   end
-
 
   describe "new page", js: true do
     before do
@@ -174,7 +165,6 @@ describe "note pages" do
     end
 
     let(:submit_form) { click_button "Create Note" }
-    let(:cancel_form) { click_link "Cancel" }
 
     context "when no template is specified" do
       let(:params) { {} }
@@ -221,13 +211,6 @@ describe "note pages" do
         end
 
         include_examples "doesn't create an Activity"
-      end
-
-      describe "cancel button" do
-        it "returns to the node page" do
-          cancel_form
-          expect(current_path).to eq project_node_path(current_project, @node)
-        end
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   # config.include ControllerMacros, type: :controller
+  config.include ActiveJob::TestHelper, type: :feature
   config.include ControllerMacros, type: :feature
   # config.include SelecterHelper,   type: :feature
   # config.include SupportHelper,    type: :controller

--- a/spec/services/revision_collapser_spec.rb
+++ b/spec/services/revision_collapser_spec.rb
@@ -2,12 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe RevisionCollapser do
+RSpec.describe RevisionCollapser, versioning: true do
   let(:resource) { create(:issue) }
-
-  before do
-    PaperTrail.enabled = true
-  end
 
   describe '.call' do
     subject(:collapse_revisions) { described_class.call(resource) }

--- a/spec/services/revision_collapser_spec.rb
+++ b/spec/services/revision_collapser_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe RevisionCollapser do
     PaperTrail.enabled = true
   end
 
-
   describe '.call' do
     subject(:collapse_revisions) { described_class.call(resource) }
 

--- a/spec/services/revision_collapser_spec.rb
+++ b/spec/services/revision_collapser_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe RevisionCollapser, versioning: true do
   let(:resource) { create(:issue) }
 
-  describe '.call' do
-    subject(:collapse_revisions) { described_class.call(resource) }
+  describe '.collapse' do
+    subject(:collapse_revisions) { described_class.collapse(resource) }
 
     it 'changes nothing when no autosaves exist' do
       expect { collapse_revisions }.to change { resource.versions.count }.by(0)

--- a/spec/services/revision_collapser_spec.rb
+++ b/spec/services/revision_collapser_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RevisionCollapser do
+  let(:resource) { create(:issue) }
+
+  before do
+    PaperTrail.enabled = true
+  end
+
+
+  describe '.call' do
+    subject(:collapse_revisions) { described_class.call(resource) }
+
+    it 'changes nothing when no autosaves exist' do
+      expect { collapse_revisions }.to change { resource.versions.count }.by(0)
+    end
+
+    context 'when there are 3 autosave revisions' do
+      before do
+        3.times do
+          resource.tap { |r| r.paper_trail_event = Activity::VALID_ACTIONS[:autosave] }.touch
+        end
+      end
+
+      it 'removes all but 1 autosave' do
+        expect { collapse_revisions }.to change {
+          resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).count
+        }.by(-2)
+      end
+
+      it 'keeps the latest autosave' do
+        last_save_id = PaperTrail::Version.last.id
+        collapse_revisions
+        expect(resource.versions.last.id).to be last_save_id
+      end
+    end
+
+    context 'when the last revision is an update' do
+      before do
+        3.times do
+          resource.tap { |r| r.paper_trail_event = Activity::VALID_ACTIONS[:autosave] }.touch
+        end
+
+        resource.touch
+      end
+
+      it 'removes all autosave revisions' do
+        expect { collapse_revisions }.to change {
+          resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).count
+        }.by(-3)
+      end
+
+      it 'keeps the latest update revision' do
+        last_save_id = PaperTrail::Version.last.id
+        collapse_revisions
+        expect(resource.versions.last.id).to be last_save_id
+      end
+    end
+
+    context 'if no resource is passed' do
+      subject(:collapse_revisions) { described_class.call(nil) }
+
+      # Don't save it. Let it blow up and make it easier for us to find.
+      it 'raises an exception' do
+        # NoMethodError calling versions on nil
+        expect { collapse_revisions }.to raise_exception NoMethodError
+      end
+    end
+  end
+end

--- a/spec/services/revision_collapser_spec.rb
+++ b/spec/services/revision_collapser_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe RevisionCollapser, versioning: true do
       # should never be more than 2.
       before do
         3.times do
-          resource.tap { |r| r.paper_trail_event = Activity::VALID_ACTIONS[:autosave] }.touch
+          resource.tap { |r| r.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave] }.touch
         end
       end
 
       it 'removes all but 1 autosave' do
         expect { collapse_revisions }.to change {
-          resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).count
+          resource.versions.where(event: RevisionTracking::REVISABLE_EVENTS[:autosave]).count
         }.by(-2)
       end
 
@@ -35,10 +35,10 @@ RSpec.describe RevisionCollapser, versioning: true do
       end
 
       it 'removes all autosaves when an update is present' do
-        resource.tap { |r| r.paper_trail_event = Activity::VALID_ACTIONS[:update] }.touch
+        resource.tap { |r| r.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:update] }.touch
 
         expect { collapse_revisions }.to change {
-          resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).count
+          resource.versions.where(event: RevisionTracking::REVISABLE_EVENTS[:autosave]).count
         }.by(-3)
       end
     end
@@ -46,9 +46,9 @@ RSpec.describe RevisionCollapser, versioning: true do
     describe 'persisting original state' do
       it 'carrys original state forward over autosaves' do
         resource = create(:issue, text: 'ABC')
-        resource.update(text: 'ABCD', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
-        resource.update(text: 'ABCDE', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
-        resource.update(text: 'ABCDEF', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
+        resource.update(text: 'ABCD', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
+        resource.update(text: 'ABCDE', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
+        resource.update(text: 'ABCDEF', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
 
         described_class.call(resource)
 
@@ -57,10 +57,10 @@ RSpec.describe RevisionCollapser, versioning: true do
 
       it 'carrys original state forward over autosaves to final update' do
         resource = create(:issue, text: 'ABC')
-        resource.update(text: 'ABCD', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
-        resource.update(text: 'ABCDE', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
-        resource.update(text: 'ABCDEF', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
-        resource.update(text: 'ABCDEF', paper_trail_event: Activity::VALID_ACTIONS[:update])
+        resource.update(text: 'ABCD', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
+        resource.update(text: 'ABCDE', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
+        resource.update(text: 'ABCDEF', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
+        resource.update(text: 'ABCDEF', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:update])
 
         described_class.call(resource)
 
@@ -71,7 +71,7 @@ RSpec.describe RevisionCollapser, versioning: true do
     context 'when the last revision is an update' do
       before do
         3.times do
-          resource.tap { |r| r.paper_trail_event = Activity::VALID_ACTIONS[:autosave] }.touch
+          resource.tap { |r| r.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave] }.touch
         end
 
         resource.touch
@@ -79,7 +79,7 @@ RSpec.describe RevisionCollapser, versioning: true do
 
       it 'removes all autosave revisions' do
         expect { collapse_revisions }.to change {
-          resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).count
+          resource.versions.where(event: RevisionTracking::REVISABLE_EVENTS[:autosave]).count
         }.by(-3)
       end
 
@@ -106,17 +106,17 @@ RSpec.describe RevisionCollapser, versioning: true do
 
     it 'removes all auto-save revisions' do
       2.times do
-        resource.tap { |r| r.paper_trail_event = Activity::VALID_ACTIONS[:autosave] }.touch
+        resource.tap { |r| r.paper_trail_event = RevisionTracking::REVISABLE_EVENTS[:autosave] }.touch
       end
 
       expect { discard_and_revert }.to change {
-        resource.versions.where(event: Activity::VALID_ACTIONS[:autosave]).count
+        resource.versions.where(event: RevisionTracking::REVISABLE_EVENTS[:autosave]).count
       }.by(-2)
     end
 
     it 'restores content from before auto-save fired' do
       resource = create(:issue, text: 'ABC')
-      resource.update(text: 'ABCDEF', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
+      resource.update(text: 'ABCDEF', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
 
       described_class.discard_and_revert(resource)
 
@@ -124,10 +124,10 @@ RSpec.describe RevisionCollapser, versioning: true do
     end
 
     it 'restores without creating a new update event' do
-      resource.update(text: 'ABCDEF', paper_trail_event: Activity::VALID_ACTIONS[:autosave])
+      resource.update(text: 'ABCDEF', paper_trail_event: RevisionTracking::REVISABLE_EVENTS[:autosave])
 
       expect { discard_and_revert }.not_to change {
-        resource.versions.where(event: Activity::VALID_ACTIONS[:update]).count
+        resource.versions.where(event: RevisionTracking::REVISABLE_EVENTS[:update]).count
       }
     end
   end

--- a/spec/support/server_auto_save_shared_examples.rb
+++ b/spec/support/server_auto_save_shared_examples.rb
@@ -32,11 +32,7 @@ shared_examples 'an editor with server side auto-save' do
       expect(autosaveable.reload.send(content_attribute)).to eq new_content
     end
 
-    context 'with papertrail active' do
-      before do
-        PaperTrail.enabled = true
-      end
-
+    context 'with papertrail active', versioning: true do
       it 'creates a papertrail version' do
         expect do
           find('.editor-field textarea').set new_content
@@ -76,14 +72,12 @@ shared_examples 'a record with auto-save revisions' do
     before do
       create(:configuration, name: 'admin:password', value: ::BCrypt::Password.create(password))
 
-      PaperTrail.enabled = true
-
       login
       visit polymorphic_path(path_params, action: :edit)
       click_link 'Source'
     end
 
-    it 'creates a single auto-save item in the revision history' do
+    it 'creates a single auto-save item in the revision history', versioning: true do
       find('.editor-field textarea').set new_content
       wait_for_js_events
 
@@ -94,7 +88,7 @@ shared_examples 'a record with auto-save revisions' do
       expect(row).to have_content('Currently Viewing')
     end
 
-    it 'only keeps a single auto-save item in the revision history' do
+    it 'only keeps a single auto-save item in the revision history', versioning: true do
       3.times do
         find('.editor-field textarea').set new_content
         wait_for_js_events

--- a/spec/support/server_auto_save_shared_examples.rb
+++ b/spec/support/server_auto_save_shared_examples.rb
@@ -98,6 +98,39 @@ shared_examples 'a record with auto-save revisions' do
 
       expect(page).to have_content('Auto-saved', count: 1)
     end
+
+    it 'removes all auto-saves when updated', versioning: true do
+      find('.editor-field textarea').set new_content
+      wait_for_js_events
+
+      within '.form-actions' do
+        find('[type="submit"]').click
+      end
+
+      visit polymorphic_path(path_params.push(:revisions))
+
+      expect(page).not_to have_content('Auto-saved')
+
+      row = find('.revisions-table table tbody tr.active')
+      expect(row).to have_content('Update')
+      expect(row).to have_content('Currently Viewing')
+    end
+
+    it 'shows entire diff between original and current not just last revision', versioning: true do
+      old_content = autosaveable.title
+      find('.editor-field textarea').set 'intermediary'
+      find('.editor-field textarea').set new_content
+      wait_for_js_events
+
+      within '.form-actions' do
+        find('[type="submit"]').click
+      end
+
+      visit polymorphic_path(path_params.push(:revisions))
+
+      expect(find('#diff del.differ')).to have_content("#[Title]#\n#{old_content}\n\n#[Description]#\nFoo\e")
+      expect(find('#diff ins.differ')).to have_content("#[Description]#\nNew info\e")
+    end
   end
 end
 

--- a/spec/support/server_auto_save_shared_examples.rb
+++ b/spec/support/server_auto_save_shared_examples.rb
@@ -107,55 +107,61 @@ shared_examples 'a record with auto-save revisions' do
     end
 
     it 'removes all auto-saves when updated', versioning: true do
-      find('.editor-field textarea').set new_content
-      wait_for_js_events
+      perform_enqueued_jobs do
+        find('.editor-field textarea').set new_content
+        wait_for_js_events
 
-      within '.form-actions' do
-        find('[type="submit"]').click
+        within '.form-actions' do
+          find('[type="submit"]').click
+        end
+
+        visit polymorphic_path(path_params.push(:revisions))
+
+        expect(page).not_to have_content('Auto-saved')
+
+        row = find('.revisions-table table tbody tr.active')
+        expect(row).to have_content('Update')
+        expect(row).to have_content('Currently Viewing')
       end
-
-      visit polymorphic_path(path_params.push(:revisions))
-
-      expect(page).not_to have_content('Auto-saved')
-
-      row = find('.revisions-table table tbody tr.active')
-      expect(row).to have_content('Update')
-      expect(row).to have_content('Currently Viewing')
     end
 
     it 'shows entire diff between original and current not just last revision', versioning: true do
-      old_content = autosaveable.title
-      find('.editor-field textarea').set 'intermediary'
-      find('.editor-field textarea').set new_content
-      wait_for_js_events
+      perform_enqueued_jobs do
+        old_content = autosaveable.title
+        find('.editor-field textarea').set 'intermediary'
+        find('.editor-field textarea').set new_content
+        wait_for_js_events
 
-      within '.form-actions' do
-        find('[type="submit"]').click
+        within '.form-actions' do
+          find('[type="submit"]').click
+        end
+
+        visit polymorphic_path(path_params.push(:revisions))
+
+        expect(find('#diff del.differ')).to have_content("#[Title]#\n#{old_content}")
+        expect(find('#diff ins.differ')).to have_content("#[Description]#\nNew info")
       end
-
-      visit polymorphic_path(path_params.push(:revisions))
-
-      expect(find('#diff del.differ')).to have_content("#[Title]#\n#{old_content}")
-      expect(find('#diff ins.differ')).to have_content("#[Description]#\nNew info")
     end
 
     it 'removes auto-saves when discarded', versioning: true do
-      # Create an update revision otherwise we won't have access to the
-      # revisions page
-      find('.editor-field textarea').set new_content
-      wait_for_js_events
+      perform_enqueued_jobs do
+        # Create an update revision otherwise we won't have access to the
+        # revisions page
+        find('.editor-field textarea').set new_content
+        wait_for_js_events
 
-      within '.form-actions' do
-        find('[type="submit"]').click
+        within '.form-actions' do
+          find('[type="submit"]').click
+        end
+
+        visit polymorphic_path(path_params, action: :edit)
+
+        find('.editor-field textarea').set 'newer_content'
+        click_link 'Discard changes'
+
+        visit polymorphic_path(path_params.push(:revisions))
+        expect(page).not_to have_content('Auto-saved')
       end
-
-      visit polymorphic_path(path_params, action: :edit)
-
-      find('.editor-field textarea').set 'newer_content'
-      click_link 'Discard changes'
-
-      visit polymorphic_path(path_params.push(:revisions))
-      expect(page).not_to have_content('Auto-saved')
     end
   end
 end


### PR DESCRIPTION
### Summary

Every time an auto-save is triggered we currently create a new revision. Instead we would like to collapse revisions to make them more manageable. We collapse revisions under three circumstances:

- When a new auto-save occurs we collapse the auto-saves into a single auto-save
- When an Update occurs we remove old auto-saves
- When Discard is clicked we revert to the last Update, and discard old auto-saves

### Other Information

This PR is build on top of the `server-caching` PR.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] ~Added a CHANGELOG entry~
