### PR TITLE
Render subscriptions via fetch instead of rendering inline.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 v3.22.0 (MMM’21)
-  * Asynchronously load the comments feed
-  * Asynchronously load the subscriptions feed
+  * Asynchronously load the comments and subscription feeds
   * Improve accessibility:
     - Add alt text to any linked images
     - Add screen reader only text to forms

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v3.22.0 (MMM’21)
   * Asynchronously load the comments feed
+  * Asynchronously load the subscriptions feed
   * Improve accessibility:
     - Add alt text to any linked images
     - Add screen reader only text to forms

--- a/app/assets/javascripts/shared/behaviors.js
+++ b/app/assets/javascripts/shared/behaviors.js
@@ -15,6 +15,7 @@
     });
 
     new Comments;
+    new Subscriptions;
 
     $parent.find('[data-behavior~=fetch]').each(async function() {
       var element = this;

--- a/app/assets/javascripts/shared/subscriptions.js
+++ b/app/assets/javascripts/shared/subscriptions.js
@@ -1,0 +1,17 @@
+class Subscriptions {
+  constructor() {
+    this.init();
+  }
+
+  init() {
+    if ($('[data-behavior~=subscription-actions]').length) {
+      var subscribed = $('[data-behavior~=subscription-actions]').data('subscribed');
+
+      if (subscribed) {
+        $('[data-behavior=unsubscribe]').removeClass('d-none');
+      } else {
+        $('[data-behavior=subscribe]').removeClass('d-none');
+      }
+    }
+  }
+}

--- a/app/assets/javascripts/shared/subscriptions.js.coffee
+++ b/app/assets/javascripts/shared/subscriptions.js.coffee
@@ -1,8 +1,0 @@
-document.addEventListener "turbolinks:load", ->
-
-  if $('[data-behavior~=subscription-actions]').length
-    subscribed = $('[data-behavior~=subscription-actions]').data('subscribed')
-    if subscribed
-      $('[data-behavior=unsubscribe]').removeClass('d-none')
-    else
-      $('[data-behavior=subscribe]').removeClass('d-none')

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -14,7 +14,6 @@ class CardsController < AuthenticatedController
 
   def show
     @activities   = @card.activities.latest
-    @subscription = @card.subscription_for(user: current_user)
     render layout: !request.xhr?
   end
 

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -13,7 +13,6 @@ class EvidenceController < NestedNodeResourceController
   def show
     @activities   = @evidence.activities.latest
     @issue        = @evidence.issue
-    @subscription = @evidence.subscription_for(user: current_user)
 
     load_conflicting_revisions(@evidence)
   end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -34,7 +34,6 @@ class IssuesController < AuthenticatedController
     @first_evidence  = Evidence.where(node: @first_node, issue: @issue)
 
     load_conflicting_revisions(@issue)
-    @subscription = @issue.subscription_for(user: current_user)
   end
 
   def new

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -34,7 +34,6 @@ class NotesController < NestedNodeResourceController
   # Retrieve a Note given its :id
   def show
     @activities = @note.activities.latest
-    @subscription = @note.subscription_for(user: current_user)
     load_conflicting_revisions(@note)
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -31,10 +31,7 @@ class SubscriptionsController < AuthenticatedController
     @subscribable ||= begin
       case params[:action]
       when 'index', 'create', 'destroy'
-        Subscription.new(
-          subscribable_id: subscription_params[:subscribable_id],
-          subscribable_type: subscription_params[:subscribable_type]
-        ).subscribable
+        Subscription.new(subscription_params).subscribable
       else
         raise 'Invalid action'
       end

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -105,7 +105,9 @@
         </div>
 
         <div class="content-container ml-xxl-3">
-          <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @card.class, subscribable_id: @card.id) %>"></div>
+          <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @card.class, subscribable_id: @card.id) %>">
+            <%= render 'shared/fetch_loader' %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -45,7 +45,7 @@
     <div class="col-12 col-xxl-7 p-0">
       <div class="content-container mt-0 mr-xxl-3">
         <div class="tab-content mt-0">
