### PR TITLE
Implement #to_xml for Board, List, Card, Comment, and Activity

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -48,4 +48,10 @@ class Activity < ApplicationRecord
     self.trackable_type = "Issue" if new_trackable.is_a?(Issue)
     new_trackable
   end
+
+  def to_xml(xml_builder, version: 3)
+    xml_builder.action(action)
+    xml_builder.user_email(user.email)
+    xml_builder.created_at(created_at.to_i)
+  end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -43,6 +43,18 @@ class Board < ApplicationRecord
     list
   end
 
+  def to_xml(xml_builder, includes: [], version: 3)
+    xml_builder.board(version: version) do |board_builder|
+      board_builder.id(id)
+      board_builder.name(name)
+      board_builder.node_id(node_id)
+
+      ordered_items.each do |list|
+        list.to_xml(xml_builder, includes: includes)
+      end
+    end
+  end
+
   private
 
   def validate_node_has_no_other_board

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -48,6 +48,42 @@ class Card < ApplicationRecord
     super(ids)
   end
 
+  def to_xml(xml_builder, includes: [], version: 3)
+    xml_builder.card do |card_builder|
+      card_builder.id(id)
+      card_builder.name(name)
+      card_builder.description do
+        card_builder.cdata!(description)
+      end
+      card_builder.due_date(due_date)
+      card_builder.previous_id(previous_id)
+
+      if includes.include?(:assignees)
+        card_builder.assignees do |assignee_builder|
+          assignees.each do |assignee|
+            assignee_builder.assignee(assignee.email)
+          end
+        end
+      end
+
+      if includes.include?(:activities)
+        card_builder.activities do |activity_builder|
+          activities.each do |activity|
+            activity.to_xml(activity_builder)
+          end
+        end
+      end
+
+      if includes.include?(:comments)
+        card_builder.comments do |comment_builder|
+          comments.each do |comment|
+            comment.to_xml(comment_builder)
+          end
+        end
+      end
+    end
+  end
+
   private
   def local_fields
     {

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -28,6 +28,17 @@ class List < ApplicationRecord
     board.lists.find_by(previous_id: id)
   end
 
+  def to_xml(xml_builder, includes: [], version: 3)
+    xml_builder.list do |list_builder|
+      list_builder.id(id)
+      list_builder.name(name)
+      list_builder.previous_id(previous_id)
+
+      ordered_items.each do |card|
+        card.to_xml(list_builder, includes: includes)
+      end
+    end
+  end
 
   private
   def adjust_link


### PR DESCRIPTION
### Summary

Put the responsibility of knowing how to turn each of this classes into an XML representation on themselves (instead of on the Template Exporter of dradis/dradis-plugins.


### Check List

- [x] Added a CHANGELOG entry

Skipped, this is an internal refactor, not really user-facing.