### PR TITLE
Kit setup args

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ v3.22.0 (MMM’21)
     - Adjustments to font and element contrast to meet at minimum Level AA WCAG 2.0 standards.
     - Fix any broken Aria references
     - Update element label association & add missing labels
+  * Kit upload CLI command update
   * Replace deprecated font-awesome-sass gem with vendor asset files
   * Subscriptions
     - Load feed asynchronously

--- a/lib/tasks/thor/setup.rb
+++ b/lib/tasks/thor/setup.rb
@@ -62,9 +62,9 @@ class DradisTasks < Thor
 
     desc 'kit', 'Import files and projects from a specified Kit configuration file'
     method_option :file, required: true, type: :string, desc: 'full path to the Kit file to use.'
-    def kit(file)
+    def kit
       puts "** Importing kit..."
-      KitImportJob.perform_now(file: file, logger: default_logger)
+      KitImportJob.perform_now(file: options[:file], logger: default_logger)
       puts "[  DONE  ]"
     end
 


### PR DESCRIPTION
### Summary

We meshed two different styles of setup arguments which resulted in neither working.

unnamed cli args get passed in as method arguments, where named args get passed in with an options block.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
