### PR TITLE
use the default note category automatically

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
     - Limit the content height for easier access to the Create/Update button.
   - Evidence:
     - Create a new issue (optionally) when creating new evidence
+  - Notes:
+    - Use the 'Default category' by default
   - Upgraded gems:
     - nokogiri, rails
   - Bugs fixes:

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -13,7 +13,7 @@ class NotesController < NestedNodeResourceController
   before_action :set_auto_save_key, only: [:new, :create, :edit, :update]
 
   def new
-    @note = @node.notes.new
+    @note = @node.notes.new(category: Category.default)
 
     # See ContentFromTemplate concern
     @note.text = template_content if params[:template]
@@ -40,6 +40,7 @@ class NotesController < NestedNodeResourceController
 
   def edit
     @versions_count = @note.versions.count
+    @note.category ||= Category.default
   end
 
   # Update the attributes of a Note

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -22,7 +22,6 @@ class NotesController < NestedNodeResourceController
   # Create a new Note for the associated Node.
   def create
     @note.author = current_user.email
-    @note.category ||= Category.default
 
     if @note.save
       track_created(@note)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -56,6 +56,8 @@ class Note < ApplicationRecord
     Subscription.where(subscribable_type: 'Issue', subscribable_id: id).destroy_all
   end
 
+  after_initialize :set_category
+
   # -- Validations ----------------------------------------------------------
   validates :category, presence: true
   validates :node, presence: true
@@ -73,5 +75,9 @@ class Note < ApplicationRecord
 
   def field_or_text(field_name)
     fields.fetch(field_name, text.truncate(20))
+  end
+
+  def set_category
+    self.category ||= Category.default
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -56,8 +56,6 @@ class Note < ApplicationRecord
     Subscription.where(subscribable_type: 'Issue', subscribable_id: id).destroy_all
   end
 
-  after_initialize :set_category
-
   # -- Validations ----------------------------------------------------------
   validates :category, presence: true
   validates :node, presence: true
@@ -75,9 +73,5 @@ class Note < ApplicationRecord
 
   def field_or_text(field_name)
     fields.fetch(field_name, text.truncate(20))
-  end
-
-  def set_category
-    self.category ||= Category.default
   end
 end

--- a/spec/support/local_auto_save_shared_examples.rb
+++ b/spec/support/local_auto_save_shared_examples.rb
@@ -95,7 +95,7 @@ shared_examples 'a form with local auto save' do |klass, action|
         elsif klass == Issue
           expect(page).to have_css('.dropdown-toggle span.tag', text: 'No tag')
         elsif klass == Note
-          expect(page).to have_select('note_category_id', selected: 'Assign note category')
+          expect(page).to have_select('note_category_id', selected: 'Default category')
         end
       end
 


### PR DESCRIPTION
### Summary

Use the `Default category` for notes by default

### Check List

- [x] Added a CHANGELOG entry
