### PR TITLE
Liquid fields

### DIFF
--- a/app/drops/evidence_drop.rb
+++ b/app/drops/evidence_drop.rb
@@ -1,3 +1,7 @@
 class EvidenceDrop < BaseDrop
-  delegate :content, to: :@record
+  delegate :content, :fields, :title, to: :@record
+
+  def issue
+    IssueDrop.new(@record.issue)
+  end
 end

--- a/app/drops/issue_drop.rb
+++ b/app/drops/issue_drop.rb
@@ -1,8 +1,12 @@
 class IssueDrop < BaseDrop
-  delegate :evidence, :text, :title, to: :@record
+  delegate :fields, :text, :title, to: :@record
 
   def affected
     @affected ||= @record.affected.map { |node| NodeDrop.new(node) }
+  end
+
+  def evidence
+    @record.evidence.map { |evidence| EvidenceDrop.new(evidence) }
   end
 
   def tags

--- a/app/drops/note_drop.rb
+++ b/app/drops/note_drop.rb
@@ -1,3 +1,3 @@
 class NoteDrop < BaseDrop
-  delegate :text, :title, to: :@record
+  delegate :fields, :text, :title, to: :@record
 end


### PR DESCRIPTION
### Spec
Currently, the specific fields for Issues, Notes, Evidence, ContentBlocks are not available in the liquid templates.

This is important since existing GW templates are using the following syntax:
```
issue.fields['CVSS']
```

**Proposed solution**
Delegate the fields method to make it accessible in liquid:
```
{{ issue.fields['CVSS.BaseScore'] }}
```

### How to test
_Setup:_
1. Use the branch `liquid-fields` for both Pro and `liquid-report-content` for Gateway. Then install Gateway by adding it to your Gemfile and pointing to the relative directory:
```
gem 'dradispro-gateway', path: '../dradispro-clientside'
```
2. If you haven't yet, run the following commands to install the necessary Gateway DB tables:
```
$ bin/rails dradis_pro_plugins_gateway:install:migrations
$ bin/rails db:migrate
```
3. Create a `themes` directory under your `dradis-pro` directory, if it doesn't exist.

_Testing steps:_
1. Create a project and upload the following project data:
2. Edit the project and enable it in gateway.
3. Upload the following theme:
4. In Gateway, associate the project with the uploaded theme.
5. Open the project in gateway and confirm that the fields appear as expected for all item types.




### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
