### PR TITLE
Integrated engines - use framework's version

### DIFF
--- a/engines/dradis-api/dradis-api.gemspec
+++ b/engines/dradis-api/dradis-api.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
   gem.license       = 'GPL-2'
 
-  gem.authors       = ['Daniel Martin']
-  gem.email         = ['etd@nomejortu.com.com>']
+  gem.authors       = ['Dradis Team']
+  gem.email         = ['>moc.stoorytiruces@liame<'.reverse]
   gem.description   = 'REST HTTP API for Dradis Framework'
   gem.summary       = 'Dradis HTTP API'
   gem.homepage      = 'http://dradisframework.org'

--- a/engines/dradis-api/lib/dradis/ce/api/gem_version.rb
+++ b/engines/dradis-api/lib/dradis/ce/api/gem_version.rb
@@ -1,19 +1,12 @@
+require_relative '../../../../../../lib/dradis/ce/version'
+
 module Dradis
   module CE
     module API
       # Returns the version of the currently loaded Dradis::CE::API as a
       # <tt>Gem::Version</tt>.
       def self.gem_version
-        Gem::Version.new VERSION::STRING
-      end
-
-      module VERSION
-        MAJOR = 0
-        MINOR = 0
-        TINY = 1
-        PRE = nil
-
-        STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+        Gem::Version.new Dradis::CE::VERSION::STRING
       end
     end
   end


### PR DESCRIPTION
### Summary

Before this PR, integrated engines kept a separate version string (which unfortunately was never updated).

This PR makes integrated engine's use the same version string as the framework they're integrated into.

### Check List

- [ ] Added a CHANGELOG entry

Skipped as internal refactor.