### PR TITLE
Release 3.17.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,28 +1,5 @@
-v3.#.# (MMM’YY)
-  * [feature #1]
-  * [feature #2]
-  * [feature ...]
+v3.17.1 (Jun 2020)
   * Upgraded gems: websocket-extensions
-  * Bugs fixed:
-    - [bug fixed #1]
-    - [bug fixed ...]
-    - Bug tracker items: #N, #M, #O, ...
-  * New integrations:
-    - [new integration #1]
-    - [new integration ...]
-  * Integration enhancements:
-    - [integration enhancement #1]
-    - [integration enhancement ...]
-  * Reporting enhancements:
-    - [reporting enhancement #1]
-    - [reporting enhancement ...]
-  * REST/JSON API enhancements:
-    - [API enhancement #1]
-    - [API enhancement ...]
-  * Security Fixes:
-    - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
-    - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
-    - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
 
 v3.17 (May 2020)
   * Add author to evidence and notes views

--- a/lib/dradis/ce/version.rb
+++ b/lib/dradis/ce/version.rb
@@ -3,7 +3,7 @@ module Dradis
     module VERSION #:nodoc:
       MAJOR = 3
       MINOR = 17
-      TINY  = 0
+      TINY  = 1
       PRE = nil
 
       STRING = [[MAJOR, MINOR, TINY].join('.'), PRE].compact.join('-')


### PR DESCRIPTION
### Summary

A version bump for release 3.17.1.

```
v3.17.1 (Jun 2020)
  * Upgraded gems: websocket-extensions
```

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
