### PR TITLE
Convert SSH git remotes to HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'html-pipeline'
 
 gem 'kaminari', '~> 1.2.1'
 
-gem 'paper_trail', git: 'git@github.com:paper-trail-gem/paper_trail.git', ref: '1e56afd'
+gem 'paper_trail', git: 'https://github.com/paper-trail-gem/paper_trail.git', ref: '1e56afd'
 
 # gem 'rails_autolink', '~> 1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:paper-trail-gem/paper_trail.git
+  remote: https://github.com/paper-trail-gem/paper_trail.git
   revision: 1e56afdf846b3e6c338ff4fcd13a95334810b4d8
   ref: 1e56afd
   specs:


### PR DESCRIPTION
### Summary

This PR fixes an issue with git remotes being referenced via SSH rather than HTTPS. Using SSH breaks unattended installs (i.e. docker) of Dradis due to host key verification and the dependency of a private key.


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Convert SSH git remotes to HTTPS