-          <div class="tab-pane active" id="info-tab" data-behavior="subscription-actions" data-subscribed="<%= !@subscription.nil? %>">
+          <div class="tab-pane active" id="info-tab">
             <% cache ['card-information-tab', @card] do %>
               <div class="note-text-inner">
                 <h4 class="mb-4 header-underline"><%= @card.name %></h4>
@@ -103,7 +103,7 @@
         </div>
 
         <div class="content-container ml-xxl-3">
-          <%= render 'subscriptions/feed', subscribable: @card %>
+          <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @card.class, subscribable_id: @card.id) %>"></div>
         </div>
       </div>
     </div>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -49,7 +49,7 @@
   <div class="col-12 col-xxl-7 p-0">
     <div class="content-container mt-0 pb-3 mr-xxl-3">
       <div class="tab-content mt-0">
-        <div class="tab-pane active" id="evidence-tab" data-behavior="subscription-actions" data-subscribed="<%= !@subscription.nil? %>">
+        <div class="tab-pane active" id="evidence-tab">
           <% cache ['evidence-evidence-tab', @evidence] do %>
             <div class="note-text-inner">
               <h4 class="header-underline">Evidence for this instance</h4>
@@ -112,7 +112,7 @@
       </div>
 
       <div class="content-container ml-xxl-3">
-        <%= render 'subscriptions/feed', subscribable: @evidence %>
+        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @evidence.class, subscribable_id: @evidence.id) %>"></div>
       </div>
     </div>
   </div>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -114,7 +114,9 @@
       </div>
 
       <div class="content-container ml-xxl-3">
-        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @evidence.class, subscribable_id: @evidence.id) %>"></div>
+        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @evidence.class, subscribable_id: @evidence.id) %>">
+          <%= render 'shared/fetch_loader' %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -46,7 +46,7 @@
   <div class="col-12 col-xxl-7 p-0">
     <div class="content-container mt-0 pb-3 mr-xxl-3">
       <div class="tab-content mt-0">
-        <div class="tab-pane active" id="info-tab" data-behavior="subscription-actions" data-subscribed="<%= !@subscription.nil? %>" >
+        <div class="tab-pane active" id="info-tab">
           <% cache ['issue-information-tab', @issue] do %>
             <div class="note-text-inner">
               <h4 class="mb-4 header-underline">Issue information -
@@ -86,7 +86,7 @@
       </div>
 
       <div class="content-container ml-xxl-3">
-        <%= render 'subscriptions/feed', subscribable: @issue %>
+        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @issue.class, subscribable_id: @issue.id) %>"></div>
       </div>
     </div>
   </div>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -88,7 +88,9 @@
       </div>
 
       <div class="content-container ml-xxl-3">
-        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @issue.class, subscribable_id: @issue.id) %>"></div>
+        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @issue.class, subscribable_id: @issue.id) %>">
+          <%= render 'shared/fetch_loader' %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -39,7 +39,7 @@
   <div class="col-12 col-xxl-7 p-0">
     <div class="content-container mt-0 pb-3 mr-xxl-3">
       <div class="tab-content mt-0">
-        <div class="tab-pane active" id="info-tab" data-behavior="subscription-actions" data-subscribed="<%= !@subscription.nil? %>">
+        <div class="tab-pane active" id="info-tab">
           <% cache ['note-information-tab', @note] do %>
             <div id="<%= dom_id(@note) %>" class="note-text-inner">
               <h4 class="header-underline">Content for this note</h4>
@@ -84,7 +84,7 @@
       </div>
 
       <div class="content-container ml-xxl-3">
-        <%= render 'subscriptions/feed', subscribable: @note %>
+        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @note.class, subscribable_id: @note.id) %>"></div>
       </div>
     </div>
   </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -86,7 +86,9 @@
       </div>
 
       <div class="content-container ml-xxl-3">
