### PR TITLE
Misc css fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,11 +16,13 @@ v3.17 (Month 2020)
   * Navigation sidebar in projects can be kept open while navigating across views
   * Refactored dots-menu to make it available in any view
   * Remove tag color from issue titles in issue summary
+  * Update code element style
   * Use shared noscript partial
   * Use user model reference for activities instead of user email
   * Upgraded gems: puma, sass-rails
   * Bugs fixed:
     - Fix textile preview not showing on issues with very long text
+    - ItemsTable extra whitespace causing unnecessary vertical scrolling
     - Long project names interfering with search bar expansion
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked
     - SemVer pre-release appending character

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 v3.17 (Month 2020)
   * Add author to evidence and notes views
-  * Adjusted Uploads layout to provide more visibility to the output console
+  * Adjust Uploads layout to provide more visibility to the output console
   * Boards can be renamed and deleted through their dots menu
   * Card improvements:
     - Activity Feed now shows board name and link
@@ -14,22 +14,22 @@ v3.17 (Month 2020)
     - Side-by-side editor preview that auto-updates
   * Link to Methodology from project summary chart
   * Navigation sidebar in projects can be kept open while navigating across views
-  * Refactored dots-menu to make it available in any view
+  * Dots-menu available in any view
   * Remove tag color from issue titles in issue summary
   * Update code element style
   * Use shared noscript partial
   * Use user model reference for activities instead of user email
   * Upgraded gems: puma, sass-rails
   * Bugs fixed:
-    - Fix textile preview not showing on issues with very long text
+    - bin/setup creating folders outside dradis-ce/
+    - bin/setup error if the attachments directory already exists
     - ItemsTable extra whitespace causing unnecessary vertical scrolling
     - Long project names interfering with search bar expansion
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked
     - SemVer pre-release appending character
     - Set :author when creating Evidence from an Issue
     - Sidebar items not showing active state
-    - Stop bin/setup from creating folders outside dradis-ce/
-    - bin/setup will not error if the attachments directory already exists
+    - Textile preview not showing on issues with very long text
     - Bug tracker items: #560
   * New integrations:
     - [new integration #1]

--- a/app/assets/stylesheets/shared/items_table.scss
+++ b/app/assets/stylesheets/shared/items_table.scss
@@ -81,10 +81,21 @@
     }
   }
 
