### PR TITLE
Link to our support side and remove broken link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
   * Editor: Allow drag & drop, copy & paste, and direct image uploading
   * Increase the node properties column size by changing it to LONGTEXT
   * Layout: Breadcrumbs have a fixed position
+  * Link to our support site on the styles help page
   * Upgraded gems: [gem #1], [gem #2]
   * Bugs fixed:
     - Use absolute send times in notification emails instead of relative

--- a/app/views/markup/help.html.erb
+++ b/app/views/markup/help.html.erb
@@ -151,6 +151,5 @@ but we only allow the 100-continue expectation.
 
 
   <h5 class="header-underline">Further help</h5>
-  <p>You can use <a href="http://redcloth.org/textile/" target="_blank">Textile</a> markup.</p>
-
+  <p>Check out our <a href="https://dradisframework.com/support/guides/word_reports/styles.html" target="blank">support website</a> for more details on supported styles.</p>
 </div>

--- a/app/views/markup/help.html.erb
+++ b/app/views/markup/help.html.erb
@@ -151,5 +151,5 @@ but we only allow the 100-continue expectation.
 
 
   <h5 class="header-underline">Further help</h5>
-  <p>Check out our <a href="https://dradisframework.com/support/guides/word_reports/styles.html" target="blank">support website</a> for more details on supported styles.</p>
+  <p>Check out our <a href="https://dradisframework.com/support/guides/word_reports/styles.html" target="_blank">support website</a> for more details on supported styles.</p>
 </div>


### PR DESCRIPTION
### Summary
The style help page was linked to a textile help page. This PR removes that link (to clarify that not all textile styles are supported in Dradis) and replaces it with a link to our support page. 

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
