### PR TITLE
Revert node_id fix for boards from methodology library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -213,7 +213,8 @@ gem 'dradis-plugins', '~>3.22'
 gem 'dradis-api', path: 'engines/dradis-api'
 
 # Import / export project data
-gem 'dradis-projects', '~>3.22'
+# gem 'dradis-projects', '~>3.22'
+gem 'dradis-projects', git: 'git@github.com:dradis/dradis-projects.git', branch: 'fix/assign-correct-methodology-libary-to-boards'
 
 plugins_file = 'Gemfile.plugins'
 if File.exists?(plugins_file)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git@github.com:dradis/dradis-projects.git
+  revision: cad2540b4897470accba15e1fff980d321752cae
+  branch: fix/assign-correct-methodology-libary-to-boards
+  specs:
+    dradis-projects (3.22.0)
+      dradis-plugins (~> 3.7)
+      rubyzip
+
+GIT
   remote: git@github.com:paper-trail-gem/paper_trail.git
   revision: 1e56afdf846b3e6c338ff4fcd13a95334810b4d8
   ref: 1e56afd
@@ -124,9 +133,6 @@ GEM
     diff-lcs (1.4.4)
     differ (0.1.2)
     dradis-plugins (3.22.0)
-    dradis-projects (3.22.0)
-      dradis-plugins (~> 3.7)
-      rubyzip
     erubi (1.10.0)
     execjs (2.7.0)
     factory_bot (5.1.1)
@@ -477,7 +483,7 @@ DEPENDENCIES
   differ (~> 0.1.2)
   dradis-api!
   dradis-plugins (~> 3.22)
-  dradis-projects (~> 3.22)
+  dradis-projects!
   factory_bot_rails
   foreman
   guard-rspec

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -44,12 +44,10 @@ class Board < ApplicationRecord
   end
 
   def to_xml(xml_builder, includes: [], version: 3)
-    xml_node_id = node == project.methodology_library ? nil : node_id
-
     xml_builder.board(version: version) do |board_builder|
       board_builder.id(id)
       board_builder.name(name)
-      board_builder.node_id(xml_node_id)
+      board_builder.node_id(node_id)
 
       ordered_items.each do |list|
         list.to_xml(xml_builder, includes: includes)

--- a/spec/features/export/v3/template_spec.rb
+++ b/spec/features/export/v3/template_spec.rb
@@ -25,8 +25,8 @@ describe 'Pro export template' do
     end
 
     it 'creates the project board xml' do
-      project_board_xml = "<board version=\"3\"><id>#{@project_board.id}</id>"\
-      "<name>#{@project_board.name}</name><node_id/></board>"
+      project_board_xml = "<board version=\"3\">\<id>#{@project_board.id}</id>"\
+      "<name>#{@project_board.name}</name><node_id>#{@project.methodology_library.id}</node_id></board>"
 
       expect(@result).to include(project_board_xml)
     end
@@ -40,3 +40,4 @@ describe 'Pro export template' do
     end
   end
 end
+


### PR DESCRIPTION
### Summary
This PR revert the fix when importing board from methodology library.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
