### PR TITLE
Fix textile table wrapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ v3.17 (Month 2020)
     - Fix textile preview not showing on issues with very long text
     - Long items_table dropdown menus not scrollable
     - Long project names interfering with search bar expansion
+    - Long unbroken table cell text in textile elements overflows
     - Repetative prompt when images are pasted after navigating multiple views.
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked
     - SemVer pre-release appending character

--- a/app/assets/stylesheets/tylium/modules/textile.scss
+++ b/app/assets/stylesheets/tylium/modules/textile.scss
@@ -62,6 +62,10 @@
         background-color: #f5f5f5;
       }
     }
+    
+    td {
+      overflow-wrap: anywhere;
+    }
 
     // Cells
     th,


### PR DESCRIPTION
### Summary

This PR fixes overflowing content when a table is added to a textile element with super long text.

### How To Text
1. Create an issue
2. Populate the source view with:
```
#[Title]#
Test wrapping

#[Description]#
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

|_. Col 1 Header|_. Col 2 Header|
|aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|Col 2 Row 1|
|Col 1 Row 2|Col 2 Row 2|
```
3. Assert the long `aaaaaa...` text is wrapped both inside and outside of the table 

### Check List

- [x] Added a CHANGELOG entry
