### PR TITLE
Move subscriptions controller out from project namespace

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -6,7 +6,7 @@ class SubscriptionsController < AuthenticatedController
     subscription.user = current_user
     subscription.save
 
-    redirect_back fallback_location: project_path(current_project), notice: 'Subscribed!'
+    redirect_back fallback_location: params[:fallback_path], notice: 'Subscribed!'
   end
 
   def destroy
@@ -17,7 +17,7 @@ class SubscriptionsController < AuthenticatedController
     )
     subscription.destroy
 
-    redirect_back fallback_location: project_path(current_project), notice: 'Unsubscribed!'
+    redirect_back fallback_location: params[:fallback_path], notice: 'Unsubscribed!'
   end
 
   private

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,6 +1,4 @@
 class SubscriptionsController < AuthenticatedController
-  include ProjectScoped
-
   def create
     subscription = Subscription.new(subscription_params)
     subscription.user = current_user

--- a/app/views/subscriptions/_actions.html.erb
+++ b/app/views/subscriptions/_actions.html.erb
@@ -1,13 +1,12 @@
 <% css_class = local_assigns[:dots_menu] ? 'dropdown-item' : '' %>
 
 <%= link_to \
-      project_subscription_path(
-        current_project,
-        0, # not really used
+      subscription_path(
         subscription: {
           subscribable_type: subscribable.class.to_s,
           subscribable_id: subscribable.id
-        }
+        },
+        fallback_path: request.path
       ),
       class: "d-none #{css_class}",
       data: {'behavior': 'unsubscribe'},
@@ -15,12 +14,12 @@
     <i class="fa fa-bell-slash fa-fw"></i> Unsubscribe
 <% end %>
 <%= link_to \
-      project_subscriptions_path(
-        current_project,
+      subscriptions_path(
         subscription: {
           subscribable_type: subscribable.class.to_s,
           subscribable_id: subscribable.id
-        }
+        },
+        fallback_path: request.path
       ),
       class: "d-none #{css_class}",
       data: {'behavior': 'subscribe'},

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,8 +94,6 @@ Rails.application.routes.draw do
       member { post :recover }
     end
 
-    resources :subscriptions, only: [:create, :destroy]
-
     get 'search' => 'search#index'
     get 'trash' => 'revisions#trash'
 
@@ -126,6 +124,8 @@ Rails.application.routes.draw do
       post :source
     end
   end
+
+  resources :subscriptions, only: [:create, :destroy]
 
   # -------------------------------------------------------------- Static pages
   resource :markup, controller: :markup, only: [] do


### PR DESCRIPTION
### Summary
This PR moves subscriptions_controller outside from the projects namespace.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
