### PR TITLE
Node properties longtext

### DIFF
--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -7,7 +7,7 @@
 
 
 # Unless the DB is already migrated, do nothing
-if Configuration.table_exists?
+if (ActiveRecord::Base.connection rescue false) && Configuration.table_exists?
   plugin_dir = nil
   source_dir = nil
   destination_dir = nil

--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -5,6 +5,11 @@
 # When such facility exists we can replace the content of this loop with a
 # simple call to (for instance) <plugin>.copy_templates
 
+# Rails 5.2 now loads the environment on all db rake tasks. Previously it did
+# not for setup or create. This means if the db doesn't exist this code will
+# fail. Technically we shouldn't communicate with AR during initializers so this
+# is workaround.
+# https://github.com/rails/rails/issues/32870
 
 # Unless the DB is already migrated, do nothing
 if (ActiveRecord::Base.connection rescue false) && Configuration.table_exists?

--- a/db/migrate/20200806120434_change_node_properties_to_long_text.rb
+++ b/db/migrate/20200806120434_change_node_properties_to_long_text.rb
@@ -1,0 +1,7 @@
+class ChangeNodePropertiesToLongText < ActiveRecord::Migration[5.2]
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    change_column :nodes, :properties, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 2020_01_08_120900) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
-    t.text "properties"
+    t.text "properties", limit: 4294967295
     t.integer "children_count", default: 0, null: false
     t.index ["parent_id"], name: "index_nodes_on_parent_id"
     t.index ["type_id"], name: "index_nodes_on_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_120900) do
+ActiveRecord::Schema.define(version: 2020_08_06_120434) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
### Spec
Currently, the node properties column in the database is of type TEXT. This can only support 65k+ bytes. This is a problem especially since importing Nessus/Nmap files can easily exceed the limit.

**Proposed solution**
Update the node properties column to LONGTEXT
Alternatively, we can truncate the extra data instead when uploading.

### How to test

1. Before testing, run rails db:migrate to update the database.
2. Upload a Nessus/Nmap export file with large data
3. Confirm that the file imports successfully.