### PR TITLE
Check for column headers before processing

### DIFF
--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -287,6 +287,16 @@ class DradisDatatable {
   // Old columns are automatically removed, because we are iterating the columns
   // on the page, and not columns inside the saved state object.
   rebuildSavedStateColumnsFromLocalStorage(localStorageData) {
+    var containsHeader = localStorageData.columns.some(function(column) {
+      return 'header' in column;
+    })
+
+    // Return localStorageData if none of the columns contain the header property,
+    // so that we don't show a page without columns.
+    if (!containsHeader) {
+      return localStorageData;
+    }
+
     var newColumns = [];
 
     this.tableHeaders.forEach(function(th, _index) {


### PR DESCRIPTION
### Summary
This PR checks if the localStorage data contains any header key before we rebuild the localStorage data, so that users won't have their DataTables reset when migrating to v4.1.0.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
