### PR TITLE
Add support for duplicated field names in Fields View

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [v#.#.#] ([month] [YYYY])
   - Add Setup Wizard
+  - Editor: Support fields with the same name in the Fields View
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -1,12 +1,7 @@
 class FieldsController < AuthenticatedController
   # Returns the form view given a source text
   def form
-    @form_data = FieldParser.source_to_fields(params[:source])
-
-    if fieldless_string.present?
-      @form_data = { '': fieldless_string }.merge(@form_data)
-    end
-
+    @form_data = FieldParser.source_to_fields_array(params[:source])
     @allow_dropdown = params[:allow_dropdown] == 'true'
   end
 
@@ -18,11 +13,5 @@ class FieldsController < AuthenticatedController
   # Returns the source text given a form data
   def source
     render plain: FieldParser.fields_to_source(params[:form])
-  end
-
-  private
-
-  def fieldless_string
-    @fieldless_string ||= FieldParser.parse_fieldless_string(params[:source])
   end
 end

--- a/app/models/field_parser.rb
+++ b/app/models/field_parser.rb
@@ -29,6 +29,40 @@ class FieldParser
     Hash[ *string.scan(FIELDS_REGEX).flatten.map(&:strip) ]
   end
 
+  # Parse the contents of the field and split it to return an array of field
+  # name/value pairs. Field / values are defined using this syntax:
+  #
+  #   #[Title]#
+  #   This is the value of the Title field
+  #
+  #   #[Description]#
+  #   Lorem ipsum...
+  #
+  # If the string contains a fieldless string, it will be prepended to
+  # the result. E.g.
+  #
+  #   Line 1
+  #   Line 2
+  #
+  #   #[Title]#
+  #   This is the value of the Title field
+  #
+  #   => [["", "Line 1\nLine2"], "Title", "This is the value of the Title field"]
+  #
+  def self.source_to_fields_array(string)
+    array = string.scan(FIELDS_REGEX).map do |field|
+      field.map(&:strip)
+    end
+
+    fieldless_string = parse_fieldless_string(string)
+
+    if fieldless_string.present?
+      array.prepend(['', fieldless_string])
+    end
+
+    array
+  end
+
   # Field-less strings are strings that do not have a field header (#[Field]#).
   # This parses all characters before a field header or end of string.
   def self.parse_fieldless_string(source)

--- a/spec/models/field_parser_spec.rb
+++ b/spec/models/field_parser_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe FieldParser do
+  describe '.source_to_fields_array' do
+    it 'converts the source to an array of field name/value pairs' do
+      source = <<~HEREDOC
+        #[Title]#
+        Issue 1
+
+        #[Description]#
+        My description
+      HEREDOC
+
+      result = [['Title', 'Issue 1'], ['Description', 'My description']]
+      expect(described_class.source_to_fields_array(source)).to eq(result)
+    end
+
+    it 'can contain duplicated field names' do
+      source = <<~HEREDOC
+        #[Title]#
+        Issue 1
+
+        #[Description]#
+        My description
+
+        #[Description]#
+        My description 2
+      HEREDOC
+
+      result = [['Title', 'Issue 1'], ['Description', 'My description'], ['Description', 'My description 2']]
+      expect(described_class.source_to_fields_array(source)).to eq(result)
+    end
+
+    it 'supports text without field names' do
+      source = <<~HEREDOC
+        Issue 1
+
+        #[Description]#
+        My description
+      HEREDOC
+
+      result = [['', 'Issue 1'], ['Description', 'My description']]
+      expect(described_class.source_to_fields_array(source)).to eq(result)
+    end
+  end
+end

--- a/spec/support/textile_editor_shared_examples.rb
+++ b/spec/support/textile_editor_shared_examples.rb
@@ -98,6 +98,21 @@ shared_examples 'a textile form view' do |klass|
     expect(find('#item_form_field_value_1').value).to eq ('Test Value')
   end
 
+  it 'supports fields with duplicated field names' do
+    content_attribute = get_content_attribute(klass)
+    text = "#[Field]#\nValue 1\n\n#[Field]#\nValue 2"
+
+    click_link 'Source'
+    fill_in "#{klass.to_s.underscore}_#{content_attribute}", with: text
+
+    click_link 'Fields'
+
+    expect(find('#item_form_field_name_0').value).to eq ('Field')
+    expect(find('#item_form_field_value_0').value).to eq ('Value 1')
+    expect(find('#item_form_field_name_1').value).to eq ('Field')
+    expect(find('#item_form_field_value_1').value).to eq ('Value 2')
+  end
+
   def get_content_attribute(klass)
     if klass == Evidence
       content_attribute = :content


### PR DESCRIPTION
### Summary
Currently, when a resource content contains duplicated field names, e.g.:
```
#[Field]#
Value 1

#[Field]#
Value 2
```

 _and_ the user switches from the Source view to Fields view, the duplicated field name/value pair **will not** be present in the Fields view because we're returning a Hash (which can only have a unique key) in the response.
https://github.com/dradis/dradis-ce/blob/develop/app/controllers/fields_controller.rb#L4
https://github.com/dradis/dradis-ce/blob/develop/app/models/field_parser.rb#L29

This PR ensures we return an array in the response and also move the logic for handling `fieldless_string` to the model.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
