### PR TITLE
CleanOpenVASSettings migration naming issue

### DIFF
--- a/db/migrate/20131002215400_clean_openvas_settings.rb
+++ b/db/migrate/20131002215400_clean_openvas_settings.rb
@@ -1,4 +1,4 @@
-class CleanOpenVASSettings < ActiveRecord::Migration[5.1]
+class CleanLegacyConfig < ActiveRecord::Migration[5.1]
   def up
     # This removes old settings that may exist in versions of Pro prior to v1.9
     %w{openvas:node_label}.each do |name|
@@ -10,3 +10,6 @@ class CleanOpenVASSettings < ActiveRecord::Migration[5.1]
     # we can't un-delete legacy settings
   end
 end
+
+klass_name = defined?(Dradis::Plugins::OpenVAS) ? 'CleanOpenVASSettings' : 'CleanOpenvasSettings'
+Object.const_set(klass_name, CleanLegacyConfig)


### PR DESCRIPTION
### Summary

Before this PR:

if OpenVAS is loaded (which includes the inflector), it works. if it’s not, it
fails with:

    NameError: uninitialized constant CleanOpenvasSettings
    Did you mean?  CleanOpenVASSettings

However, if you change it to`CleanOpenvasSettings`, then:

if OpenVAS is loaded, it fails.

    NameError: uninitialized constant CleanOpenVASSettings
    Did you mean?  CleanOpenvasSettings

if OpenVAS isn’t loaded, it works.


### Check List
- [x] Added a CHANGELOG entry

This is an internal refactor that isn't user-facing or requiring a CHANGELOG entry.