### PR TITLE
Add attachment.exists? to check if attachment exists in file system

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -80,6 +80,12 @@ class Attachment < File
     find(:all).count
   end
 
+  def self.exists?(filename:, node_id:)
+    find(filename, conditions: { node_id: node_id } )
+  rescue StandardError => e
+    false
+  end
+
   # Return the attachment instance(s) based on the find parameters
   def self.find(*args)
     options = args.extract_options!


### PR DESCRIPTION
### Summary
This PR adds a helper method to check if an attachment exists since the current `Attachment.find` will raise an error if it isn't found in the file system.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