-  tr:hover {
+  tr {
+  
+    &:hover {
 
-    .column-actions a { 
-      visibility: visible;
+      .column-actions a {
+        visibility: visible;
+      }
+    }
+
+    &:last-of-type {
+
+      [aria-label]:after {
+        top: initial;
+        bottom: 110%;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/tylium/base.scss
+++ b/app/assets/stylesheets/tylium/base.scss
@@ -76,6 +76,13 @@ button:focus {
   box-shadow: none !important;
 }
 
+code {
+  background-color: #f9f2f4;
+  border-radius: 4px;
+  color: $codeText;
+  padding: 2px 4px;
+}
+
 .custom-select {
   font-size: inherit;
 }

--- a/app/assets/stylesheets/tylium/layout.scss
+++ b/app/assets/stylesheets/tylium/layout.scss
@@ -19,25 +19,6 @@
   }
 }
 
-.back-fade {
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  background: #000;
-  z-index: 4;
-  transition: visibility 0.5s ease-in-out, opacity 0.5s ease-in-out;
-
-  &.faded {
-    opacity: 0.7;
-    visibility: initial;
-  }
-
-  &.not-faded {
-    opacity: 0;
-    visibility: hidden;
-  }
-}
-
 .breadcrumb {
   margin-bottom: 0;
   padding-left: $mainContentPadding;

--- a/app/assets/stylesheets/tylium/modules.scss
+++ b/app/assets/stylesheets/tylium/modules.scss
@@ -253,6 +253,12 @@ table {
   }
 }
 
+time {
+  &[aria-label]:after {
+    display: none;
+  }
+}
+
 .tooltip-inner {
     
   ul {

--- a/app/assets/stylesheets/tylium/modules.scss
+++ b/app/assets/stylesheets/tylium/modules.scss
@@ -14,6 +14,7 @@
 @import "tylium/modules/notifications";
 @import "tylium/modules/nodes";
 @import "tylium/modules/projects";
+@import "tylium/modules/restrict_height";
 @import "tylium/modules/search";
 @import "tylium/modules/secondary_sidebar";
 @import "tylium/modules/sidebar";
@@ -201,75 +202,6 @@ pre {
   background-color: $secondaryBgColor;
   border: 1px solid $borderColor;
   border-radius: 5px;
-}
-
-.restrict-height {
-  overflow: auto;
-
-  &.full-height {
-    max-height: calc(100vh - 10rem);
-  }
-
-  &.half-height {
-    max-height: calc(50vh - 4rem);
-  }
-
-  &.quarter-height {
-    max-height: calc(25vh - 3.4rem);
-  }
-
-  .scroll-more-wrapper {
-    position: sticky;
-    width: 100%;
-    opacity: 1;
-    bottom: -2rem;
-    left: 0;
-    transition: all 0.3s ease-in-out;
-    visibility: initial;
-
-    &.hidden {
-      opacity: 0;
-      visibility: hidden;
-    }
-
-    .gradient {
-      position: absolute;
-      height: 6rem;
-      width: 100%;
-      bottom: 0;
-      background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.75) 50%, rgba(255,255,255,1) 100%);
-    }
-
-    .line {
-      position: absolute;
-      width: 100%;
-      left: 0;
-      bottom: 2rem;
-      border-bottom: 1px solid #ddd;
-    }
-
-    .scroll-more {
-      position: absolute;
-      bottom: 1rem;
-      left: calc(50% - 3.875rem);
-      background: #fff;
-      border: 1px solid #ddd;
-      padding: 0.125rem 1rem;
-      z-index: 2;
-      cursor: default;
-    }
-  }
-}
-
-// Firefox Fixes //
-@-moz-document url-prefix() {
-
-  // this fixes ignored padding when parent is scrollable.
-  .restrict-height::after {
-    content: "";
-    height: 2rem;
-    display: block;
-  }
 }
 
 .tabs-container {

--- a/app/assets/stylesheets/tylium/modules/_restrict_height.scss
+++ b/app/assets/stylesheets/tylium/modules/_restrict_height.scss
@@ -1,0 +1,68 @@
+.restrict-height {
+  overflow: auto;
+
+  &.full-height {
+    max-height: calc(100vh - 10rem);
+  }
+
+  &.half-height {
+    max-height: calc(50vh - 4rem);
+  }
+
+  &.quarter-height {
+    max-height: calc(25vh - 3.4rem);
+  }
+
+  .scroll-more-wrapper {
+    position: sticky;
+    width: 100%;
+    opacity: 1;
+    bottom: -2rem;
+    left: 0;
+    transition: all 0.3s ease-in-out;
+    visibility: initial;
+
+    &.hidden {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    .gradient {
+      position: absolute;
+      height: 6rem;
+      width: 100%;
+      bottom: 0;
+      background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.75) 50%, rgba(255,255,255,1) 100%);
+    }
+
+    .line {
+      position: absolute;
+      width: 100%;
+      left: 0;
+      bottom: 2rem;
+      border-bottom: 1px solid #ddd;
+    }
+
+    .scroll-more {
+      position: absolute;
+      bottom: 1rem;
+      left: calc(50% - 3.875rem);
+      background: #fff;
+      border: 1px solid #ddd;
+      padding: 0.125rem 1rem;
+      z-index: 2;
+      cursor: default;
+    }
+  }
+}
+
+// Firefox Fixes //
+@-moz-document url-prefix() {
+
+  // this fixes ignored padding when parent is scrollable.
+  .restrict-height::after {
+    content: "";
+    height: 2rem;
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/tylium/modules/_secondary_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_secondary_sidebar.scss
@@ -78,11 +78,11 @@
   }
 
   .note-list {
-  
-    .active a {
-      color: $white;
+
+    .active > a {
+      color: $white !important;
     }
-    
+
     .list-item {
       line-height: 1.2rem;
       padding: 0.5rem;
@@ -92,7 +92,7 @@
       a {
         color: $lightColor;
       }
-  
+
       .list-item-actions {
         padding-top: 0.3rem;
         text-align: right;
@@ -103,10 +103,6 @@
           padding: 0 4px;
         }
 
-        &.active a {
-          color: $white;
-        }
-    
         .list-item-action-delete,
         .list-item-action-edit {
           color: $lightColor;
@@ -138,7 +134,7 @@
             color: $white;
           }
         }
-        
+
         .list-item-actions {
           visibility: visible;
         }
@@ -148,7 +144,6 @@
     .summary-link {
       color: $lightColor;
 
-      &.active,
       &:hover {
         color: $white;
       }

--- a/app/assets/stylesheets/tylium/modules/styles.scss
+++ b/app/assets/stylesheets/tylium/modules/styles.scss
@@ -24,7 +24,9 @@ body.styles_tylium {
       font-size: 0.8rem;
 
       code {
+        background-color: transparent;
         color: #FFF;
+        padding: 0;
 
         .an {
           color: #9CDCFE;

--- a/app/assets/stylesheets/tylium/variables.scss
+++ b/app/assets/stylesheets/tylium/variables.scss
@@ -21,6 +21,7 @@ $primaryColor: $ceGreen;
 $darkColor: $darkGreen;
 
 // Text Colors
+$codeText: #c7254e;
 $defaultText: #333;
 $errorText: $red;
 $mutedText: #bbb;

--- a/app/views/styles_tylium/index.html.erb
+++ b/app/views/styles_tylium/index.html.erb
@@ -5,8 +5,9 @@
 
     <div class="content-container">
       <h1 class="text-center mb-4">Tylium Style Guide [ WIP ]</h1>
-      <p>Welcome to the Tylium style guide, here you will see all the major style components that we use in the Tylium layout.</p>
-      <p class="mb-0">If you find something you would like to implement in the view you are working on, you can simply press the <i class="fa fa-code" style="font-weight: bold;"></i> button to reveal the code structure including all the element tags, classes, data-attributes etc.</p>
+      <p>Welcome to the Tylium style guide, here you will see all the major custom style components that we use in the Tylium layout.</p>
+      <p>If you find something you would like to implement in the view you are working on, you can simply press the <i class="fa fa-code" style="font-weight: bold;"></i> button to reveal the code structure including all the element tags, classes, data-attributes etc.</p>
+      <p>Tylium uses Bootstrap 4, please refer to <a href="https://getbootstrap.com/docs/4.0/getting-started/introduction/" target="_blank">the official documentation</a> for standard bootstrap classes and element structure.</p>
     </div>
 
     <div class="content-container">
@@ -51,13 +52,13 @@
       <div class="style-example">
         <div class="tab-content mt-0">
           <div id="tab1" class="tab-pane fade">
-            <p class="mb-0">Tab 1 Content</p>
+            <p>Tab 1 Content</p>
           </div>
           <div id="tab2" class="tab-pane fade active show">
-            <p class="mb-0">Tab 2 Content</p>
+            <p>Tab 2 Content</p>
           </div>
           <div id="tab3" class="tab-pane fade">
-            <p class="mb-0">Tab 3 Content</p>
+            <p>Tab 3 Content</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Summary

This PR contains a few misc style changes:

- Re-fix secondary-sidebar active state style
- Fix style bug where ItemsTable's would have extra whitespace at the bottom causing an ugly vertical scroll to blank space.
- Remove un-used `.back-fade` css (this lingered from making the sidebar sticky)
- Extract `.restrict-height` css from `modules.scss` to its own module
- Update `<code>` style
- Fix double tooltips showing on time elements (this is because of local_time gem adding `title` and `aria-label` attributes). Note: This bug was introduced with the implementation of the editor toolbar so it doesn't need a changelog entry.

### Check List

- [x] Added a CHANGELOG entry
