### PR TITLE
Add migrations for changing primary key and foreign keys from int to bigint.

### DIFF
--- a/db/migrate/20210201061359_change_primary_keys_to_bigint.rb
+++ b/db/migrate/20210201061359_change_primary_keys_to_bigint.rb
@@ -1,0 +1,119 @@
+class ChangePrimaryKeysToBigint < ActiveRecord::Migration[6.1]
+  def up
+    change_table :active_storage_attachments do |t|
+      t.change :record_id, :bigint
+      t.change :blob_id, :bigint
+    end
+
+    change_table :activities do |t|
+      t.change :trackable_id, :bigint
+      t.change :user_id, :bigint
+    end
+
+    change_table :boards do |t|
+      t.change :node_id, :bigint
+    end
+
+    change_table :cards do |t|
+      t.change :list_id, :bigint
+      t.change :previous_id, :bigint
+    end
+
+    change_table :evidence do |t|
+      t.change :issue_id, :bigint
+      t.change :node_id, :bigint
+    end
+
+    change_table :lists do |t|
+      t.change :board_id, :bigint
+      t.change :previous_id, :bigint
+    end
+
+    change_table :nodes do |t|
+      t.change :parent_id, :bigint
+    end
+
+    change_table :notes do |t|
+      t.change :category_id, :bigint
+      t.change :node_id, :bigint
+    end
+
+    change_table :notifications do |t|
+      t.change :notifiable_id, :bigint
+      t.change :actor_id, :bigint
+      t.change :recipient_id, :bigint
+    end
+
+    change_table :subscriptions do |t|
+      t.change :subscribable_id, :bigint
+      t.change :user_id, :bigint
+    end
+
+    change_table :taggings do |t|
+      t.change :tag_id, :bigint
+    end
+
+    change_table :versions do |t|
+      t.change :item_id, :bigint
+    end
+  end
+
+  def down
+    change_table :active_storage_attachments do |t|
+      t.change :record_id, :int
+      t.change :blob_id, :int
+    end
+
+    change_table :activities do |t|
+      t.change :trackable_id, :int
+      t.change :user_id, :int
+    end
+
+    change_table :boards do |t|
+      t.change :node_id, :int
+    end
+
+    change_table :cards do |t|
+      t.change :list_id, :int
+      t.change :previous_id, :int
+    end
+
+    change_table :evidence do |t|
+      t.change :issue_id, :int
+      t.change :node_id, :int
+    end
+
+    change_table :lists do |t|
+      t.change :board_id, :int
+      t.change :previous_id, :int
+    end
+
+    change_table :nodes do |t|
+      t.change :parent_id, :int
+    end
+
+    change_table :notes do |t|
+      t.change :category_id, :int
+      t.change :node_id, :int
+    end
+
+    change_table :notifications do |t|
+      t.change :notifiable_id, :int
+      t.change :actor_id, :int
+      t.change :recipient_id, :int
+    end
+
+    change_table :subscriptions do |t|
+      t.change :subscribable_id, :int
+      t.change :user_id, :int
+    end
+
+    change_table :taggings do |t|
+      t.change :tag_id, :int
+    end
+
+    change_table :versions do |t|
+      t.change :item_id, :int
+    end
+  end
+end

--- a/db/migrate/20210201061359_change_primary_keys_to_bigint.rb
+++ b/db/migrate/20210201061359_change_primary_keys_to_bigint.rb
@@ -1,119 +1,293 @@
 class ChangePrimaryKeysToBigint < ActiveRecord::Migration[6.1]
   def up
     change_table :active_storage_attachments do |t|
-      t.change :record_id, :bigint
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :blob_id, :bigint
+      t.change :record_id, :bigint
+    end
+
+    change_table :active_storage_blobs do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
     end
 
     change_table :activities do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :trackable_id, :bigint
       t.change :user_id, :bigint
     end
 
     change_table :boards do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :node_id, :bigint
     end
 
     change_table :cards do |t|
       t.change :list_id, :bigint
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :previous_id, :bigint
     end
 
