### PR TITLE
add padding-right to header names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@ v3.17 (Month 2020)
     - Repetative prompt when images are pasted after navigating multiple views.
     - Report 'Download' button becoming a disabled 'Processing...' button once clicked
     - SemVer pre-release appending character
+    - Secondary-sidebar long header names over-lapping icons
     - Set :author when creating Evidence from an Issue
     - Sidebar items not showing active state
     - Textile preview not showing on issues with very long text

--- a/app/assets/stylesheets/tylium/modules/_secondary_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_secondary_sidebar.scss
@@ -30,8 +30,9 @@
     padding-top: 0.5rem;
 
     .header-name {
-      margin-top: 0.5rem;
       cursor: default;
+      margin-top: 0.5rem;
+      padding-right: 2.5rem;
     
       a {
         color: $lightColor;


### PR DESCRIPTION
### Summary

This PR fixes long header names in the secondary sidebar overlapping icons.

<img width="261" alt="Screen Shot 2020-05-18 at 6 00 41 PM" src="https://user-images.githubusercontent.com/46340573/82205931-8a3e3000-9931-11ea-8c5f-061d636a441b.png">

### How To Text
1. Navigate to any view with a secondary-sidebar.
2. Adjust your browser width
3. Assert all widths wrap the header name appropriately. 
   1. You may need to use the inspector to change the text in order to make it longer.

### Check List

- [x] Added a CHANGELOG entry
