### PR TITLE
update tooltips to use aria-tooltip

### DIFF
--- a/app/assets/javascripts/shared/editor_toolbar.js
+++ b/app/assets/javascripts/shared/editor_toolbar.js
@@ -236,44 +236,44 @@ class EditorToolbar {
   textareaElements(include) {
     var str = '';
 
-    if (include.includes('field')) str += '<div class="editor-btn" data-btn="field" aria-label="add new field">\
+    if (include.includes('field')) str += '<div class="editor-btn" data-btn="field" aria-tooltip="add new field">\
       <i class="fa fa-plus"></i>\
     </div>\
     <div class="divider-vertical"></div>';
 
-    if (include.includes('bold')) str += '<div class="editor-btn" data-btn="bold" aria-label="bold text">\
+    if (include.includes('bold')) str += '<div class="editor-btn" data-btn="bold" aria-tooltip="bold text">\
       <i class="fa fa-bold"></i>\
     </div>';
 
-    if (include.includes('italic')) str += '<div class="editor-btn px-2" data-btn="italic" aria-label="italic text">\
+    if (include.includes('italic')) str += '<div class="editor-btn px-2" data-btn="italic" aria-tooltip="italic text">\
       <i class="fa fa-italic"></i>\
     </div>';
 
     str += '<div class="divider-vertical"></div>';
 
-    if (include.includes('block-code')) str += '<div class="editor-btn" data-btn="block-code" aria-label="code block">\
+    if (include.includes('block-code')) str += '<div class="editor-btn" data-btn="block-code" aria-tooltip="code block">\
       <i class="fa fa-code"></i>\
     </div>';
 
-    if (include.includes('link')) str += '<div class="editor-btn" data-btn="link" aria-label="link">\
+    if (include.includes('link')) str += '<div class="editor-btn" data-btn="link" aria-tooltip="link">\
       <i class="fa fa-link"></i>\
     </div>';
-    if (include.includes('table')) str += '<div class="editor-btn" data-btn="table" aria-label="table">\
+    if (include.includes('table')) str += '<div class="editor-btn" data-btn="table" aria-tooltip="table">\
       <i class="fa fa-table"></i>\
     </div>';
 
     str += '<div class="divider-vertical"></div>';
 
-    if (include.includes('list-ul')) str += '<div class="editor-btn" data-btn="list-ul" aria-label="unordered list">\
+    if (include.includes('list-ul')) str += '<div class="editor-btn" data-btn="list-ul" aria-tooltip="unordered list">\
       <i class="fa fa-list-ul"></i>\
     </div>';
-    if (include.includes('list-ol')) str += '<div class="editor-btn" data-btn="list-ol" aria-label="ordered list">\
+    if (include.includes('list-ol')) str += '<div class="editor-btn" data-btn="list-ol" aria-tooltip="ordered list">\
       <i class="fa fa-list-ol"></i>\
     </div>';
 
     str += '<div class="divider-vertical"></div>';
 
-    if (include.includes('image')) str += '<div class="editor-btn image-btn" data-btn="image" aria-label="image">\
+    if (include.includes('image')) str += '<div class="editor-btn image-btn" data-btn="image" aria-tooltip="image">\
       <i class="fa fa-picture-o"></i>\
     </div>';
 

--- a/app/assets/stylesheets/tylium/modules.scss
+++ b/app/assets/stylesheets/tylium/modules.scss
@@ -19,7 +19,7 @@
 @import "tylium/modules/uploads";
 @import "tylium/modules/versions";
 
-[aria-label] {
+[aria-tooltip] {
   position: relative;
 
   &:after {
@@ -27,7 +27,7 @@
     border-radius: 5px;
     box-shadow: 1px 2px 6px rgba(0,0,0,0.5);
     color: $white;
-    content: attr(aria-label);
+    content: attr(aria-tooltip);
     font-size: .7em;
     line-height: 15px;
     opacity: 0;

--- a/app/views/styles_tylium/index.html.erb
+++ b/app/views/styles_tylium/index.html.erb
@@ -413,19 +413,19 @@
     <div class="content-container">
       <div class="scroll-offset" id="tooltips"></div>
       <div class="style-header">
-        <h4 class="header-underline">Tooltips using aria-labels</h4>
+        <h4 class="header-underline">Tooltips using aria-tooltips</h4>
         <button class="reveal-code" data-toggle="collapse" data-target="#tooltips-code"><i class="fa fa-code"></i><label class="sr-only">Toggle code</label></button>
       </div>
       <div class="style-example">
-        <p>Hover over the below button to see a tooltip using the aria-label attribute. We use aria-labels as tooltips as they are easily customizable and do not require any kind of plugin's or 3rd party code to function. This example uses a button element but this can be used on almost any kind of element.</p>
+        <p>Hover over the below button to see a tooltip using the aria-tooltip attribute. We use aria-tooltips as tooltips as they are easily customizable and do not require any kind of plugin's or 3rd party code to function. This example uses a button element but this can be used on almost any kind of element.</p>
         <div class="w-100 d-flex justify-content-center">
-          <button class="btn btn-primary" aria-label="Tooltip text using aria-label">Hover Me!</button>
+          <button class="btn btn-primary" aria-tooltip="Tooltip text using aria-tooltip">Hover Me!</button>
         </div>
       </div>
       
       <div class="style-code-wrapper collapse" id="tooltips-code">
         <pre class="style-code">
-<code><span class="et">&lt;button</span><span class="an"> class=</span><span class="av">"btn btn-primary"</span><span class="an"> aria-label=</span><span class="av">"Tooltip text using aria-labels"</span><span class="et">></span>Hover Me!<span class="et">&lt;/button></span></code>
+<code><span class="et">&lt;button</span><span class="an"> class=</span><span class="av">"btn btn-primary"</span><span class="an"> aria-tooltip=</span><span class="av">"Tooltip text using aria-tooltips"</span><span class="et">></span>Hover Me!<span class="et">&lt;/button></span></code>
         </pre>
       </div>
     </div>
@@ -493,7 +493,7 @@
         <a href="#scroll" class="nav-link">Scroll-For-More Indicator</a>
         <a href="#tables" class="nav-link">Tables</a>
         <a href="#input" class="nav-link">Text Input with Inset Button</a>
-        <a href="#tooltips" class="nav-link">Tooltips Using Aria-Labels</a>
+        <a href="#tooltips" class="nav-link">Tooltips Using Aria-Tooltips</a>
         <a href="#typography" class="nav-link">Typography</a>
       </nav>
 


### PR DESCRIPTION
### Summary

There is a conflict with using `aria-label` as tooltips as DataTables is also using `aria-label`. This PR moves tooltips to aria-tooltip.

### Check List

~- [ ] Added a CHANGELOG entry~