+    change_table :cards_users do |t|
+      t.change :card_id, :bigint
+      t.change :user_id, :bigint
+    end
+
+    change_table :categories do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
+    end
+
+   change_table :comments do |t|
+      t.change :commentable_id, :bigint
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
+      t.change :user_id, :bigint
+    end
+
+    change_table :configurations do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
+    end
+
     change_table :evidence do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :issue_id, :bigint
       t.change :node_id, :bigint
     end
 
     change_table :lists do |t|
       t.change :board_id, :bigint
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :previous_id, :bigint
     end
 
+    change_table :logs do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
+    end
+
     change_table :nodes do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :parent_id, :bigint
     end
 
     change_table :notes do |t|
       t.change :category_id, :bigint
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :node_id, :bigint
     end
 
     change_table :notifications do |t|
-      t.change :notifiable_id, :bigint
       t.change :actor_id, :bigint
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
+      t.change :notifiable_id, :bigint
       t.change :recipient_id, :bigint
     end
 
     change_table :subscriptions do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :subscribable_id, :bigint
       t.change :user_id, :bigint
     end
 
     change_table :taggings do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :tag_id, :bigint
+      t.change :taggable_id, :bigint
+    end
+
+    change_table :tags do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
+    end
+
+    change_table :users do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
     end
 
     change_table :versions do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :bigint, unique: true, null: false, auto_increment: true
+      end
       t.change :item_id, :bigint
+      t.change :project_id, :bigint
     end
   end
 
   def down
     change_table :active_storage_attachments do |t|
-      t.change :record_id, :int
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :blob_id, :int
+      t.change :record_id, :int
+    end
+
+    change_table :active_storage_blobs do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
     end
 
     change_table :activities do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :trackable_id, :int
       t.change :user_id, :int
     end
 
     change_table :boards do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :node_id, :int
     end
 
     change_table :cards do |t|
       t.change :list_id, :int
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :previous_id, :int
     end
 
+    change_table :cards_users do |t|
+      t.change :card_id, :int
+      t.change :user_id, :int
+    end
+
+    change_table :categories do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
+    end
+
+   change_table :comments do |t|
+      t.change :commentable_id, :int
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
+      t.change :user_id, :int
+    end
+
+    change_table :configurations do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
+    end
+
     change_table :evidence do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :issue_id, :int
       t.change :node_id, :int
     end
 
     change_table :lists do |t|
       t.change :board_id, :int
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :previous_id, :int
     end
 
+    change_table :logs do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
+    end
+
     change_table :nodes do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :parent_id, :int
     end
 
     change_table :notes do |t|
       t.change :category_id, :int
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :node_id, :int
     end
 
     change_table :notifications do |t|
-      t.change :notifiable_id, :int
       t.change :actor_id, :int
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
+      t.change :notifiable_id, :int
       t.change :recipient_id, :int
     end
 
     change_table :subscriptions do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :subscribable_id, :int
       t.change :user_id, :int
     end
 
     change_table :taggings do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :tag_id, :int
+      t.change :taggable_id, :int
+    end
+
+    change_table :tags do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
+    end
+
+    change_table :users do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
     end
 
     change_table :versions do |t|
+      if ActiveRecord::Base.connection.adapter_name != 'SQLite'
+        t.change :id, :int, unique: true, null: false, auto_increment: true
+      end
       t.change :item_id, :int
+      t.change :project_id, :int
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
 
   create_table "cards_users", id: false, force: :cascade do |t|
     t.integer "card_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.index ["card_id", "user_id"], name: "index_cards_users_on_card_id_and_user_id"
     t.index ["user_id", "card_id"], name: "index_cards_users_on_user_id_and_card_id"
   end
@@ -82,10 +82,10 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
     t.text "content"
     t.string "commentable_type"
     t.integer "commentable_id"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
-    t.text "properties", limit: 4294967295
+    t.text "properties", limit: 1073741823
     t.integer "children_count", default: 0, null: false
     t.index ["parent_id"], name: "index_nodes_on_parent_id"
     t.index ["type_id"], name: "index_nodes_on_type_id"
