### PR TITLE
Datatables versioned localstorage keys

### DIFF
--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -5,7 +5,7 @@ class DradisDatatable {
 
     this.dataTable = null;
     this.itemName = this.$table.data('item-name');
-    this.localStorageKey = this.$table.data('local-storage-key');
+    this.localStorageKey = this.versionedLocalStorageKey(this.$table.data('local-storage-key'));
     this.tableHeaders = Array.from(this.$table[0].querySelectorAll('thead th'));
 
     var defaultColumns = this.$table.data('default-columns') || [];
@@ -304,5 +304,26 @@ class DradisDatatable {
 
     localStorageData.columns = newColumns;
     return localStorageData;
+  }
+
+  versionedLocalStorageKey(localStorageKey) {
+    if (!localStorageKey) {
+      return;
+    }
+
+    // V2 was introduced as a result of a fix to persist user's DataTable state
+    // (see https://github.com/dradis/dradis-ce/pull/901).
+    //
+    // It adds table headers on the page to localStorage data so that
+    // when the page loads, it uses these table headers to identify if columns
+    // on the page are existing or new.
+    //
+    // But users with existing localStorage data will not have these table headers
+    // saved because it was only added in the same patch.
+    //
+    // So this is where versionedLocalStorageKey comes in. It indirectly resets
+    // the DataTable to use default columns and prevents the need for a localStorage
+    // migration.
+    return `${localStorageKey}.v2`;
   }
 }

--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -1,4 +1,21 @@
 class DradisDatatable {
+  static get LocalStorageKeyVersion() {
+    // V2 was introduced as a result of a fix to persist user's DataTable state
+    // (see https://github.com/dradis/dradis-ce/pull/901).
+    //
+    // It adds table headers on the page to localStorage data so that
+    // when the page loads, it uses these table headers to identify if columns
+    // on the page are existing or new.
+    //
+    // But users with existing localStorage data will not have these table headers
+    // saved because it was only added in the same patch.
+    //
+    // So this is where versionedLocalStorageKey comes in. It indirectly resets
+    // the DataTable to use default columns and prevents the need for a localStorage
+    // migration.
+    return 'v2';
+  }
+
   constructor(tableElement) {
     this.$table = $(tableElement);
     this.$paths = this.$table.closest('[data-behavior~=datatable-paths]');
@@ -311,19 +328,6 @@ class DradisDatatable {
       return;
     }
 
-    // V2 was introduced as a result of a fix to persist user's DataTable state
-    // (see https://github.com/dradis/dradis-ce/pull/901).
-    //
-    // It adds table headers on the page to localStorage data so that
-    // when the page loads, it uses these table headers to identify if columns
-    // on the page are existing or new.
-    //
-    // But users with existing localStorage data will not have these table headers
-    // saved because it was only added in the same patch.
-    //
-    // So this is where versionedLocalStorageKey comes in. It indirectly resets
-    // the DataTable to use default columns and prevents the need for a localStorage
-    // migration.
-    return `${localStorageKey}.v2`;
+    return `${localStorageKey}.${DradisDatatable.LocalStorageKeyVersion}`;
   }
 }


### PR DESCRIPTION
### Summary
This PR adds a version to DataTables localStorage keys so that we can reset its localStorage data when we introduce new changes to DataTables localStorage data.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
