### PR TITLE
Fix template directory 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 [v#.#.#] ([month] [YYYY])
   - [entity]:
     - [future tense verb] [feature]
-  - Upgraded gems: 
+  - Upgraded gems:
     - [gem]
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - Initial configuration
+      - Correctly reference the templates directory on initialization
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -2,7 +2,12 @@
 # Each Configuration object has a :name and a :value. Some configuration
 # parameters can be accessed through the helper methods provided in this class.
 class Configuration < ApplicationRecord
-  TEMPLATES_DIR = Pathname.new File.readlink(Rails.root.join('templates'))
+  TEMPLATES_DIR =
+    if File.exists?(Rails.root.join('templates'))
+      Pathname.new File.readlink(Rails.root.join('templates'))
+    else
+      ''
+    end
 
   # -- Relationships --------------------------------------------------------
 

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -3,11 +3,10 @@
 # parameters can be accessed through the helper methods provided in this class.
 class Configuration < ApplicationRecord
   TEMPLATES_DIR =
-    if File.exists?(Rails.root.join('templates'))
-      Pathname.new File.readlink(Rails.root.join('templates'))
-    else
-      ''
-    end
+    Pathname.new(
+      File.exists?(Rails.root.join('templates')) ?
+        File.readlink(Rails.root.join('templates')) : ''
+    )
 
   # -- Relationships --------------------------------------------------------
 

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -2,6 +2,8 @@
 # Each Configuration object has a :name and a :value. Some configuration
 # parameters can be accessed through the helper methods provided in this class.
 class Configuration < ApplicationRecord
+  TEMPLATES_DIR = Pathname.new File.readlink(Rails.root.join('templates'))
+
   # -- Relationships --------------------------------------------------------
 
   # -- Callbacks ------------------------------------------------------------
@@ -42,27 +44,27 @@ class Configuration < ApplicationRecord
 
   # --------------------------------------------------------------- admin:paths
   def self.paths_templates_methodologies
-    create_with(value: Rails.root.join('../../shared/templates/methodologies/').to_s)
+    create_with(value: TEMPLATES_DIR.join('methodologies').to_s)
       .find_or_create_by(name: 'admin:paths:templates:methodologies').value
   end
 
   def self.paths_templates_notes
-    create_with(value: Rails.root.join('../../shared/templates/notes/').to_s)
+    create_with(value: TEMPLATES_DIR.join('notes').to_s)
       .find_or_create_by(name: 'admin:paths:templates:notes').value
   end
 
   def self.paths_templates_plugins
-    create_with(value: Rails.root.join('templates', 'plugins').to_s)
+    create_with(value: TEMPLATES_DIR.join('plugins').to_s)
       .find_or_create_by(name: 'admin:paths:templates:plugins').value
   end
 
   def self.paths_templates_projects
-    create_with(value: Rails.root.join('../../shared/templates/projects/').to_s)
+    create_with(value: TEMPLATES_DIR.join('projects').to_s)
       .find_or_create_by(name: 'admin:paths:templates:projects').value
   end
 
   def self.paths_templates_reports
-    create_with(value: Rails.root.join('templates', 'reports'))
+    create_with(value: TEMPLATES_DIR.join('reports').to_s)
       .find_or_create_by(name: 'admin:paths:templates:reports').value
   end
 

--- a/bin/setup
+++ b/bin/setup
@@ -38,6 +38,9 @@ FileUtils.chdir APP_ROOT do
   end
 
   puts "\n== Preparing database =="
+  File.symlink '../../shared/templates', 'templates'
+
+  puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'
 
   puts "\n== Loading some sample content =="

--- a/db/migrate/20120903184931_settings_add_project_and_methodology_paths.rb.rb
+++ b/db/migrate/20120903184931_settings_add_project_and_methodology_paths.rb.rb
@@ -3,7 +3,7 @@
 
 class SettingsAddProjectAndMethodologyPaths < ActiveRecord::Migration[5.1]
   def up
-    new_value = Rails.root.join('templates', 'projects').to_s
+    new_value = Configuration::TEMPLATES_DIR.join('project')
 
     # If there was an old setting, honor it.
     if (old_setting = Configuration.find_by_name('admin:paths:methodologies'))


### PR DESCRIPTION
### Spec
Currently, the projects template directory location is using the current release directory in production. This configuration isn't migratable since the path it's using is absolute.

For example:
```
Configuration.find_by(name: 'admin:paths:templates:projects').value
```

returns
```
/opt/dradispro/dradispro/releases/202104120746/templates/projects/
```

If the instance is migrated into a different VM, the project template persists as the above. The directory /opt/dradispro/dradispro/releases/202104120746/ wouldn't exist in this new VM, causing issues.

**Proposed solution**
Use File.readlink to traverse the symlink instead.

### How to test
Since this change only works for new instances, we need to simulate testing a new instance by cloning the repository and setting it up.

1. Clone the repository:
```
g clone --branch fix-template-directory-2 git@github.com:dradis/dradis-ce.git
```
2. Setup this new instance with:
```
bin/setup
```
3. Check the initial configuration using the following commands:
```
$ rails console
> Configuration.find_by(name: 'admin:paths:templates:projects').value
```
4. Confirm that it returns the path to the "shared/templates" directory. In contrast, without the fix, it returns the path to "dradis-ce/templates".


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
