### PR TITLE
Allow filenames with "+" to be found

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -127,7 +127,14 @@ class Attachment < File
       end
     else
       # in this routine we find the attachment by file name and node id
-      filename = CGI::unescape(args.first.to_s)
+
+      # When unescaping "+", it'll be converted to " ".
+      # To prevent that, we manually convert it to its URL encoded char (%2B) first.
+      # CGI::unescape('+') => " "
+      # CGI::unescape('%2B') => "+"
+
+      filename = args.first.to_s.gsub('+', '%2B')
+      filename = CGI::unescape(filename)
       attachments = []
       raise "You need to supply a node id in the condition parameter" unless options[:conditions] && options[:conditions][:node_id]
       node_id = options[:conditions][:node_id].to_s

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -54,6 +54,18 @@ describe Attachment do
         expect(Attachment.find('attachment%20with%20space.png', conditions: { node_id: node.id })).to be_a(Attachment)
       end
     end
+
+    context 'when passing in a filename that contains "+"' do
+      let(:attachment) do
+        attachment = Attachment.new(Rails.root.join('public', 'images', 'attachment_with_+.png'), node_id: node.id)
+        attachment.save
+        attachment
+      end
+
+      it 'returns the attachment object' do
+        expect(Attachment.find('attachment_with_+.png', conditions: { node_id: node.id })).to be_a(Attachment)
+      end
+    end
   end
 
   describe '.fullpath' do


### PR DESCRIPTION
### Summary
This PR allows attachments with `+` in its filename to be found.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
