### PR TITLE
Add FieldsDrop

### DIFF
--- a/app/drops/evidence_drop.rb
+++ b/app/drops/evidence_drop.rb
@@ -1,3 +1,11 @@
 class EvidenceDrop < BaseDrop
-  delegate :content, to: :@record
+  delegate :content, :title, to: :@record
+
+  def fields
+    @fields ||= FieldsDrop.new(@record.fields)
+  end
+
+  def issue
+    IssueDrop.new(@record.issue)
+  end
 end

--- a/app/drops/fields_drop.rb
+++ b/app/drops/fields_drop.rb
@@ -1,0 +1,17 @@
+class FieldsDrop < ::Liquid::Drop
+  def initialize(fields)
+    @fields = fields
+
+    define_drop_methods
+  end
+
+  private
+
+  def define_drop_methods
+    @fields.each do |key, value|
+      method_name = key.parameterize(separator: '_')
+      define_singleton_method(method_name) { value }
+      self.class.invokable_methods << method_name
+    end
+  end
+end

--- a/app/drops/issue_drop.rb
+++ b/app/drops/issue_drop.rb
@@ -1,8 +1,16 @@
 class IssueDrop < BaseDrop
-  delegate :evidence, :text, :title, to: :@record
+  delegate :text, :title, to: :@record
 
   def affected
     @affected ||= @record.affected.map { |node| NodeDrop.new(node) }
+  end
+
+  def fields
+    @fields ||= FieldsDrop.new(@record.fields)
+  end
+
+  def evidence
+    @record.evidence.map { |evidence| EvidenceDrop.new(evidence) }
   end
 
   def tags

--- a/app/drops/node_drop.rb
+++ b/app/drops/node_drop.rb
@@ -4,4 +4,8 @@ class NodeDrop < BaseDrop
   def evidence
     @evidence ||= @record.evidence.map { |evidence| EvidenceDrop.new(evidence) }
   end
+
+  def notes
+    @notes ||= @record.notes.map { |note| NoteDrop.new(note) }
+  end
 end

--- a/app/drops/note_drop.rb
+++ b/app/drops/note_drop.rb
@@ -1,3 +1,7 @@
 class NoteDrop < BaseDrop
   delegate :text, :title, to: :@record
+
+  def fields
+    @fields ||= FieldsDrop.new(@record.fields)
+  end
 end

--- a/spec/drops/fields_drop_spec.rb
+++ b/spec/drops/fields_drop_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe FieldsDrop do
+  subject { described_class.new(@params) }
+
+  it 'returns the record\'s fields' do
+    issue = create(:issue, text: "#[Title]#\nIssue #1\n\n#[CVSS]#\n4.5\n\n")
+    @params = issue.fields
+
+    expect(subject.title).to eq('Issue #1')
+    expect(subject.cvss).to eq('4.5')
+  end
+
+  it 'returns a record\'s fields with spaces and dot in name' do
+    issue = create(:issue, text: "#[CVSS.BaseScore]#\n4.5\n\n#[Field Space]#\ntest\n\n")
+    @params = issue.fields
+
+    expect(subject.cvss_basescore).to eq('4.5')
+    expect(subject.field_space).to eq('test')
+  end
+
+  it 'throws an error if the field is missing' do
+    issue = create(:issue, text: "#[Title]#\nIssue #1\n\n")
+    @params = issue.fields
+
+    expect{ subject.missing_field }.to raise_error(NoMethodError)
+  end
+
+  it 'returns the fields in the drop' do
+    issue = create(:issue, text: "#[Title]#\nIssue #1\n\n#[CVSS]#\n4.5\n\n")
+    drop = IssueDrop.new(issue)
+
+    expect(drop.fields.title).to eq('Issue #1')
+    expect(drop.fields.cvss).to eq('4.5')
+  end
+end


### PR DESCRIPTION
### Spec
Currently, the specific fields for Issues, Notes, Evidence, ContentBlocks are not available in the liquid templates.

This is important since existing GW templates are using the following syntax:
```
issue.fields['CVSS']
```

**Proposed solution**
Add a FieldsDrop that return the specific fields using the dot notation:
```
issue.fields.cvss
```

For spaces and dots (.) in the field name, they are converted to underscore and the field name is downcased. For example, given a field CVSS.BaseScore the resulting method call in liquid will be:
```
issue.fields.cvss_basescore
```

### How to test
_Setup:_
1. Use the branch `liquid-fields` for both Pro and `liquid-report-content` for Gateway. Then install Gateway by adding it to your Gemfile and pointing to the relative directory:
```
gem 'dradispro-gateway', path: '../dradispro-clientside'
```
2. If you haven't yet, run the following commands to install the necessary Gateway DB tables:
```
$ bin/rails dradis_pro_plugins_gateway:install:migrations
$ bin/rails db:migrate
```
3. Create a `themes` directory under your `dradis-pro` directory, if it doesn't exist.

_Testing steps:_
1. Create a project and upload the following project data:
2. Edit the project and enable it in gateway.
3. Upload the following theme:
4. In Gateway, associate the project with the uploaded theme.
5. Open the project in gateway and confirm that the fields appear as expected for all item types.



### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
