### PR TITLE
Redirect Cards to new Lists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ v3.17 (Month 2020)
   * Card improvements:
     - Activity Feed now shows board name and link
     - No mandatory due date
+    - Redirects to new url if the card has changed lists
   * Comments can now have Textile markup
   * Comments now show author's name instead of email
   * Display note and evidence titles in breadcrumbs

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -7,7 +7,8 @@ class CardsController < AuthenticatedController
   include NotificationsReader
 
   # Not sorted because we need the Board and List first!
-  before_action :set_resources
+  before_action :set_current_board_and_list
+  before_action :set_or_initialize_card
   before_action :initialize_sidebar, only: [:show, :new, :edit]
 
   layout 'cards'
@@ -91,18 +92,17 @@ class CardsController < AuthenticatedController
     @sorted_cards = @list.ordered_cards.select(&:persisted?)
   end
 
-  def set_resources
-    @board = current_project.boards.includes(:lists).find(params[:board_id])
-    @list = @board.lists.includes(:cards).find(params[:list_id])
-
+  def set_or_initialize_card
     if params[:id]
-      # Cards move lists, but don't move boards, assume it's on the same board
-      # somewhere.
-      @card = Card.where(list_id: @board.lists).find(params[:id])
-
+      @card = @board.cards.find(params[:id])
       redirect_to [current_project, @board, @card.list, @card] if @card.list_id != @list.id
     else
       @card = @list.cards.new
     end
+  end
+
+  def set_current_board_and_list
+    @board = current_project.boards.includes(:lists).find(params[:board_id])
+    @list  = @board.lists.includes(:cards).find(params[:list_id])
   end
 end

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -7,8 +7,7 @@ class CardsController < AuthenticatedController
   include NotificationsReader
 
   # Not sorted because we need the Board and List first!
-  before_action :set_current_board_and_list
-  before_action :set_or_initialize_card
+  before_action :set_resources
   before_action :initialize_sidebar, only: [:show, :new, :edit]
 
   layout 'cards'
@@ -92,16 +91,18 @@ class CardsController < AuthenticatedController
     @sorted_cards = @list.ordered_cards.select(&:persisted?)
   end
 
-  def set_or_initialize_card
+  def set_resources
+    @board = current_project.boards.includes(:lists).find(params[:board_id])
+    @list = @board.lists.includes(:cards).find(params[:list_id])
+
     if params[:id]
-      @card = @list.cards.find(params[:id])
+      # Cards move lists, but don't move boards, assume it's on the same board
+      # somewhere.
+      @card = Card.where(list_id: @board.lists).find(params[:id])
+
+      redirect_to [current_project, @board, @card.list, @card] if @card.list_id != @list.id
     else
       @card = @list.cards.new
     end
-  end
-
-  def set_current_board_and_list
-    @board = current_project.boards.includes(:lists).find(params[:board_id])
-    @list  = @board.lists.includes(:cards).find(params[:list_id])
   end
 end

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -224,6 +224,25 @@ describe 'Card pages:' do
 
         include_examples 'creates an Activity', :destroy
       end
+
+      describe 'card redirects' do
+        it 'redirects to the existing card if list has changed' do
+          new_list = create(:list, board: @board)
+          @card.update(list: new_list)
+
+          visit project_board_list_card_path(current_project, @board, @list, @card)
+          expect(page).to have_current_path project_board_list_card_path(current_project, @board, new_list, @card)
+        end
+
+        it 'does not allow access to cards on other boards' do
+          new_list = create(:list)
+          @card.update(list: new_list)
+
+          expect {
+            visit project_board_list_card_path(current_project, @board, @list, @card)
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
     end
   end
 end

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -198,10 +198,7 @@ describe 'Card pages:' do
         expect(page).to have_selector("a[href='#{project_board_list_card_path(current_project, @board, @list, @card)}'][data-method='delete']")
       end
 
-      describe "clicking 'delete'" do
-        before { PaperTrail.enabled = true }
-        after  { PaperTrail.enabled = false }
-
+      describe "clicking 'delete'", versioning: true do
         let(:submit_form) { click_link 'Delete' }
 
         it 'deletes the card' do


### PR DESCRIPTION
### Summary

### Spec

If someone sends me a link to a card and that card has moved to a new list the link is a dead link.

### Proposed solution

We can make the assumption the card will never move off the board, but may move between lists. Don’t care about the list scoping. We can authorize the resource by safely authorizing the project, and board, and ensuring the card comes from any list on that board. So find the card, and validate which list it’s on now and redirect to the card.

### How to test
- Navigate to a card
- Open that card in a new window
- Move the card to another list
- In the second window refresh the page
- See that the URL has changed and updated to match the list the card is now on.

### Check List

- [x] Added a CHANGELOG entry
