### PR TITLE
Use default-columns instead of hide-on-load

### DIFF
--- a/app/assets/javascripts/shared/dradis_datatable.js
+++ b/app/assets/javascripts/shared/dradis_datatable.js
@@ -1,10 +1,11 @@
 class DradisDatatable {
   constructor(tableElement) {
     this.$table = $(tableElement);
-    this.dataTable = null;
-    this.tableHeaders = Array.from(this.$table[0].querySelectorAll('thead th'));
     this.$paths = this.$table.closest('[data-behavior~=datatable-paths]');
+    this.dataTable = null;
+    this.defaultColumns = this.$table.data('default-columns') || [];
     this.itemName = this.$table.data('item-name');
+    this.tableHeaders = Array.from(this.$table[0].querySelectorAll('thead th'));
     this.init();
   }
 
@@ -76,7 +77,7 @@ class DradisDatatable {
   }
 
   behaviors() {
-    this.hideColumns();
+    this.setupDefaultColumns();
 
     this.setupCheckboxListeners();
 
@@ -203,17 +204,6 @@ class DradisDatatable {
     setTimeout(ConsoleUpdater.updateConsole, 1000);
   }
 
-  hideColumns() {
-    // Hide columns that has data-hide-on-load="true" on page load
-    var that = this;
-    that.tableHeaders.forEach(function(column, index) {
-      if (column.dataset.hideOnLoad == 'true') {
-        var dataTableColumn = that.dataTable.column(index);
-        dataTableColumn.visible(false);
-      }
-    });
-  }
-
   rowIds(rows) {
     var ids = rows.ids().toArray().map(function(id) {
       // The dom id for <tr> is in the following format: <tr id="item_name-id"></tr>,
@@ -261,6 +251,24 @@ class DradisDatatable {
     }
   }
 
+  setupDefaultColumns() {
+    // Show all columns if defaultColumns not provided
+    if (this.defaultColumns.length === 0) {
+      return;
+    }
+
+    var defaultColumns = this.defaultColumns.concat(['Select', 'Actions']);
+    var that = this;
+
+    that.tableHeaders.forEach(function(column, index) {
+      var columnName = column.textContent.trim();
+
+      if (!defaultColumns.includes(columnName)) {
+        var dataTableColumn = that.dataTable.column(index);
+        dataTableColumn.visible(false);
+      }
+    });
+  }
 
   ///////////////////// Checkbox /////////////////////
 

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -1,12 +1,12 @@
 <% cache ['issues-table', @columns, issues.map(&:id), @issues.map(&:updated_at).map(&:to_i).sort.last] do %>
-    <table class="table table-striped mb-0" data-behavior="dradis-datatable" data-item-name="issue">
+    <table class="table table-striped mb-0"
+      data-behavior="dradis-datatable" data-item-name="issue"
+      data-default-columns='["Title", "Created", "Updated"]'>
       <thead>
         <tr>
           <th class="hide-sort" data-column-visible="false"><span class="sr-only">Select</span></th>
           <% @columns.each do |column| %>
-            <th data-hide-on-load="<%= ['Title', 'Created', 'Updated'].exclude?(column) %>">
-              <%= column %>
-            </th>
+            <th><%= column %></th>
           <% end %>
           <th class="hide-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
         </tr>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -1,13 +1,14 @@
 <% cache ["#{dom_class(items.first).pluralize}-table", columns, items.map(&:id), items.map(&:updated_at).map(&:to_i).sort.last] do %>
   <div class="table-wrapper">
-    <table class="table table-striped" data-behavior="dradis-datatable" data-item-name="<%= items.first.class.name.underscore %>">
+    <table class="table table-striped"
+      data-behavior="dradis-datatable"
+      data-item-name="<%= items.first.class.name.underscore %>"
+      data-default-columns='["Title", "Created", "Updated"]'>
       <thead>
         <tr>
           <th class="hide-sort" data-column-visible="false"><span class="sr-only">Select</span></th>
           <% columns.each do |column| %>
-            <th data-hide-on-load="<%= ['Title', 'Created', 'Updated'].exclude?(column) %>">
-              <%= column %>
-            </th>
+            <th><%= column %></th>
           <% end %>
           <th class="hide-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
         </tr>


### PR DESCRIPTION
### Summary
Use `default-columns` instead of populating `hide-on-load` for each column.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
