### PR TITLE
Datatables cleanup

### DIFF
--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -1,5 +1,4 @@
 .dataTables_wrapper {
-  overflow: hidden;
 
   .dataTable {
     margin-top: 0 !important;

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -16,7 +16,7 @@
       }
     }
 
-    .hide-sort {
+    .no-sort {
       pointer-events: none;
 
       &.sorting {

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -20,9 +20,11 @@
     .hide-sort {
       pointer-events: none;
 
-      &:after,
-      &:before {
-        display: none;
+      &.sorting {
+        &:after,
+        &:before {
+          display: none;
+        }
       }
     }
 
@@ -104,27 +106,32 @@
           clip-path: inset(0px 0px -20px -1px);
         }
 
-        &:not(.sorting_disabled) {
-          padding: 0.75rem 0.75rem 0.75rem 1.75rem;
-        }
+        &.sorting {
+          &::after {
+            content: '\f0dc';
+            display: inline-block;
+            font-family: 'FontAwesome';
+            margin-left: 0.5rem;
+            opacity: 0;
+            position: static;
+          }
 
-        &.sorting{
-          &::after,
-          &::before{
-            top: calc(50% - 0.55rem);
+          &:before {
+            display: none;
+          }
 
-            // Firefox //
-            @-moz-document url-prefix() {
-              top: calc(50% - 0.8rem);
+          &.sorting_asc {
+            &::after {
+              content: '\f0d8';
+              opacity: 1;
             }
           }
 
-          &::after {
-            left: 1rem;
-          }
-
-          &::before {
-            left: 0.5rem;
+          &.sorting_desc {
+            &::after {
+              content: '\f0d7';
+              opacity: 1;
+            }
           }
         }
       }

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -7,11 +7,11 @@
       data-tags=<%= @tags.map { |t| [t.display_name, t.color, t.name] }.to_json %>>
       <thead>
         <tr>
-          <th class="hide-sort" data-column-visible="false"><span class="sr-only">Select</span></th>
+          <th class="no-sort" data-column-visible="false"><span class="sr-only">Select</span></th>
           <% @columns.each do |column| %>
             <th><%= column %></th>
           <% end %>
-          <th class="hide-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
+          <th class="no-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -7,11 +7,11 @@
       data-local-storage-key="project.ce.<%= items.first.class.name.underscore.pluralize %>_datatable">
       <thead>
         <tr>
-          <th class="hide-sort" data-column-visible="false"><span class="sr-only">Select</span></th>
+          <th class="no-sort" data-column-visible="false"><span class="sr-only">Select</span></th>
           <% columns.each do |column| %>
             <th><%= column %></th>
           <% end %>
-          <th class="hide-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
+          <th class="no-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/revisions/trash.html.erb
+++ b/app/views/revisions/trash.html.erb
@@ -13,7 +13,7 @@
               <th>Item</th>
               <th>Removed by</th>
               <th>When</th>
-              <th class="hide-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
+              <th class="no-sort" data-column-visible="false"><span class="sr-only">Actions</span></th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
### Summary

Post-merge CSS changes

- Bug Fix: Column selection menu now completely visible on short tables with many columns
- Sorting icons appear directly after the column header text and only on the column that is currently being sorted

### Check List

~- [ ] Added a CHANGELOG entry~