@@ -159,7 +159,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["actor_id"], name: "index_notifications_on_actor_id"
-    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
     t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
   end
 
@@ -170,19 +170,19 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subscribable_id", "subscribable_type", "user_id"], name: "index_subscriptions_on_subscribablue_and_user", unique: true
-    t.index ["subscribable_type", "subscribable_id"], name: "index_subscriptions_on_subscribable_type_and_subscribable_id"
+    t.index ["subscribable_type", "subscribable_id"], name: "index_subscriptions_on_subscribable"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
   create_table "taggings", force: :cascade do |t|
-    t.bigint "tag_id"
+    t.integer "tag_id"
     t.string "taggable_type"
-    t.integer "taggable_id"
+    t.bigint "taggable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["tag_id", "taggable_id", "taggable_type"], name: "index_taggings_on_tag_id_and_taggable_id_and_taggable_type", unique: true
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
-    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable"
   end
 
   create_table "tags", force: :cascade do |t|
@@ -204,14 +204,20 @@ ActiveRecord::Schema.define(version: 2021_02_01_061359) do
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.bigint "item_id", null: false
+    t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object", limit: 1073741823
     t.datetime "created_at"
-    t.integer "project_id"
+    t.bigint "project_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
     t.index ["project_id"], name: "index_versions_on_project_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "boards", "nodes", on_delete: :cascade
+  add_foreign_key "comments", "users", on_delete: :nullify
+  add_foreign_key "notifications", "users", column: "actor_id", on_delete: :cascade
+  add_foreign_key "notifications", "users", column: "recipient_id", on_delete: :cascade
+  add_foreign_key "subscriptions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,21 +2,21 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_06_120434) do
+ActiveRecord::Schema.define(version: 2021_02_01_061359) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   end
 
   create_table "activities", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.string "trackable_type", null: false
     t.integer "trackable_id", null: false
     t.string "action", null: false
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
 
   create_table "boards", force: :cascade do |t|
     t.string "name"
-    t.integer "node_id"
+    t.bigint "node_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["node_id"], name: "index_boards_on_node_id"
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
     t.text "description"
     t.date "due_date"
     t.integer "list_id"
-    t.integer "previous_id"
+    t.bigint "previous_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["list_id"], name: "index_cards_on_list_id"
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   end
 
   create_table "evidence", force: :cascade do |t|
-    t.integer "node_id"
+    t.bigint "node_id"
     t.integer "issue_id"
     t.text "content"
     t.string "author"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   create_table "lists", force: :cascade do |t|
     t.string "name"
     t.integer "board_id"
-    t.integer "previous_id"
+    t.bigint "previous_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["board_id"], name: "index_lists_on_board_id"
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   create_table "nodes", force: :cascade do |t|
     t.integer "type_id"
     t.string "label"
-    t.integer "parent_id"
+    t.bigint "parent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   create_table "notes", force: :cascade do |t|
     t.string "author"
     t.text "text"
-    t.integer "node_id"
+    t.bigint "node_id"
     t.integer "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
     t.string "notifiable_type"
     t.integer "notifiable_id"
     t.integer "actor_id"
-    t.integer "recipient_id"
+    t.bigint "recipient_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["actor_id"], name: "index_notifications_on_actor_id"
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   create_table "subscriptions", force: :cascade do |t|
     t.string "subscribable_type"
     t.integer "subscribable_id"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subscribable_id", "subscribable_type", "user_id"], name: "index_subscriptions_on_subscribablue_and_user", unique: true
@@ -175,7 +175,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
   end
 
   create_table "taggings", force: :cascade do |t|
-    t.integer "tag_id"
+    t.bigint "tag_id"
     t.string "taggable_type"
     t.integer "taggable_id"
     t.datetime "created_at", null: false
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_120434) do
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.integer "item_id", null: false
+    t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object", limit: 1073741823


### PR DESCRIPTION
### Summary
This PR changes the existing primary and foreign keys from int to bigint. Starting from Rails 6, the default primary key when creating a new table and adding foreign key using references will be bigint unless manually specified as int.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
