### PR TITLE
Prevent concurrent assets compilations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libv8 (8.4.255.0)
+    libv8 (8.4.255.0-x86_64-darwin-19)
+    libv8 (8.4.255.0-x86_64-linux)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -526,6 +528,8 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   RedCloth (~> 4.3.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,9 @@ module Dradis
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.assets.configure do |env|
+      env.export_concurrent = false
+    end
   end
 end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,10 +57,6 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  config.assets.configure do |env|
-    env.export_concurrent = false
-  end
-
   config.assets.precompile += %w( tylium/test.css tylium/test.js )
 
   # Raises error for missing translations.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,6 +57,10 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  config.assets.configure do |env|
+    env.export_concurrent = false
+  end
+
   config.assets.precompile += %w( tylium/test.css tylium/test.js )
 
   # Raises error for missing translations.


### PR DESCRIPTION
### Summary

CE suffered from two separate issues:

- sassc Segfaulting sometimes when utilizing concurrent building.
- libv8 failing to build in the CI environment. libv8 offer pre-compiled binaries but we need to specify the supported versions in the Gemfile for them to be utilized, as of Bundler 2.2.x.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] ~Added a CHANGELOG entry~
