### PR TITLE
Scope the datatable storage keys under a project

### DIFF
--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -3,7 +3,7 @@
       data-behavior="dradis-datatable"
       data-default-columns='["Title", "Created", "Updated"]'
       data-item-name="issue"
-      data-local-storage-key="project.ce.issues_datatable"
+      data-local-storage-key="project.ce.<%= dom_id(current_project) %>.issues_datatable"
       data-tags='<%= @tags.map { |t| [t.display_name, t.color, t.name] }.to_json %>'>
       <thead>
         <tr>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -4,7 +4,7 @@
       data-behavior="dradis-datatable"
       data-default-columns='["Title", "Created", "Updated"]'
       data-item-name="<%= items.first.class.name.underscore %>"
-      data-local-storage-key="project.ce.<%= items.first.class.name.underscore.pluralize %>_datatable">
+      data-local-storage-key="project.ce.<%= dom_id(current_project) %>.<%= items.first.class.name.underscore.pluralize %>_datatable">
       <thead>
         <tr>
           <th class="no-sort" data-column-visible="false"><span class="sr-only">Select</span></th>

--- a/app/views/revisions/trash.html.erb
+++ b/app/views/revisions/trash.html.erb
@@ -7,7 +7,7 @@
         <table class="table table-striped"
           data-behavior="dradis-datatable"
           data-default-columns='["Item", "Removed by", "When"]'
-          data-local-storage-key="project.ce.revisions_datatable">
+          data-local-storage-key="project.ce.<%= dom_id(current_project) %>.revisions_datatable">
           <thead>
             <tr>
               <th>Item</th>


### PR DESCRIPTION
### Summary

Update the datatable storage keys with the project scope to prevent the cache from sharing in different projects.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
