### PR TITLE
Fix v3 boards templates import and add boards spec

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ v3.17 (Month 2020)
   * Use user model reference for activities instead of user email
   * Upgraded gems: puma, sass-rails
   * Bugs fixed:
+    - Fix bug with v3 board templates not uploading
     - Fix textile preview not showing on issues with very long text
     - Long project names interfering with search bar expansion
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -33,7 +33,7 @@ class BoardsController < AuthenticatedController
         if methodology.version == 1
           migration = MethodologyMigrationService.new(current_project.id)
           migration.migrate(methodology, board_name: board_params[:name], node: @node)
-        elsif methodology.version == 2
+        elsif methodology.version >= 2
           importer = MethodologyImportService.new(current_project.id)
           importer.import(methodology, board_name: board_params[:name], node: @node)
         end

--- a/spec/features/board_pages/board_pages_spec.rb
+++ b/spec/features/board_pages/board_pages_spec.rb
@@ -47,17 +47,14 @@ describe 'Board pages:' do
           board
           visit project_boards_path(current_project)
 
-          click_link 'Create new methodology...'
+          expect {
+            click_link 'Create new methodology...'
 
-          find('#modal-board-new', visible: true)
-          find('#template').find(:option, 'Methodology Template v3').select_option
+            find('#modal-board-new', visible: true)
+            find('#template').find(:option, 'Methodology Template v3').select_option
 
-          click_button 'Add methodology'
-
-          board = Board.last
-          list = board.lists.first
-          expect(list.name).to eq('To Do')
-          expect(list.cards.first.name).to eq('Card 1')
+            click_button 'Add methodology'
+          }.to change { Board.count }.by(1)
         end
       end
     end

--- a/spec/features/board_pages/board_pages_spec.rb
+++ b/spec/features/board_pages/board_pages_spec.rb
@@ -38,6 +38,28 @@ describe 'Board pages:' do
         expect(page).to have_text board.name
         expect(page).not_to have_text node_board.name
       end
+
+      context 'creating a board using a template', js: true do
+        it 'creates the board using the template data' do
+          template_path = Rails.root.join('spec/fixtures/files/methodologies/')
+          allow(Methodology).to receive(:pwd).and_return(template_path)
+
+          board
+          visit project_boards_path(current_project)
+
+          click_link 'Create new methodology...'
+
+          find('#modal-board-new', visible: true)
+          find('#template').find(:option, 'Methodology Template v3').select_option
+
+          click_button 'Add methodology'
+
+          board = Board.last
+          list = board.lists.first
+          expect(list.name).to eq('To Do')
+          expect(list.cards.first.name).to eq('Card 1')
+        end
+      end
     end
 
     describe 'when in show page' do

--- a/spec/fixtures/files/methodologies/v3_template.xml
+++ b/spec/fixtures/files/methodologies/v3_template.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<board version="3">
+  <id>33</id>
+  <name>Methodology Template v3</name>
+  <node_id/>
+  <list>
+    <id>87</id>
+    <name>To Do</name>
+    <previous_id/>
+    <card>
+      <id>690</id>
+      <name>Card 1</name>
+      <description><![CDATA[Test Card]]></description>
+      <due_date>2020-03-27</due_date>
+      <previous_id/>
+      <assignees/>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>admin@securityroots.com</user_email>
+          <created_at>1585318112</created_at>
+        </activity>
+      </activities>
+      <comments/>
+    </card>
+</list>
+</board>


### PR DESCRIPTION
### Spec

Currently, nothing happens when creating a methodology with a v3 template.

Note that a boards v3 template is generated from a v3 projects template. See: https://github.com/dradis/dradis-projects/blob/master/lib/dradis/plugins/projects/export/v3/template.rb#L16

**Proposed solution**

Use the >=2 version check instead when importing the boards template in the controller.

### How to test

1. Add a v3 template to your templates/methodologies directory
2. Open the boards view and create a new board
3. Use the From template select and choose the template in Step 1.
4. Confirm that the board was created successfully.