### PR TITLE
Backport changes from pro

### DIFF
--- a/app/controllers/concerns/notified.rb
+++ b/app/controllers/concerns/notified.rb
@@ -1,12 +1,13 @@
 module Notified
   protected
 
-  def broadcast_notifications(action:, actor:, notifiable:)
+  def broadcast_notifications(action:, actor:, notifiable:, data: {})
     NotificationsBroadcastJob.perform_later(
       action: action.to_s,
       actor_id: actor.id,
       notifiable_id: notifiable.id,
       notifiable_type: notifiable.class.to_s,
+      data: data
     )
   end
 end

--- a/app/jobs/notifications_broadcast_job.rb
+++ b/app/jobs/notifications_broadcast_job.rb
@@ -1,10 +1,11 @@
 class NotificationsBroadcastJob < ApplicationJob
   queue_as :dradis_project
 
-  def perform(action:, actor_id:, notifiable_id:, notifiable_type:)
+  def perform(action:, actor_id:, notifiable_id:, notifiable_type:, data: {})
     notifiable = notifiable_type.constantize.find_by(id: notifiable_id)
+
     if notifiable.respond_to?(:notify)
-      notifiable.notify(action, User.find(actor_id))
+      notifiable.notify(action: action, actor: User.find(actor_id), data: data)
 
       notifiable.notifications.each do |notification|
         NotificationsChannel.broadcast_to(notification.recipient, {})

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -36,7 +36,7 @@ class Comment < ApplicationRecord
     Subscription.subscribe(user: user, to: commentable) if user
   end
 
-  def notify(action, actor)
+  def notify(action:, actor:, data: {})
     case action.to_s
     when 'create'
       subscribe_mentioned()

--- a/spec/jobs/notifications_broadcast_job_spec.rb
+++ b/spec/jobs/notifications_broadcast_job_spec.rb
@@ -19,7 +19,8 @@ describe NotificationsBroadcastJob do #, type: :job do
         action: 'create',
         actor_id: notifiable.user.id,
         notifiable_id: notifiable.id,
-        notifiable_type: notifiable.class.to_s
+        notifiable_type: notifiable.class.to_s,
+        data: {}
       )
     end
   end


### PR DESCRIPTION
Pre-requisite: https://github.com/dradis/dradis-ce/pull/789

This PR is a backport from Pro. It adds another parameter, `data: {}`, to the `notify` method of notifiables.