### PR TITLE
fix blockcode background color

### DIFF
--- a/app/assets/stylesheets/tylium/base.scss
+++ b/app/assets/stylesheets/tylium/base.scss
@@ -139,6 +139,10 @@ mark {
   height: 3rem;
 }
 
+pre code {
+  background-color: initial;
+}
+
 .required-input {
   color: $red;
 }


### PR DESCRIPTION
### Summary

This PR fixes the `<code>` element bg color in code blocks.

Before:
<img width="1068" alt="Screen Shot 2020-05-29 at 12 31 56 PM" src="https://user-images.githubusercontent.com/46340573/83224858-a1d6ad80-a1a8-11ea-8a0e-3b80a9fa04aa.png">

After:
<img width="1071" alt="Screen Shot 2020-05-29 at 12 31 39 PM" src="https://user-images.githubusercontent.com/46340573/83224864-a733f800-a1a8-11ea-9afe-153ecbda4857.png">

### Check List

~- [ ] Added a CHANGELOG entry~
