### PR TITLE
fix image injected syntax location on image paste

### DIFF
--- a/app/assets/javascripts/shared/editor_toolbar.js
+++ b/app/assets/javascripts/shared/editor_toolbar.js
@@ -82,6 +82,9 @@ class EditorToolbar {
     // Handler for setting the correct textarea heights on load (for current values)
     this.$target.each(setHeight);
 
+    // Handler for setting the correct textarea height when focus is lost
+    this.$target.on('blur', setHeight);
+
     // when a toolbar button is clicked
     this.$editorToolbar.find('[data-btn]').click(function() {
       var $element = that.$editorField.find('textarea, input[type=text]');

--- a/app/assets/javascripts/shared/editor_toolbar.js
+++ b/app/assets/javascripts/shared/editor_toolbar.js
@@ -72,26 +72,15 @@ class EditorToolbar {
       }
     });
 
+    function setHeight(e) {
+      $(this).css({'height': '1px'}).css({'height': this.scrollHeight + 2});
+    };
+
     // Handler for setting the correct textarea height on keyboard input
     this.$target[0].addEventListener('input', setHeight);
-
-    function setHeight(e) {
-      const shrinkEvents = ['deleteContentForward', 'deleteContentBackward', 'deleteByCut', 'historyUndo', 'historyRedo'];
-
-      if (shrinkEvents.includes(e.inputType)) {
-        // shrink the text area when content is being removed
-        $(this).css({'height': '1px'});
-      }
-      
-      // expand the textarea to fix the content
-      $(this).css({'height': this.scrollHeight + 2});
-    };
   
     // Handler for setting the correct textarea heights on load (for current values)
     this.$target.each(setHeight);
-
-    // Handler for setting the correct textarea height when focus is lost
-    this.$target.on('blur', setHeight);
 
     // when a toolbar button is clicked
     this.$editorToolbar.find('[data-btn]').click(function() {

--- a/app/assets/javascripts/tylium/modules/fileupload.js
+++ b/app/assets/javascripts/tylium/modules/fileupload.js
@@ -36,14 +36,13 @@ function fileUploadInit() {
 
       $.each(data.files, function (index, file) {
         var uploadedFile = data.result[0].url,
-            str = '\n!' + file.name + ' uploading...' + '!\n';
+            str = '\n!' + file.name + ' uploading...' + '!\n',
+            affix = editorToolbar.affixes['image'];
 
-        // remove placeholder from textarea for each file once it's uploaded
-        $textarea.focus().val($textarea.val().replace(str, ''));
+        // replace placeholder with injected syntax for each file once
+        // it's uploaded to automatically display uploaded image
+        $textarea.focus().val($textarea.val().replace(str, affix.withSelection(uploadedFile), $textarea));
 
-        // inject syntax into textarea to automatically display uploaded image
-        affix = editorToolbar.affixes['image'];
-        editorToolbar.replace(affix.withSelection(uploadedFile), $textarea);
         $textarea.trigger('textchange');
       })
     }


### PR DESCRIPTION
### Summary

fix syntax injection bug where pasted image syntax is injected at the end of the textarea element

### Check List

~- [ ] Added a CHANGELOG entry~