-        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @note.class, subscribable_id: @note.id) %>"></div>
+        <div class="fetch-container" data-behavior="fetch" data-path="<%= main_app.subscriptions_path(subscribable_type: @note.class, subscribable_id: @note.id) %>">
+          <%= render 'shared/fetch_loader' %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/subscriptions/_actions.html.erb
+++ b/app/views/subscriptions/_actions.html.erb
@@ -2,6 +2,7 @@
 
 <%= link_to \
       main_app.subscription_path(
+        subscribable,
         subscription: {
           subscribable_type: subscribable.class.to_s,
           subscribable_id: subscribable.id

--- a/app/views/subscriptions/_feed.html.erb
+++ b/app/views/subscriptions/_feed.html.erb
@@ -1,15 +1,15 @@
-<% cache ['subscriptions-feed', subscribable.subscriptions] do %>
+<% cache ['subscriptions-feed', subscriptions] do %>
   <h4 class="d-flex header-underline">
     Subscribers
     <span class="badge bg-primary text-white mx-2">
-      <%= subscribable.subscriptions.count %>
+      <%= subscriptions.count %>
     </span>
-    <span class="actions pt-1">
-      - <%= render 'subscriptions/actions', subscribable: subscribable %>
+    <span class="actions pt-1" data-behavior="subscription-actions" data-subscribed="<%= !current_user_subscription.nil? %>">
+      - <%= render 'subscriptions/actions' %>
     </span>
   </h4>
   <div class="subscriptions-feed">
-    <% subscribable.subscriptions.each do |subscription| %>
+    <% subscriptions.each do |subscription| %>
       <%= avatar_image(subscription.user, size: 40) %>
     <% end %>
   </div>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -1,0 +1,1 @@
+<%= render 'subscriptions/feed' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :subscriptions, only: [:create, :destroy]
+  resources :subscriptions, only: [:index, :create, :destroy]
 
   # -------------------------------------------------------------- Static pages
   resource :markup, controller: :markup, only: [] do

--- a/spec/features/card_pages/polling_spec.rb
+++ b/spec/features/card_pages/polling_spec.rb
@@ -173,7 +173,12 @@ describe 'card pages', js: true do
   after { PaperTrail.enabled = false }
 
   describe 'when I am viewing a card' do
-    before { visit project_board_list_card_path(current_project, @board, @list, @card) }
+    before do
+      visit project_board_list_card_path(current_project, @board, @list, @card)
+      # Wait for ajax
+      find('.fetch-container > .subscriptions-feed')
+      find('.comment-feed > .comment-list')
+    end
     let(:action) { :show }
     it_behaves_like 'a card page with poller'
   end

--- a/spec/features/comment_pages/polling_spec.rb
+++ b/spec/features/comment_pages/polling_spec.rb
@@ -66,6 +66,7 @@ describe 'comment pages', js: true do
       visit project_issue_path(@project, @commentable)
 
       # Wait for ajax
+      find('.fetch-container > .subscriptions-feed')
       find('.comment-feed > .comment-list')
     end
 

--- a/spec/features/evidence_pages/polling_spec.rb
+++ b/spec/features/evidence_pages/polling_spec.rb
@@ -57,7 +57,13 @@ describe "evidence pages", js: true do
   end
 
   describe "when I am viewing an Evidence" do
-    before { visit project_node_evidence_path(current_project, @node, @evidence) }
+    before do
+      visit project_node_evidence_path(current_project, @node, @evidence)
+
+      # Wait for ajax
+      find('.fetch-container > .subscriptions-feed')
+      find('.comment-feed > .comment-list')
+    end
     it_behaves_like "an evidence page with poller"
   end
 

--- a/spec/features/note_pages/polling_spec.rb
+++ b/spec/features/note_pages/polling_spec.rb
@@ -58,7 +58,13 @@ describe "note pages", js: true do
   end
 
   describe "when I am viewing a Note" do
-    before { visit project_node_note_path(current_project, @node, @note) }
+    before do
+      visit project_node_note_path(current_project, @node, @note)
+
+      # Wait for ajax
+      find('.fetch-container > .subscriptions-feed')
+      find('.comment-feed > .comment-list')
+    end
     it_behaves_like "a note page with poller"
   end
 


### PR DESCRIPTION
### Prerequisite 
**Do not merge until the following is merged**
https://github.com/dradis/dradis-ce/pull/803

### Summary
This PR loads subscriptions via fetch instead of inline.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
