### PR TITLE
change float to elimiinate the need for margin

### DIFF
--- a/app/assets/stylesheets/tylium/modules/_comments.scss
+++ b/app/assets/stylesheets/tylium/modules/_comments.scss
@@ -65,6 +65,13 @@
   }
 }
 
+.subscriptions-feed {
+
+  .gravatar {
+    float: initial;
+  }
+}
+
 // tribute @-mentions plugin styles
 .tribute-container {
   position: absolute;

--- a/app/views/subscriptions/_feed.html.erb
+++ b/app/views/subscriptions/_feed.html.erb
@@ -8,7 +8,7 @@
       - <%= render 'subscriptions/actions', subscribable: subscribable %>
     </span>
   </h4>
-  <div class="subscriptions-feed <%= 'mb-5' if subscribable.subscriptions.any? %>">
+  <div class="subscriptions-feed">
     <% subscribable.subscriptions.each do |subscription| %>
       <%= avatar_image(subscription.user, size: 40) %>
     <% end %>


### PR DESCRIPTION
### Summary

This PR changes the float of gravatars in the subscription container to eliminate the condition margin class.

No changelog is needed here as nothing will visually change. This fix is more so for Pro and to eliminate css divergence that occurred at some point.

### How To Test
1. View a resource that can be subscribed to (issue, note, evidence, etc)
2. Subscribe to this resource
3. Asset there subscribers section below the comments feed does not have an unnecessarily large bottom margin.

For reference, the broken version looked like this:
<img width="613" alt="Screen Shot 2020-05-18 at 4 35 44 PM" src="https://user-images.githubusercontent.com/46340573/82197834-a63bd480-9925-11ea-9bf6-5cec635d2ab0.png">

### Check List

~- [ ] Added a CHANGELOG entry~
