### PR TITLE
Editor view memory

### DIFF
--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -31,6 +31,7 @@ describe 'Card pages:' do
         let(:action_path) { new_project_board_list_card_path(current_project, @board, @list) }
         let(:required_form) { fill_in :card_name, with: 'New Card' }
         it_behaves_like 'a textile form view', Card
+        it_behaves_like 'an editor that remembers what view you like'
       end
 
       describe 'submitting the form with valid information' do
@@ -99,6 +100,7 @@ describe 'Card pages:' do
         let(:action_path) { edit_project_board_list_card_path(current_project, @board, @list, @card) }
         let(:item) { @card }
         it_behaves_like 'a textile form view', Card
+        it_behaves_like 'an editor that remembers what view you like'
       end
 
       describe 'submitting the form with valid information' do

--- a/spec/features/evidence_spec.rb
+++ b/spec/features/evidence_spec.rb
@@ -105,6 +105,7 @@ describe 'evidence' do
       let(:action_path) { edit_project_node_evidence_path(current_project, @node, @evidence) }
       let(:item) { @evidence }
       it_behaves_like 'a textile form view', Evidence
+      it_behaves_like 'an editor that remembers what view you like'
     end
 
     describe 'submitting the form with valid information', js: true do
@@ -164,6 +165,7 @@ describe 'evidence' do
       let(:params) { {} }
       let(:required_form) { find('#evidence_issue_id option:nth-of-type(2)').select_option }
       it_behaves_like 'a textile form view', Evidence
+      it_behaves_like 'an editor that remembers what view you like'
     end
 
     context 'when no template is specified' do

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -53,6 +53,7 @@ describe 'Issues pages' do
 
         let(:action_path) { new_project_issue_path(current_project) }
         it_behaves_like 'a textile form view', Issue
+        it_behaves_like 'an editor that remembers what view you like'
 
         context 'submitting the form with valid information' do
           before do
@@ -147,6 +148,7 @@ describe 'Issues pages' do
         let(:action_path) { edit_project_issue_path(current_project, @issue) }
         let(:item) { @issue }
         it_behaves_like 'a textile form view', Issue
+        it_behaves_like 'an editor that remembers what view you like'
 
         before do
           issuelib = current_project.issue_library

--- a/spec/features/note_pages_spec.rb
+++ b/spec/features/note_pages_spec.rb
@@ -103,6 +103,7 @@ describe "note pages" do
       let(:action_path) { edit_project_node_note_path(current_project, @node, @note) }
       let(:item) { @note }
       it_behaves_like 'a textile form view', Note
+      it_behaves_like 'an editor that remembers what view you like'
     end
 
     # TODO handle the case where a Note has no paperclip versions (legacy data)
@@ -239,6 +240,7 @@ describe "note pages" do
 
       let(:action_path) { new_project_node_note_path(current_project, @node) }
       it_behaves_like 'a textile form view', Note
+      it_behaves_like 'an editor that remembers what view you like'
     end
 
     include_examples 'nodes pages breadcrumbs', :new, Note

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,8 @@ ActiveRecord::Migration.maintain_test_schema!
 Capybara.register_driver :chrome do |app|
   options = %w[headless disable-gpu window-size=1920,1080]
   Capybara::Selenium::Driver.new app, browser: :chrome,
-    options: Selenium::WebDriver::Chrome::Options.new(args: options)
+    options: Selenium::WebDriver::Chrome::Options.new(args: options),
+    clear_local_storage: true
 end
 
 Capybara.server = :puma, { Silent: true }

--- a/spec/support/textile_editor_shared_examples.rb
+++ b/spec/support/textile_editor_shared_examples.rb
@@ -11,11 +11,36 @@ shared_examples 'a form with a help button' do
   end
 end
 
+shared_examples 'an editor that remembers what view you like' do
+  before do
+    visit action_path
+  end
+  
+  it 'will load source view after using source view' do
+    click_link 'Source'
+
+    visit action_path
+
+    expect(page).to have_css('textarea.textile')
+  end
+
+  it 'will load fields view after viewing source view but clicking back to fields view' do
+    click_link 'Source'
+    click_link 'Fields'
+
+    visit action_path
+
+    expect(page).to have_css('.textile-form')
+  end
+end
+
 shared_examples 'a textile form view' do |klass|
   before do
     visit action_path
 
     required_form if defined?(required_form)
+
+    click_link 'Fields'
   end
 
   it 'add fields in the form', js: true do

--- a/vendor/assets/javascripts/jquery.textile.js
+++ b/vendor/assets/javascripts/jquery.textile.js
@@ -21,6 +21,7 @@
   var pluginName = 'textile',
       document = window.document,
       defaults = {
+        defaultViewKey: 'editor.view',
         // Start fullscreen?
         fullscreen: false,
         // Add a resizer bar at the bottom of the editor
@@ -95,6 +96,8 @@
 
       // Event bindings
       this._bindBehaviors();
+
+      this._setDefaultView();
     },
     _bindBehaviors: function() {
       // Sync preview
@@ -227,6 +230,7 @@
       }
     },
     _onBtnFields: function() {
+      localStorage.setItem(this.options.defaultViewKey, 'fields');
       // Activate toolbar button
       var scope = this.options.$wrap;
       $('.textile-toolbar a', scope).removeClass('active');
@@ -301,6 +305,7 @@
     },
     // Toolbar button handlers
     _onBtnSource: function() {
+      localStorage.setItem(this.options.defaultViewKey, 'source');
       // Activate toolbar button
       var scope = this.options.$wrap;
       $('.textile-toolbar a', scope).removeClass('active');
@@ -330,6 +335,12 @@
 
     _serializedFormData: function() {
       return JSON.stringify( $('[name^=item_form]', this.options.$fields).serializeArray() );
+    },
+
+    _setDefaultView: function() {
+      if (localStorage.getItem(this.options.defaultViewKey) == 'source') {
+        this._onBtnSource();
+      }
     }
   };
 


### PR DESCRIPTION
### Summary

Currently every time the editor loads it loads on the Fields view. I may be an old dog who can't learn new tricks. Or maybe I'm just stubborn and know what I like. If I use the source view I want the editor to always load on the source view. By the way get off my lawn...

### Proposed solution
We utilize localStorage and save the last view a user used. Upon coming back to the editor we either allow the default Fields view to load, or change over to Source view if that's what was last used.

### How to test
* Navigate to an editor view
* Switch to Source view
* Navigate away from the editor
* Navigate back to any editor view
* Find that source view is on by default. Hazzah!

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] ~Added a CHANGELOG entry~
