### PR TITLE
Setup Wizard: allow users to choose a Kit to start with

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 [v#.#.#] ([month] [YYYY])
-  - Add Setup Wizard
+  - Add Setup Wizard: set shared password and initial content.
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -1,0 +1,34 @@
+module Setup
+  class KitsController < BaseController
+    before_action :set_kit, only: :create
+
+    def new
+    end
+
+    def create
+      case @kit
+      when :none
+        ;
+      when :welcome
+        kit_file = ''
+        logger = nil
+        KitImportJob.perform_later(file: kit_file, logger: logger)
+      end
+
+      redirect_to login_path
+    end
+
+    private
+    def ensure_pristine
+      redirect_to project_path(1) unless (Evidence.count == 0) && (Issue.count == 0) && (Node.count == 0) && (Note.count == 0)
+    end
+
+    def set_kit
+      if %w{none welcome}.include?(params[:kit])
+        @kit = params[:kit].to_sym
+      else
+        render :new
+      end
+    end
+  end
+end

--- a/app/controllers/setup/passwords_controller.rb
+++ b/app/controllers/setup/passwords_controller.rb
@@ -17,7 +17,7 @@ module Setup
 
       if setting.save
         flash[:notice] = 'All done. May the findings for this project be plentiful!'
-        redirect_to login_path
+        redirect_to new_setup_kit_path
       else
         flash[:alert] = "Something went wrong: #{setting.errors.full_messages.join('; ')}"
         render :new

--- a/app/controllers/setup_required_controller.rb
+++ b/app/controllers/setup_required_controller.rb
@@ -11,6 +11,10 @@ class SetupRequiredController < ApplicationController
     if (::Configuration.shared_password == 'improvable_dradis')
       redirect_to new_setup_password_path
     end
+
+    if (Evidence.count == 0) && (Issue.count == 0) && (Node.count == 0) && (Note.count == 0)
+      redirect_to new_setup_kit_path
+    end
   end
 
   # -- Pro methods ------------------------------------------------------------

--- a/app/views/setup/kits/new.html.erb
+++ b/app/views/setup/kits/new.html.erb
@@ -1,0 +1,24 @@
+<div class="col-6 offset-3">
+  <div class="card">
+    <div class="card-header bg-custom">
+      <h5 class="m-0">Would you like some help?</h5>
+    </div>
+    <div class="card-body">
+      <p>
+        We can prefill the project with some sample data so it's easier to get
+        your head around how everything fits together.
+      </p>
+
+      <div class="row text-center">
+        <div class="col-6">
+          <%= link_to 'Yes, please', setup_kit_path(kit: :welcome), class: 'btn btn-primary', method: :post %>
+          <p>A sample project with Issues, Evidence, and Nodes will be loaded.</p>
+        </div>
+        <div class="col-6">
+          <%= link_to 'No thanks', setup_kit_path(kit: :none), method: :post %>
+          <p>Start with a blank slate.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
   namespace :setup, only: [:index] do
     if defined?(Dradis::Pro)
     else
+      resource :kit, only: [:new, :create]
       resource :password, only: [:new, :create]
     end
   end

--- a/spec/features/setup/kits_spec.rb
+++ b/spec/features/setup/kits_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'Setup::Kits', focus: true do
+  context "when shared password is already set" do
+    it "enqueues a KitImport job if a valid kit is passed" do
+
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+
+      visit new_setup_kit_path
+      expect(page).to have_link('Yes, please', href: setup_kit_path(kit: :welcome)) do |link|
+        link['data-method'] == 'post'
+      end
+
+      expect do
+        # We'd need JS to be able to click in the link and send a POST
+        page.driver.post setup_kit_path(kit: :welcome)
+      end.to have_enqueued_job(KitImportJob)
+    end
+
+    it "doesn't enque a KitImport if :none is passed" do
+      visit new_setup_kit_path
+      expect do
+        # We'd need JS to be able to click in the link and send a POST
+        page.driver.post setup_kit_path(kit: :none)
+      end.to_not have_enqueued_job(KitImportJob)
+    end
+
+    it "doesn't enque a KitImport if invalid kit is passed" do
+      visit new_setup_kit_path
+      expect do
+        # We'd need JS to be able to click in the link and send a POST
+        page.driver.post setup_kit_path(kit: :rspec)
+      end.to_not have_enqueued_job(KitImportJob)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Before this PR, users could use `./bin/setup` to start with a Welcome project to show them around.

This PR makes that part of the initial Setup Wizard, and users will be able to use the browser to choose between a Welcome kit and an empty slate.


### Check List

- [x] Added a CHANGELOG entry
