### PR TITLE
fix dots menu margin

### DIFF
--- a/app/assets/stylesheets/tylium/layout.scss
+++ b/app/assets/stylesheets/tylium/layout.scss
@@ -24,7 +24,7 @@
   margin-bottom: 0;
   padding-left: $mainContentPadding;
   white-space: nowrap;
-  width: calc(100% - 35px);
+  width: 100%;
 
   .breadcrumb-item {
     white-space: nowrap;

--- a/app/assets/stylesheets/tylium/modules/_dots-menu.scss
+++ b/app/assets/stylesheets/tylium/modules/_dots-menu.scss
@@ -5,6 +5,10 @@
   align-items: center;
   padding-right: 1rem;
 
+  .breadcrumb {
+    width: calc(100% - 35px);
+  }
+
   .dots-dropdown {
     border: 1px solid darken($borderColor, 2%);
     border-radius: 50px;


### PR DESCRIPTION
### Summary

This PR fixes a margin issue with the breadcrumbs bar where there is no dots-menu present.

<img width="271" alt="Screen Shot 2020-05-15 at 6 15 46 PM" src="https://user-images.githubusercontent.com/46340573/82052274-92099480-96e5-11ea-8606-e9c2ba21f2f6.png">

Changelog entry is not needed as the dots-menu was not released yet

### How To Test
1. Open a project with some boards populated
2. Navigate to boards#index
3. Assert:
   1. the breadcrumb bar spans the entire width of the view
   2. dots-menu button ***is not*** present
4. Click on a board
5. Assert: 
   1. the breadcrumb bar spans the entire width of the view
   2. dots-menu button ***is*** present

### Check List

~- [ ] Added a CHANGELOG entry~
