### PR TITLE
Fix DataTable tag spaces

### DIFF
--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -4,7 +4,7 @@
       data-default-columns='["Title", "Created", "Updated"]'
       data-item-name="issue"
       data-local-storage-key="project.ce.issues_datatable"
-      data-tags=<%= @tags.map { |t| [t.display_name, t.color, t.name] }.to_json %>>
+      data-tags='<%= @tags.map { |t| [t.display_name, t.color, t.name] }.to_json %>'>
       <thead>
         <tr>
           <th class="no-sort" data-column-visible="false"><span class="sr-only">Select</span></th>


### PR DESCRIPTION
### Spec
The DataTable is borked when a project has a tag with a space in the name. The JSON is set as a data attribute directly and it mishandles the data when whitespaces exist.

**Proposed solution**
Use single quotes for the data attribute so it treats the JSON as a string.

### How to test
1. Add a tag with a space in a project.
2. Visit the issues#index
3. Confirm the table works.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
