### PR TITLE
Diff by word rather than by line

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
   * Editor: Allow drag & drop, copy & paste, and direct image uploading
   * Increase the node properties column size by changing it to LONGTEXT
   * Layout: Breadcrumbs have a fixed position
+  * In the revision history, diff by word rather than by line
   * Upgraded gems: [gem #1], [gem #2]
   * Bugs fixed:
     - Use absolute send times in notification emails instead of relative

--- a/app/models/diffed_revision.rb
+++ b/app/models/diffed_revision.rb
@@ -9,7 +9,7 @@ class DiffedRevision
   end
 
   def diff
-    @diff ||= Differ.diff_by_line(
+    @diff ||= Differ.diff_by_word(
                 after[content_attribute],
                 before[content_attribute]
               )


### PR DESCRIPTION
### Summary
The revision history currently checks by line. This PR updates the revision history to see changes by word instead. This should offer more granularity as far as the changes made. 

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List
- [x] Added a CHANGELOG entry
