### PR TITLE
Absolute email notification timestamp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
-[v3.8.0] ([MMM’YY])
+[v3.19.0] ([MMM’YY])
   * Auto upload attachments and screenshots without requiring the use of the staging area
   * Cards, Evidence, Issues, and Notes now have their own attachment support
   * Editor: Allow drag & drop, copy & paste, and direct image uploading
   * Layout: Breadcrumbs have a fixed position
   * Upgraded gems: [gem #1], [gem #2]
   * Bugs fixed:
-    - [bug fixed #1]
+    - Use absolute send times in notification emails instead of relative
     - [bug fixed ...]
     - Bug tracker items: #N, #M, #O, ...
   * New integrations:

--- a/app/presenters/digest_presenter.rb
+++ b/app/presenters/digest_presenter.rb
@@ -2,7 +2,7 @@ class DigestPresenter < NotificationPresenter
   attr_reader :current_project, :notifications, :template
 
   # Jul 9th at 2:45pm
-  Time::DATE_FORMATS[:digest_format] = ->(time) { time.strftime "%h #{time.day.ordinalize} at %l:%M%P" }
+  Time::DATE_FORMATS[:digest_format] = ->(time) { time.strftime "%h #{time.day.ordinalize} at %l:%M%P #{time.zone}" }
 
   def initialize(notifications, project, template)
     @current_project = project
@@ -23,7 +23,7 @@ class DigestPresenter < NotificationPresenter
   end
 
   def created_at
-    notification.created_at.to_s(:digest_format)
+    notification.created_at.localtime.to_s(:digest_format)
   end
 
   def text_title

--- a/app/presenters/digest_presenter.rb
+++ b/app/presenters/digest_presenter.rb
@@ -1,9 +1,6 @@
 class DigestPresenter < NotificationPresenter
   attr_reader :current_project, :notifications, :template
 
-  # Jul 9th at 2:45pm
-  Time::DATE_FORMATS[:digest_format] = ->(time) { time.strftime "%h #{time.day.ordinalize} at %l:%M%P #{time.zone}" }
-
   def initialize(notifications, project, template)
     @current_project = project
     @notifications = notifications
@@ -23,7 +20,8 @@ class DigestPresenter < NotificationPresenter
   end
 
   def created_at
-    notification.created_at.localtime.to_s(:digest_format)
+    time = notification.created_at.localtime
+    time.strftime("%h #{time.day.ordinalize} at %l:%M%P #{time.zone}") # Jul 9th at 2:45pm CEST
   end
 
   def text_title

--- a/app/presenters/digest_presenter.rb
+++ b/app/presenters/digest_presenter.rb
@@ -1,6 +1,9 @@
 class DigestPresenter < NotificationPresenter
   attr_reader :current_project, :notifications, :template
 
+  # Jul 9th at 2:45pm
+  Time::DATE_FORMATS[:digest_format] = ->(time) { time.strftime "%h #{time.day.ordinalize} at %l:%M%P" }
+
   def initialize(notifications, project, template)
     @current_project = project
     @notifications = notifications
@@ -19,9 +22,8 @@ class DigestPresenter < NotificationPresenter
     )
   end
 
-  def created_at_ago
-    # We can't use the local_time gem here because there's no JS
-    "#{time_ago_in_words(notification.created_at)} ago"
+  def created_at
+    notification.created_at.to_s(:digest_format)
   end
 
   def text_title

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -69,7 +69,7 @@
       </tr>
       <tr align="center">
         <td>
-          <span>© 2012-2019 Dradis Framework — Security Roots Ltd</span><br>
+          <span>© 2012-<%= Time.now.year %> Dradis Framework — Security Roots Ltd</span><br>
           <span>10 Portfleet Place, De Beauvoir Road</span><br>
           <span>London, N1 5SZ</span>
         </td>

--- a/app/views/notification_mailer/_notification.html.erb
+++ b/app/views/notification_mailer/_notification.html.erb
@@ -5,6 +5,6 @@
   <td colspan="5" style="padding-left: 0; font-weight: 400;">
     <%= presenter.render_title %>
     <span style="font-size: 80%; color: #777; white-space: nowrap;">
-      <%= presenter.created_at_ago %>
+      <%= presenter.created_at %>
     </span>
   </td>

--- a/app/views/notification_mailer/_notification.text.erb
+++ b/app/views/notification_mailer/_notification.text.erb
@@ -1,1 +1,1 @@
-<%= presenter.text_title %> <%= presenter.created_at_ago %>
+<%= presenter.text_title %> <%= presenter.created_at %>

--- a/app/views/notification_mailer/digest.html.erb
+++ b/app/views/notification_mailer/digest.html.erb
@@ -13,8 +13,8 @@
         </td>
       </tr>
     </table>
-  </tr>
-</td>
+  </td>
+</tr>
 
 <tr>
   <td>
@@ -27,13 +27,13 @@
                 <td height="20px"></td>
               </tr>
               <tr>
-                <td width="20px"></td>
+                <td width="20px">&nbsp;</td>
                 <td align="left" nowrap style="font-weight: 700; font-size: 1.1rem; line-height: 1.2rem;"><%= project.name %></td>
-                <td width="20px"></td>
+                <td width="20px">&nbsp;</td>
                 <td style="width: 590px">
                   <hr style="border-top: 0.5px solid #ddd; border-bottom: 0.5px solid #ddd; border-right: 0.5px solid transparent; border-left: 0.5px solid transparent;">
                 </td>
-                <td width="20px"></td>
+                <td width="20px">&nbsp;</td>
               </tr>
             </table>
           </td>
@@ -65,17 +65,21 @@
             <td colspan="12" align="center">
               <table cellspacing="0" cellpadding="0">
                 <tr>
+                  <td width="20px">&nbsp;</td>
                   <td width="590px">
                     <hr style="border-top: 0.5px solid #ddd; border-bottom: 0.5px solid #ddd; border-right: 0.5px solid transparent; border-left: 0.5px solid transparent;">
                   </td>
+                  <td width="20px">&nbsp;</td>
                 </tr>
                 <tr>
                   <td height="10px"></td>
                 </tr>
                 <tr>
+                  <td width="20px">&nbsp;</td>
                   <td align="center">
                     <%= link_to 'See all notifications', project_notifications_url(project), class: 'button', style: 'display: inline-block; border-radius: 5px; padding: 8px 15px; color: #fff;background-color: #378137;' %> <%# background-color: #298DCC in pro %>
                   </td>
+                  <td width="20px">&nbsp;</td>
                 </tr>
                 <tr>
                   <td height="20px"></td>
@@ -86,5 +90,5 @@
         <% end %>
       <% end %>
     </table>
-  </tr>
-</td>
+  </td>
+</tr>

--- a/app/views/notification_mailer/digest.html.erb
+++ b/app/views/notification_mailer/digest.html.erb
@@ -27,13 +27,13 @@
                 <td height="20px"></td>
               </tr>
               <tr>
-                <td width="20px">&nbsp;</td>
+                <td width="20px">&nbsp;&nbsp;</td>
                 <td align="left" nowrap style="font-weight: 700; font-size: 1.1rem; line-height: 1.2rem;"><%= project.name %></td>
-                <td width="20px">&nbsp;</td>
+                <td width="20px">&nbsp;&nbsp;</td>
                 <td style="width: 590px">
                   <hr style="border-top: 0.5px solid #ddd; border-bottom: 0.5px solid #ddd; border-right: 0.5px solid transparent; border-left: 0.5px solid transparent;">
                 </td>
-                <td width="20px">&nbsp;</td>
+                <td width="20px">&nbsp;&nbsp;</td>
               </tr>
             </table>
           </td>


### PR DESCRIPTION
### Summary

When email notifications get sent out each comment has a timestamp written in a relative format "8 minutes ago" etc. This relative timestamp is accurate the moment the email is sent, but if the email isn't read for 15 hours then the real time the comment was made was 15 hours and 8 minutes ago, not 8 minutes ago. This can be confusing when reading the email and attempting to build a mental timeline of when events occur.

### Solution

Change relative time to actual time (ie. Jul 9th at 2:45pm)

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
