### PR TITLE
Fix comment edit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,9 @@ v3.#.# (MMM’YY)
   * [feature ...]
   * Upgraded gems: websocket-extensions
   * Bugs fixed:
-    - [bug fixed #1]
-    - [bug fixed ...]
+    - Comments:
+      - Fix `edit` link available while editing
+      - Fix comment borders remaining after deleting comments
     - Bug tracker items: #N, #M, #O, ...
   * New integrations:
     - [new integration #1]

--- a/app/assets/javascripts/tylium/modules/comments.js.coffee
+++ b/app/assets/javascripts/tylium/modules/comments.js.coffee
@@ -6,6 +6,7 @@ document.addEventListener "turbolinks:load", ->
     comment = element.closest(".comment")
     comment.find(".content").show()
     comment.find("form").hide()
+    comment.find('[data-action~=edit]').show()
   )
 
   if $('[data-behavior~=mentionable]').length

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -16,7 +16,7 @@
 
 
             <div class="actions pull-right">
-              <%= link_to edit_project_comment_path(current_project, comment), remote: true do %>
+              <%= link_to edit_project_comment_path(current_project, comment), remote: true, data: { action: 'edit' } do %>
                 <i class="fa fa-pencil"></i> Edit
               <% end %>
               <%= link_to [current_project, comment],

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -1,4 +1,4 @@
-$("#<%= dom_id(@comment) %>").remove()
+$("#<%= dom_id(@comment) %>").parent().remove()
 <% if @comment.commentable.comments.empty? %>
   $('[data-notice~=no-comments]').show()
 <% end %>

--- a/app/views/comments/edit.js.erb
+++ b/app/views/comments/edit.js.erb
@@ -1,5 +1,6 @@
 <% if can? :update, @comment %>
   $('#<%= dom_id(@comment) %> .content').hide();
+  $('#<%= dom_id(@comment) %> [data-action~=edit]').hide();
   $('#<%= dom_id(@comment) %> .body').append("<%= j render 'form' %>");
   Mentions.init($('#<%= dom_id(@comment) %> [data-behavior~=mentionable]')[0]);
 

--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,3 +1,4 @@
 $('#<%= dom_id(@comment) %> form').hide();
 $('#<%= dom_id(@comment) %> .content').html("<%= j(comment_formatter(@comment.content)) %>");
 $('#<%= dom_id(@comment) %> .content').show();
+$('#<%= dom_id(@comment) %> [data-action~=edit]').show()


### PR DESCRIPTION
### Summary

When a comment is is edit mode, the edit button is still available. This allows the user to infinitely append the edit form to the view. This PR hides the edit button when the user clicks edit.

Also, the PR updates the comment js to select the correct element when deleting comments so old comment borders don't remain in the view after the comments have been deleted.

### Check List

- [x] Added a CHANGELOG entry
