### PR TITLE
Auto Save timed save

### DIFF
--- a/app/assets/javascripts/tylium/modules/auto_save/server.js
+++ b/app/assets/javascripts/tylium/modules/auto_save/server.js
@@ -52,9 +52,12 @@
       this._cleanupBound = this.cleanup.bind(this);
       document.addEventListener('turbolinks:before-cache', this._cleanupBound)
 
-      this._timedSave = setInterval(function() {
+      boundSave = function() {
         this.editorChannel.save();
-      }.bind(this), this._timedIntervalInMS);
+      }.bind(this);
+
+      window.addEventListener('beforeunload', boundSave);
+      this._timedSave = setInterval(boundSave, this._timedIntervalInMS);
     },
     cleanup: function() {
       this.editorChannel.save(); // Save the results once more

--- a/app/assets/javascripts/tylium/modules/auto_save/server.js
+++ b/app/assets/javascripts/tylium/modules/auto_save/server.js
@@ -4,6 +4,9 @@
 // accept content for resources to update, and create revisions from. It will
 // receive timestamps back from the server to update the `original_updated_at`
 // field which helps us with conflict resolution.
+// Auto-saved forms are set to be saved at two points:
+//  - When the user navigates away from the page
+//  - Every 5 minutes
 (function($, window) {
   function ServerAutoSave(form) {
     this.form = form;

--- a/app/assets/javascripts/tylium/modules/auto_save/server.js
+++ b/app/assets/javascripts/tylium/modules/auto_save/server.js
@@ -6,7 +6,7 @@
 // field which helps us with conflict resolution.
 // Auto-saved forms are set to be saved at two points:
 //  - When the user navigates away from the page
-//  - Every 5 minutes
+//  - Every 3 minutes
 (function($, window) {
   function ServerAutoSave(form) {
     this.form = form;

--- a/app/assets/javascripts/tylium/modules/auto_save/server.js
+++ b/app/assets/javascripts/tylium/modules/auto_save/server.js
@@ -11,7 +11,7 @@
   function ServerAutoSave(form) {
     this.form = form;
 
-    this._timedIntervalInMS = 300000; // 5 minutes in MS
+    this._timedIntervalInMS = 3*60*1000;
     this.originalUpdatedAt = form.querySelector('[data-behavior~=auto-save-updated-at]');
     this.projectId = form.dataset.asProjectId;
     this.resourceId = form.dataset.asResourceId;

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -7,7 +7,7 @@
 default: &default
  adapter: sqlite3
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
- timeout: 5000
+ timeout: 15000
 
 development:
  <<: *default

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -26,15 +26,6 @@ module ControllerMacros
     page.visit(arg)
 
     if RSpec.current_example.metadata[:js]
-      # When visiting a form we've already entered data into we will get the
-      # cached data prompt. We won't always, and we can't check for it. So we have
-      # to try and close the prompt every time and rescue if it errors.
-      begin
-        page.driver.browser.switch_to.alert
-        page.dismiss_prompt
-      rescue
-      end
-
       page.execute_script File.read("#{Rails.root}/spec/support/selenium/disable_animations.js")
     end
   end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -26,6 +26,15 @@ module ControllerMacros
     page.visit(arg)
 
     if RSpec.current_example.metadata[:js]
+      # When visiting a form we've already entered data into we will get the
+      # cached data prompt. We won't always, and we can't check for it. So we have
+      # to try and close the prompt every time and rescue if it errors.
+      begin
+        page.driver.browser.switch_to.alert
+        page.dismiss_prompt
+      rescue
+      end
+
       page.execute_script File.read("#{Rails.root}/spec/support/selenium/disable_animations.js")
     end
   end

--- a/spec/support/local_auto_save_shared_examples.rb
+++ b/spec/support/local_auto_save_shared_examples.rb
@@ -103,9 +103,9 @@ shared_examples 'a form with local auto save' do |klass, action|
     end
   end
 
-  context 'when Cancel is clicked' do
+  context 'when Discard is clicked' do
     it 'clears cached data' do
-      click_link 'Cancel'
+      click_link 'Discard'
       visit model_path
       click_link 'Source'
 


### PR DESCRIPTION
### Summary

Currently auto-save happens after keystroke events are completed, and when navigating away. This closely mirrors the local-caching methods and isn't entirely useful. Instead lets keep auto saves to navigating away, and on an interval of every 5 minutes.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] ~Added a CHANGELOG entry~
