### PR TITLE
Add more padding for items-table arrow. Fix items-table th styles get…

### DIFF
--- a/app/assets/stylesheets/shared/items_table.scss
+++ b/app/assets/stylesheets/shared/items_table.scss
@@ -31,8 +31,8 @@
     vertical-align: middle;
   }
 
-  th {
-    padding: 0.5rem 1.25rem 0.5rem 0.5rem;
+  thead tr th {
+    padding: 0.5rem 1.75rem 0.5rem 0.5rem;
     cursor: pointer;
     position: relative;
 
@@ -83,7 +83,7 @@
 
   tr:hover {
 
-    .column-actions a { 
+    .column-actions a {
       visibility: visible;
     }
   }


### PR DESCRIPTION
### Summary
This PR updates the sort arrow exceeding items-table border in projects#index and also make sure items-table style does not get override by bootstrap 3 default table style.

### How To Test
1. Create multiple projects with very very long name.
2. Try to sort some columns, make sure the sort arrow does not exceed the th border.

### Check List

- [ ] Added a CHANGELOG entry
