### PR TITLE
Limit textile-inner height

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 [v#.#.#] ([month] [YYYY])
-  - [entity]:
-    - [future tense verb] [feature]
+  - Editor:
+    - Limit the content height for easier access to the Create/Update button.
   - Upgraded gems:
     - rails
   - Bugs fixes:

--- a/app/assets/javascripts/shared/editor_toolbar.js
+++ b/app/assets/javascripts/shared/editor_toolbar.js
@@ -71,11 +71,9 @@ class EditorToolbar {
       }
     });
 
-    // Handler for setting the correct textarea height on keyboard input, when
-    // focus is lost, or when content is inserted programmatically
-    // Handler for setting the correct textarea height when focus is lost, or
-    // when content is inserted programmatically
-    this.$target.on('blur textchange input', this.setHeight);
+    // Handler for setting the correct textarea height on keyboard input, on focus,
+    // when focus is lost, or when content is inserted programmatically
+    this.$target.on('blur focus textchange input', this.setHeight);
 
     // Handler for setting the correct textarea heights on load (for current values)
     this.$target.each(this.setHeight);
@@ -115,12 +113,13 @@ class EditorToolbar {
       var $inputElement = $(this),
           $toolbarElement = $inputElement.parent().prev(),
           $parentElement = $inputElement.parents('[data-behavior~=editor-field]'),
+          $scrollLimitElement = $parentElement.parents('.textile-wrap').parent(),
           topOffset;
       
       $toolbarElement.css({'opacity': 1, 'visibility': 'visible'});
 
       // set offset to 0 if user is in fullscreen mode.
-      if ($inputElement.parents('.textile-fullscreen').length ? topOffset = 0 : topOffset = 106); // 106 = navbar height + breadcrumb height
+      if ($inputElement.parents('.textile-fullscreen').length ? topOffset = 0 : topOffset = $parentElement.find('.editor-toolbar').outerHeight());
 
       // this is needed incase user sets focus on textarea where toolbar would render off screen
       if ($inputElement.height() > 40 && $parentElement.offset().top < $(window).scrollTop() + topOffset) {
@@ -128,11 +127,11 @@ class EditorToolbar {
       }
 
       // adjust position on scroll to make toolbar always appear at the top of the textarea
-      document.querySelector('[data-behavior~=view-content], .textile-fullscreen').addEventListener('scroll', (function () {
+      document.querySelector('.textile-wrap, .textile-fullscreen').addEventListener('scroll', (function () {
         var parentOffsetTop = $parentElement.offset().top - topOffset;
 
         // keep toolbar at the top of text area when scrolling
-        if ($inputElement.height() > 40 && parentOffsetTop < $(window).scrollTop()) {
+        if ($inputElement.height() > 40 && parentOffsetTop < $scrollLimitElement.offset().top - 10) {
           $parentElement.addClass('sticky-toolbar');
         } else {
           // reset the toolbar to the default position and appearance

--- a/app/assets/stylesheets/shared/editor_toolbar.scss
+++ b/app/assets/stylesheets/shared/editor_toolbar.scss
@@ -13,7 +13,7 @@
     padding: 0.25rem;
     position: absolute;
     right: 0;
-    top: -3.3rem;
+    top: -3rem;
     transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
     visibility: hidden;
     z-index: 999;
@@ -25,7 +25,7 @@
       height: 0;
       left: 20%;
       position: absolute;
-      top: 2.45rem;
+      top: 2.25rem;
       width: 0;
     }
 
@@ -36,7 +36,7 @@
       height: 0;
       left: 20%;
       position: absolute;
-      top: 2.5rem;
+      top: 2.35rem;
       width: 0;
     }
 
@@ -48,11 +48,11 @@
       color: $defaultText;
       cursor: pointer;
       display: flex;
-      height: 2rem;
+      height: 1.75rem;
       justify-content: center;
       padding: 0.5rem;
       transition: all 0.2s ease-in-out;
-      width: 2rem;
+      width: 1.75rem;
 
       &.disabled {
         pointer-events: none;
@@ -99,7 +99,7 @@
       margin: 0 1px;
       position: sticky;
       text-align: center;
-      top: 47px; // breadcrumb height
+      top: 0;
 
       &:after,
       &:before {
@@ -114,6 +114,10 @@
         margin-top: -42px !important;
       }
     }
+  }
+
+  & > .textarea-container > textarea {
+    min-height: 100%;
   }
 
   .textarea-container {

--- a/app/assets/stylesheets/shared/textile.scss
+++ b/app/assets/stylesheets/shared/textile.scss
@@ -162,8 +162,11 @@
   }
 
   .textile-inner {
-    padding: 0;
     background: transparent;
+    max-height: calc(100vh - 28rem);
+    overflow: auto;
+    padding: 0;
+    
 
     .textile-form {
 

--- a/app/assets/stylesheets/shared/textile.scss
+++ b/app/assets/stylesheets/shared/textile.scss
@@ -123,10 +123,14 @@
 
 .textile-wrap {
   background-color: #fff;
+  max-height: calc(100vh - 28rem);
+  overflow-x: hidden;
+  overflow-y: auto;
   word-break: break-word;
 
   &.textile-fullscreen {
     font-size: 0.9rem;
+    max-height: 100vh;
     padding-top: 0;
     overflow: auto;
 
@@ -163,8 +167,6 @@
 
   .textile-inner {
     background: transparent;
-    max-height: calc(100vh - 28rem);
-    overflow: auto;
     padding: 0;
     
 

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -14,7 +14,7 @@
   <%=
     f.input :description,
       input_html: {
-        class: 'textile h-100',
+        class: 'textile',
         data: {
           allow_dropdown: @card.new_record?,
           behavior: 'rich-toolbar drop-zone',

--- a/app/views/evidence/_form.html.erb
+++ b/app/views/evidence/_form.html.erb
@@ -16,7 +16,7 @@
       f.input :content,
       label: false,
       input_html: {
-        class: 'textile h-100',
+        class: 'textile',
         data: {
           allow_dropdown: @evidence.new_record?,
           behavior: 'auto-save rich-toolbar drop-zone',

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -13,7 +13,7 @@
     f.input :text,
       label: false,
       input_html: {
-        class: 'textile h-100',
+        class: 'textile',
         data: {
           allow_dropdown: @issue.new_record?,
           behavior: 'auto-save rich-toolbar drop-zone',

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -13,7 +13,7 @@
     f.input :text,
       label: false,
       input_html: {
-        class: 'textile h-100',
+        class: 'textile',
         data: {
           allow_dropdown: @note.new_record?,
           behavior: 'auto-save rich-toolbar drop-zone',

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -83,7 +83,7 @@ describe 'Issues pages' do
             click_link 'Source'
 
             # Manually update the textarea, otherwise we will get a timeout
-            execute_script("$('#issue_text').val('#{'a' * 65536}')")
+            execute_script("$('#issue_text').val('#{'a' * 65536}').trigger('textchange');")
           end
 
           it "doesn't create a new Issue" do
@@ -202,7 +202,7 @@ describe 'Issues pages' do
         context 'submitting the form with invalid information' do
           before do
             # Manually update the textarea, otherwise we will get a timeout
-            execute_script("$('#issue_text').val('#{'a' * 65536}')")
+            execute_script("$('#issue_text').val('#{'a' * 65536}').trigger('textchange');")
           end
 
           it "doesn't update the issue" do

--- a/vendor/assets/javascripts/jquery.textile.js
+++ b/vendor/assets/javascripts/jquery.textile.js
@@ -331,6 +331,7 @@
       this.options.$help.hide();
       this.options.$preview.show();
       this.$source.show();
+      this.$source.find('textarea').focus();
     },
 
     // --------------------------------------------------- Other event handlers


### PR DESCRIPTION
### Summary

Allow the editor content to scroll within the content container so that form's submit button is easily accessible.

### Check List

- [x] Added a CHANGELOG entry
