### PR TITLE
Specs - use a fixture for shared pwd management

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
   resources :notifications, only: [:index, :update]
 
-  resources :projects, only: [:show] do
+  resources :projects, only: [:index, :show] do
     resources :activities, only: [:index] do
       collection do
         get :poll, constraints: { format: /js/ }

--- a/spec/features/activity_pages/activity_pages_spec.rb
+++ b/spec/features/activity_pages/activity_pages_spec.rb
@@ -4,7 +4,6 @@ describe 'Activity pages:' do
   subject { page }
 
   it 'should require authenticated users' do
-    Configuration.create(name: 'admin:password', value: 'rspec_pass')
     visit project_activities_path(create(:project))
     expect(current_path).to eq(login_path)
     expect(page).to have_content('Access denied.')

--- a/spec/features/attachments_spec.rb
+++ b/spec/features/attachments_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe "Describe attachments" do
   it "should require authenticated users" do
-    Configuration.create(name: 'admin:password', value: 'rspec_pass')
     node = create(:node)
     visit project_node_attachments_path(node.project, node)
 

--- a/spec/features/board_pages/board_pages_spec.rb
+++ b/spec/features/board_pages/board_pages_spec.rb
@@ -4,7 +4,6 @@ describe 'Board pages:' do
   subject { page }
 
   it 'should require authenticated users' do
-    Configuration.create(name: 'admin:password', value: 'rspec_pass')
     visit project_boards_path(create(:project))
     expect(current_path).to eq(login_path)
     expect(page).to have_content('Access denied.')

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -6,7 +6,6 @@ describe 'Card pages:' do
   it 'should require authenticated users' do
     project = create(:project)
     @board = create(:board, project: project, node: project.methodology_library)
-    Configuration.create(name: 'admin:password', value: 'rspec_pass')
     visit project_board_path(@board.project, @board)
     expect(current_path).to eq(login_path)
     expect(page).to have_content('Access denied.')

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -4,7 +4,7 @@ describe 'Issues pages' do
   subject { page }
 
   it 'should require authenticated users' do
-    visit project_issues_path(project_id: 1)
+    visit project_issues_path(create(:project))
     expect(current_path).to eq(login_path)
     expect(page).to have_content('Access denied.')
   end

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -4,7 +4,6 @@ describe 'Issues pages' do
   subject { page }
 
   it 'should require authenticated users' do
-    Configuration.create(name: 'admin:password', value: 'rspec_pass')
     visit project_issues_path(project_id: 1)
     expect(current_path).to eq(login_path)
     expect(page).to have_content('Access denied.')

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -3,13 +3,8 @@ require 'rails_helper'
 describe 'Sessions' do
   subject { page }
 
-  before do
+  let(:user) do
     create(
-      :configuration,
-      name: 'admin:password',
-      value: ::BCrypt::Password.create('rspec_pass')
-    )
-    @user = create(
       :user,
       :author,
       password_hash: ::BCrypt::Password.create('rspec_pass')
@@ -20,7 +15,7 @@ describe 'Sessions' do
 
   let(:login) do
     visit login_path
-    fill_in 'login', with: @user.email
+    fill_in 'login', with: user.email
     fill_in 'password', with: password
     click_button 'Let me in!'
   end
@@ -61,7 +56,7 @@ describe 'Sessions' do
     it 'forces a logout' do
       login
 
-      @user.destroy
+      user.destroy
       visit project_path(Project.find(1))
 
       expect(current_path).to eq(login_path)

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Sessions' do
   subject { page }
 
+  let(:password) { 'rspec_pass' }
   let(:user) do
     create(
       :user,
@@ -11,8 +12,8 @@ describe 'Sessions' do
     )
   end
 
-  let(:password) { 'rspec_pass' }
-
+  # This needs to be a helper and not a let() block, because let is memoized
+  # and reused.
   let(:login) do
     visit login_path
     fill_in 'login', with: user.email
@@ -57,7 +58,7 @@ describe 'Sessions' do
       login
 
       user.destroy
-      visit project_path(Project.find(1))
+      visit projects_path
 
       expect(current_path).to eq(login_path)
       expect(page).to have_content('Access denied')

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -14,7 +14,7 @@ describe 'Sessions' do
 
   # This needs to be a helper and not a let() block, because let is memoized
   # and reused.
-  let(:login) do
+  def login
     visit login_path
     fill_in 'login', with: user.email
     fill_in 'password', with: password

--- a/spec/fixtures/configurations.yml
+++ b/spec/fixtures/configurations.yml
@@ -1,6 +1,7 @@
-revision:
-  name: 'admin:revision'
-  value: 0
+# ::BCrypt::Password.create('rspec_pass')
+password:
+  name: 'admin:password'
+  value: $2a$10$KXgHWzfmtCULbUFYg8XRLOqQLitq6CL6xbXO2gszKbPwRUoRhy6CC
 
 plugin_templates:
   name: 'admin:paths:plugin_templates'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
 
   # config.include ControllerMacros, type: :controller
   config.include ControllerMacros, type: :feature
+  config.include ControllerMacros, type: :request
   # config.include SelecterHelper,   type: :feature
   # config.include SupportHelper,    type: :controller
   # config.include SupportHelper,    type: :feature

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 describe "upload requests" do
 
   before do
-    @project = Project.new
-    # login as admin
-    Configuration.create(name: 'admin:password', value: ::BCrypt::Password.create('rspec_pass'))
-    @user = create(:user, :admin)
-    post session_path, params: { login: @user.email, password: 'rspec_pass' }
+    login_to_project_as_user
 
     @uploads_node = @project.plugin_uploads_node
   end
@@ -50,7 +46,7 @@ describe "upload requests" do
         allow(importer).to receive(:import)
 
         expect(importer_class).to receive(:new).with(
-          hash_including(default_user_id: User.first.id)
+          hash_including(default_user_id: @logged_in_as.id)
         )
         expect(importer).to receive(:import)
 


### PR DESCRIPTION
### Summary

Instead of calling `Configuration.create(name: 'admin:password', value: 'rspec_pass')` in a bunch of specs, just extract that to a fixture.


### Check List

- [x] Added a CHANGELOG entry

More of an internal refactor than a user-facing change.
