### PR TITLE
Implement multi edit of issue states in issues#index

### DIFF
--- a/app/controllers/issues/states_controller.rb
+++ b/app/controllers/issues/states_controller.rb
@@ -1,0 +1,24 @@
+class Issues::StatesController < AuthenticatedController
+  include ProjectScoped
+
+  def update_states
+    issues = current_project.issues.where(id: params[:ids])
+
+    if issues.update_all(state: state_params, updated_at: Time.now)
+      render json: { state: Issue.state_names[state_params] }
+    else
+      render json: { message: 'Something went wrong.' }
+    end
+  end
+
+  private
+
+  def state_params
+    @state_params ||=
+      if Issue.states.keys.include?(params[:state])
+        params[:state]
+      else
+        :published
+      end
+  end
+end

--- a/app/views/issues/_toolbar.html.erb
+++ b/app/views/issues/_toolbar.html.erb
@@ -39,6 +39,19 @@
         </div>
       </div>
 
+      <div class="btn-group dropdown h-100">
+        <button id="state-selected" class="btn dropdown-toggle" data-toggle="dropdown" title="Change state of selected issues">
+          <i class="fa fa-pencil-square-o"></i>
+          State
+          <i class="fa fa-caret-down"></i>
+        </button>
+        <div class="dropdown-menu" data-url="<%= update_states_project_states_path(current_project) %>">
+          <a href="javascript:void(0)" class="dropdown-item" data-behavior="change-state" data-state="draft"><i class="fa fa-pencil-square-o"></i> Draft</a>
+          <a href="javascript:void(0)" class="dropdown-item" data-behavior="change-state" data-state="review"><i class="fa fa-share-square-o"></i> Ready for Review</a>
+          <a href="javascript:void(0)" class="dropdown-item" data-behavior="change-state" data-state="published"><i class="fa fa-check-square-o"></i> Published</a>
+        </div>
+      </div>
+
     </div>
 
     <div class="btn-group dropdown">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
       collection do
         post :import
         resources :merge, only: [:new, :create], controller: 'issues/merge'
+        resources :states, only: [], controller: 'issues/states' do
+          collection { put :update_states }
+        end
       end
 
       resources :nodes, only: [:show], controller: 'issues/nodes'

--- a/spec/features/issue_pages/states_spec.rb
+++ b/spec/features/issue_pages/states_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'issue pages' do
+  describe 'states', js: true do
+    before do
+      login_to_project_as_user
+
+      # create 2 issues
+      @issue1 = create(:issue, node: current_project.issue_library, state: :draft)
+      @issue2 = create(:issue, node: current_project.issue_library, state: :draft)
+
+      visit project_issues_path(current_project)
+
+      # Enable 'State' as a column for the issues table
+      within('.btn-toolbar') do
+        find('.btn-group.dropdown').click
+      end
+
+      within('.js-table-columns') do
+        find('[data-column="state"]').click
+      end
+
+      # click > 1 issue checkboxes
+      all('input.js-multicheck').each(&:click)
+
+      find('#state-selected').click
+    end
+
+    it 'updates the state of the issues' do
+      find('[data-state="published"]').click
+
+      find('td', text: 'Published', match: :first)
+
+      expect(@issue1.reload.state).to eq('published')
+      expect(@issue2.reload.state).to eq('published')
+    end
+  end
+end


### PR DESCRIPTION
### Spec

With the implementation of issue states, we need to add a way to edit multiple issue states, otherwise users will have to open and edit each issue to update their states.

**Proposed solution**

Add a “State” functionality in the issues table toolbar

### How to test

1. Add multiple issues in a project
2. Visit the Issues Summary page
3. Select multiple issues in the table and select a State.
4. Confirm that the issues have their state changed.