### PR TITLE
Use legacy columns as default columns for datatables

### DIFF
--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -6,10 +6,16 @@ class DradisDatatable {
     this.dataTable = null;
     this.itemName = this.$table.data('item-name');
     this.localStorageKey = this.$table.data('local-storage-key');
+    this.legacyStorageKey = this.$table.data('legacy-storage-key');
     this.tableHeaders = Array.from(this.$table[0].querySelectorAll('thead th'));
 
-    var defaultColumns = this.$table.data('default-columns') || [];
-    this.defaultColumns = defaultColumns.concat(['Select', 'Actions']);
+    if (localStorage.getItem(this.legacyStorageKey) !== null) {
+      this.defaultColumns = localStorage.getItem(this.legacyStorageKey);
+    }
+    else {
+      var defaultColumns = this.$table.data('default-columns') || [];
+      this.defaultColumns = defaultColumns.concat(['select', 'actions']);
+    }
 
     this.init();
   }
@@ -31,7 +37,7 @@ class DradisDatatable {
       this.tableHeaders.forEach(function(column, index) {
         var columnName = column.textContent.trim();
 
-        if (!that.defaultColumns.includes(columnName)) {
+        if (!that.defaultColumns.includes(columnName.toLowerCase())) {
           hiddenColumnIndexes.push(index);
         }
       });

--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -10,12 +10,12 @@ class DradisDatatable {
     this.tableHeaders = Array.from(this.$table[0].querySelectorAll('thead th'));
 
     if (localStorage.getItem(this.legacyStorageKey) !== null) {
-      this.defaultColumns = localStorage.getItem(this.legacyStorageKey);
+      var defaultColumns = localStorage.getItem(this.legacyStorageKey);
     }
     else {
       var defaultColumns = this.$table.data('default-columns') || [];
-      this.defaultColumns = defaultColumns.concat(['select', 'actions']);
     }
+    this.defaultColumns = defaultColumns.concat(['select', 'actions']);
 
     this.init();
   }

--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -10,7 +10,7 @@ class DradisDatatable {
     this.tableHeaders = Array.from(this.$table[0].querySelectorAll('thead th'));
 
     if (localStorage.getItem(this.legacyStorageKey) !== null) {
-      var defaultColumns = localStorage.getItem(this.legacyStorageKey);
+      var defaultColumns = JSON.parse(localStorage.getItem(this.legacyStorageKey));
     }
     else {
       var defaultColumns = this.$table.data('default-columns') || [];

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -1,9 +1,10 @@
 <% cache ['issues-table', @columns, issues.map(&:id), @issues.map(&:updated_at).map(&:to_i).sort.last] do %>
     <table class="table table-striped mb-0"
       data-behavior="dradis-datatable"
-      data-default-columns='["Title", "Created", "Updated"]'
+      data-default-columns='["title", "created", "updated"]'
       data-item-name="issue"
       data-local-storage-key="project.ce.issues_datatable"
+      data-legacy-storage-key="project.ce.issue_columns"
       data-tags='<%= @tags.map { |t| [t.display_name, t.color, t.name] }.to_json %>'>
       <thead>
         <tr>

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -3,7 +3,7 @@
       data-behavior="dradis-datatable"
       data-default-columns='["title", "created", "updated"]'
       data-item-name="issue"
-      data-local-storage-key="project.ce.issues_datatable"
+      data-local-storage-key="project.ce.<%= dom_id(current_project) %>.issues_datatable"
       data-legacy-storage-key="project.ce.issue_columns"
       data-tags='<%= @tags.map { |t| [t.display_name, t.color, t.name] }.to_json %>'>
       <thead>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -4,7 +4,7 @@
       data-behavior="dradis-datatable"
       data-default-columns='["title", "created", "updated"]'
       data-item-name="<%= items.first.class.name.underscore %>"
-      data-local-storage-key="project.ce.<%= items.first.class.name.underscore.pluralize %>_datatable"
+      data-local-storage-key="project.ce.<%= dom_id(current_project) %>.<%= items.first.class.name.underscore.pluralize %>_datatable"
       data-legacy-storage-key="project.ce.<%= dom_id(@node) %>.<%= items.first.class.name.underscore %>_columns"
       >
       <thead>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -2,9 +2,11 @@
   <div class="table-wrapper">
     <table class="table table-striped"
       data-behavior="dradis-datatable"
-      data-default-columns='["Title", "Created", "Updated"]'
+      data-default-columns='["title", "created", "updated"]'
       data-item-name="<%= items.first.class.name.underscore %>"
-      data-local-storage-key="project.ce.<%= items.first.class.name.underscore.pluralize %>_datatable">
+      data-local-storage-key="project.ce.<%= items.first.class.name.underscore.pluralize %>_datatable"
+      data-legacy-storage-key="project.ce.<%= dom_id(@node) %>.<%= items.first.class.name.underscore %>_columns"
+      >
       <thead>
         <tr>
           <th class="no-sort" data-column-visible="false"><span class="sr-only">Select</span></th>

--- a/app/views/revisions/trash.html.erb
+++ b/app/views/revisions/trash.html.erb
@@ -7,7 +7,7 @@
         <table class="table table-striped"
           data-behavior="dradis-datatable"
           data-default-columns='["item", "removed by", "when"]'
-          data-local-storage-key="project.ce.revisions_datatable">
+          data-local-storage-key="project.ce.<%= dom_id(current_project) %>.revisions_datatable">
           <thead>
             <tr>
               <th>Item</th>

--- a/app/views/revisions/trash.html.erb
+++ b/app/views/revisions/trash.html.erb
@@ -6,7 +6,7 @@
       <div class="table-wrapper">
         <table class="table table-striped"
           data-behavior="dradis-datatable"
-          data-default-columns='["Item", "Removed by", "When"]'
+          data-default-columns='["item", "removed by", "when"]'
           data-local-storage-key="project.ce.revisions_datatable">
           <thead>
             <tr>


### PR DESCRIPTION
### Spec
The column configuration from before the datatables are not respected for the datatable views.

**Proposed solution**
Hard-code the legacy storage keys and check them if it exists. If so, use the legacy columns as the default columns.

### How to test
Take note of the following legacy keys for each table:
Issues - project.ce.issue_columns
Evidence - project.ce.node_<node_id>.evidence_columns
Notes - project.ce.node_<node_id>.note_columns

1. Visit a datatable view that you want to test. For example, the 'All Issues' page.
2. Open the console in your browser (default key is F12)
3. In the javascript console tab, clear the existing local storage cache:
```
localStorage.clear();
```
4. Save a sample legacy column config:
```
localStorage.setItem('<old legacy key>', ['title'])
```
For example, if you're testing the Issue table:
```
localStorage.setItem('project.ce.issue_columns', ['title'])
```
5. Refresh the page
6. Confirm that the legacy column config is shown. In the example, only the title column is selected.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
