### PR TITLE
add padding-right to select elements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@ v3.17 (Month 2020)
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked
     - SemVer pre-release appending character
     - Set :author when creating Evidence from an Issue
+    - Select element text overflowing on to select arrows
     - Sidebar items not showing active state
     - Textile preview not showing on issues with very long text
     - Bug tracker items: #560

--- a/app/assets/stylesheets/tylium/base.scss
+++ b/app/assets/stylesheets/tylium/base.scss
@@ -150,6 +150,7 @@ select {
   -webkit-appearance: none !important;
   background: white url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+') no-repeat 95% 50% !important;
   background-position: calc(100% - 5px) center !important;
+  padding-right: 1.5rem !important;
 }
 
 // Firefox Fixes //


### PR DESCRIPTION
### Summary

With our custom `<select>` element styling (to standardize styling across browsers), long text may overflow onto the elements dropdown arrows. This PR adds important padding-right to the select styling override.

### How To Test
1. Navigate to a view with a pre-populated select 
   1. for example you can go to boards#index, click on `Create new methodology`
2. Ensure the select element has padding between the text and the arrows on the right.

### Check List

- [x] Added a CHANGELOG entry
