### PR TITLE
bin/setup - set bundler config path to vendor/bundle/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
     - Remove height restriction from code blocks
     - Move '...' (more actions) menu closer to the content affected by the actions of the menu
     - Simplify issues table columns
+  - Setup: store gem dependencies under ./vendor/bundle/
   - Upgraded gems:
     - rails
   - Bugs fixes:

--- a/bin/setup
+++ b/bin/setup
@@ -19,7 +19,10 @@ FileUtils.chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  unless system('bundle check')
+    system('bundle config set path \'vendor/bundle/\'')
+    system!('bundle install')
+  end
 
   # Install JavaScript dependencies
   # system('bin/yarn')


### PR DESCRIPTION
### Summary

Default `bundle install` to store the local bundle under `./vendor/bundle/`, this will hopefully minimise the risk of gem versioning, or permissions issues.

### Check List

- [x] Added a CHANGELOG entry
