### PR TITLE
Cache Column Title keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 [v#.#.#] ([month] [YYYY])
   - Add Setup Wizard
   - Editor: Support fields with the same name in the Fields View
+  - Inceased page loading performance on Issues, Evidence, and Notes for
+    projects with *a lot* of issues, evidence, or notes
   - Tylium:
     - Import CSS manifests from addons
     - Move '...' (more actions) menu closer to the content affected by the actions of the menu

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 [v#.#.#] ([month] [YYYY])
   - Add Setup Wizard
   - Editor: Support fields with the same name in the Fields View
-  - Inceased page loading performance on Issues, Evidence, and Notes for
+  - Increased table loading performance on Issues, Evidence, and Notes for
     projects with *a lot* of issues, evidence, or notes
   - Tylium:
     - Import CSS manifests from addons

--- a/app/controllers/concerns/cached_columns.rb
+++ b/app/controllers/concerns/cached_columns.rb
@@ -2,7 +2,7 @@ module CachedColumns
   CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it
-  def cached_collection_column_keys(collection, extra_columns, identifier: @current_project.id)
+  def cached_collection_column_keys(collection, extra_columns, identifier = "projects-#{@current_project.id}")
     last_updated_record = collection.order(updated_at: :desc).first
     # Exit early if the collection is empty.
     return extra_columns unless last_updated_record

--- a/app/controllers/concerns/cached_columns.rb
+++ b/app/controllers/concerns/cached_columns.rb
@@ -1,0 +1,18 @@
+module CachedColumns
+  CACHE_KEY = "projects/%{project_id}/%{record_type}/column-keys/%{tail}".freeze
+
+  # Takes an ActiveRecord::Relation so we can make one more query off it
+  def cached_collection_column_keys(collection, extra_columns)
+    last_updated_record = collection.order(updated_at: :desc).first
+    last_updated = last_updated_record.updated_at.to_i
+
+    key_opts = { project_id: current_project.id, record_type: last_updated_record.class.name }
+
+    Rails.cache.fetch(CACHE_KEY % key_opts.merge(tail: last_updated)) do
+      # Delete any old key before we write the new one
+      Rails.cache.delete_matched(CACHE_KEY % key_opts.merge(tail: '*'))
+
+      collection.map(&:fields).map(&:keys).uniq.flatten | extra_columns
+    end
+  end
+end

--- a/app/controllers/concerns/cached_columns.rb
+++ b/app/controllers/concerns/cached_columns.rb
@@ -2,10 +2,10 @@ module CachedColumns
   CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it
-  def cached_collection_column_keys(collection, extra_columns, identifier = "projects-#{@current_project.id}")
+  def cached_collection_column_keys(collection, identifier = "projects-#{@current_project.id}")
     last_updated_record = collection.order(updated_at: :desc).first
     # Exit early if the collection is empty.
-    return extra_columns unless last_updated_record
+    return [] unless last_updated_record
 
     last_updated = last_updated_record.updated_at.to_i
 
@@ -15,7 +15,7 @@ module CachedColumns
       # Delete any old key before we write the new one
       Rails.cache.delete_matched(CACHE_KEY % key_opts.merge(tail: '*'))
 
-      collection.map(&:fields).map(&:keys).uniq.flatten | extra_columns
+      collection.map(&:fields).map(&:keys).uniq.flatten
     end
   end
 end

--- a/app/controllers/concerns/cached_columns.rb
+++ b/app/controllers/concerns/cached_columns.rb
@@ -6,6 +6,9 @@ module CachedColumns
     last_updated_record = collection.order(updated_at: :desc).first
     last_updated = last_updated_record.updated_at.to_i
 
+    # DradisPro IssueLibrary support
+    current_project ||= OpenStruct.new(id: 'issuelib')
+
     key_opts = { project_id: current_project.id, record_type: last_updated_record.class.name }
 
     Rails.cache.fetch(CACHE_KEY % key_opts.merge(tail: last_updated)) do

--- a/app/controllers/concerns/cached_columns.rb
+++ b/app/controllers/concerns/cached_columns.rb
@@ -1,18 +1,15 @@
 module CachedColumns
-  CACHE_KEY = "projects/%{project_id}/%{record_type}/column-keys/%{tail}".freeze
+  CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it
-  def cached_collection_column_keys(collection, extra_columns)
+  def cached_collection_column_keys(collection, extra_columns, identifier: @current_project.id)
     last_updated_record = collection.order(updated_at: :desc).first
     # Exit early if the collection is empty.
     return extra_columns unless last_updated_record
 
     last_updated = last_updated_record.updated_at.to_i
 
-    # DradisPro IssueLibrary support
-    current_project ||= OpenStruct.new(id: 'issuelib')
-
-    key_opts = { project_id: current_project.id, record_type: last_updated_record.class.name }
+    key_opts = { identifier: identifier, record_type: last_updated_record.class.name }
 
     Rails.cache.fetch(CACHE_KEY % key_opts.merge(tail: last_updated)) do
       # Delete any old key before we write the new one

--- a/app/controllers/concerns/cached_columns.rb
+++ b/app/controllers/concerns/cached_columns.rb
@@ -4,6 +4,9 @@ module CachedColumns
   # Takes an ActiveRecord::Relation so we can make one more query off it
   def cached_collection_column_keys(collection, extra_columns)
     last_updated_record = collection.order(updated_at: :desc).first
+    # Exit early if the collection is empty.
+    return extra_columns unless last_updated_record
+
     last_updated = last_updated_record.updated_at.to_i
 
     # DradisPro IssueLibrary support

--- a/app/controllers/concerns/dynamic_field_names_cacher.rb
+++ b/app/controllers/concerns/dynamic_field_names_cacher.rb
@@ -3,10 +3,9 @@ module DynamicFieldNamesCacher
 
   # Takes an ActiveRecord::Relation so we can make one more query off it
   def collection_field_names(collection, identifier = nil)
-    last_updated_record = collection.order(updated_at: :desc).first
-    # Exit early if the collection is empty.
-    return [] unless last_updated_record
+    return [] unless collection.empty?
 
+    last_updated_record = collection.order(updated_at: :desc).first
     last_updated = last_updated_record.updated_at.to_i
 
     identifier ||= "projects-#{@current_project.id}"

--- a/app/controllers/concerns/dynamic_field_names_cacher.rb
+++ b/app/controllers/concerns/dynamic_field_names_cacher.rb
@@ -1,4 +1,4 @@
-module CachedColumns
+module DynamicFieldTitlesCacher
   CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it

--- a/app/controllers/concerns/dynamic_field_names_cacher.rb
+++ b/app/controllers/concerns/dynamic_field_names_cacher.rb
@@ -1,4 +1,4 @@
-module DynamicFieldTitlesCacher
+module DynamicFieldNamesCacher
   CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it

--- a/app/controllers/concerns/dynamic_field_names_cacher.rb
+++ b/app/controllers/concerns/dynamic_field_names_cacher.rb
@@ -2,13 +2,14 @@ module DynamicFieldNamesCacher
   CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it
-  def collection_field_names(collection, identifier = "projects-#{@current_project.id}")
+  def collection_field_names(collection, identifier = nil)
     last_updated_record = collection.order(updated_at: :desc).first
     # Exit early if the collection is empty.
     return [] unless last_updated_record
 
     last_updated = last_updated_record.updated_at.to_i
 
+    identifier ||= "projects-#{@current_project.id}"
     key_opts = { identifier: identifier, record_type: last_updated_record.class.name }
 
     Rails.cache.fetch(CACHE_KEY % key_opts.merge(tail: last_updated)) do

--- a/app/controllers/concerns/dynamic_field_names_cacher.rb
+++ b/app/controllers/concerns/dynamic_field_names_cacher.rb
@@ -2,7 +2,7 @@ module DynamicFieldTitlesCacher
   CACHE_KEY = "%{identifier}/%{record_type}/column-keys/%{tail}".freeze
 
   # Takes an ActiveRecord::Relation so we can make one more query off it
-  def cached_collection_column_keys(collection, identifier = "projects-#{@current_project.id}")
+  def collection_field_names(collection, identifier = "projects-#{@current_project.id}")
     last_updated_record = collection.order(updated_at: :desc).first
     # Exit early if the collection is empty.
     return [] unless last_updated_record

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,5 +1,6 @@
 class IssuesController < AuthenticatedController
   include ActivityTracking
+  include CachedColumns
   include ContentFromTemplate
   include ConflictResolver
   include LiquidEnabledResource
@@ -15,9 +16,10 @@ class IssuesController < AuthenticatedController
   before_action :set_or_initialize_tags, except: [:destroy]
   before_action :set_auto_save_key, only: [:new, :create, :edit, :update]
 
+  EXTRA_COLUMNS = ['Title', 'Tags', 'Affected', 'Created', 'Created by', 'Updated'].freeze
+
   def index
-    @columns = @issues.map(&:fields).map(&:keys).uniq.flatten |
-      ['Title', 'Tags', 'Affected', 'Created', 'Created by', 'Updated']
+    @columns = cached_collection_column_keys(@unsorted_issues, EXTRA_COLUMNS)
   end
 
   def show
@@ -126,13 +128,15 @@ class IssuesController < AuthenticatedController
     # We need a transaction because multiple DELETE calls can be issued from
     # index and a TOCTOR can appear between the Note read and the Issue.find
     Note.transaction do
-      @issues = Issue.where(node_id: @issuelib.id).select(
+      @unsorted_issues = Issue.where(node_id: @issuelib.id).select(
         'notes.id, notes.author, notes.text, '\
         'count(evidence.id) as affected_count, notes.created_at, notes.updated_at'
       ).
       joins('LEFT OUTER JOIN evidence on notes.id = evidence.issue_id').
       group('notes.id').
-      includes(:affected, :tags).sort
+      includes(:affected, :tags)
+
+      @issues = @unsorted_issues.sort
     end
   end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -19,7 +19,7 @@ class IssuesController < AuthenticatedController
   EXTRA_COLUMNS = ['Title', 'Tags', 'Affected', 'Created', 'Created by', 'Updated'].freeze
 
   def index
-    @columns = cached_collection_column_keys(@unsorted_issues, EXTRA_COLUMNS)
+    @columns = cached_collection_column_keys(@unsorted_issues) | EXTRA_COLUMNS
   end
 
   def show

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -19,7 +19,7 @@ class IssuesController < AuthenticatedController
   EXTRA_COLUMNS = ['Title', 'Tags', 'Affected', 'Created', 'Created by', 'Updated'].freeze
 
   def index
-    @columns = cached_collection_column_keys(@unsorted_issues) | EXTRA_COLUMNS
+    @columns = collection_field_names(@unsorted_issues) | EXTRA_COLUMNS
   end
 
   def show

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,8 +1,8 @@
 class IssuesController < AuthenticatedController
   include ActivityTracking
-  include CachedColumns
-  include ContentFromTemplate
   include ConflictResolver
+  include ContentFromTemplate
+  include DynamicFieldNamesCacher
   include LiquidEnabledResource
   include Mentioned
   include MultipleDestroy

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -13,8 +13,8 @@ class NodesController < NestedNodeResourceController
   def show
     @activities       = @node.nested_activities.latest
 
-    @note_columns     = cached_collection_column_keys(@node.notes) | EXTRA_COLUMNS
-    @evidence_columns = cached_collection_column_keys(@node.evidence) | EXTRA_COLUMNS
+    @note_columns     = collection_field_names(@node.notes) | EXTRA_COLUMNS
+    @evidence_columns = collection_field_names(@node.evidence) | EXTRA_COLUMNS
   end
 
   # GET /nodes/<id>/edit

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -1,7 +1,7 @@
 # This controller exposes the REST operations required to manage the Node
 # resource.
 class NodesController < NestedNodeResourceController
-  include CachedColumns
+  include DynamicFieldNamesCacher
   include NodesSidebar
 
   skip_before_action :find_or_initialize_node, only: [ :sort, :create_multiple ]

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -1,18 +1,20 @@
 # This controller exposes the REST operations required to manage the Node
 # resource.
 class NodesController < NestedNodeResourceController
+  include CachedColumns
   include NodesSidebar
 
   skip_before_action :find_or_initialize_node, only: [ :sort, :create_multiple ]
   before_action :initialize_nodes_sidebar, except: [ :sort, :create_multiple ]
 
+  EXTRA_COLUMNS = ['Title', 'Created', 'Created by', 'Updated'].freeze
+
   # GET /nodes/<id>
   def show
     @activities       = @node.nested_activities.latest
-    @note_columns     = @sorted_notes.map(&:fields).map(&:keys).uniq.flatten \
-                      | ['Title', 'Created', 'Created by', 'Updated']
-    @evidence_columns = @sorted_evidence.map(&:fields).map(&:keys).uniq.flatten \
-                      | ['Title', 'Created', 'Created by', 'Updated']
+
+    @note_columns     = cached_collection_column_keys(@node.notes, EXTRA_COLUMNS)
+    @evidence_columns = cached_collection_column_keys(@node.evidence, EXTRA_COLUMNS)
   end
 
   # GET /nodes/<id>/edit

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -13,8 +13,8 @@ class NodesController < NestedNodeResourceController
   def show
     @activities       = @node.nested_activities.latest
 
-    @note_columns     = cached_collection_column_keys(@node.notes, EXTRA_COLUMNS)
-    @evidence_columns = cached_collection_column_keys(@node.evidence, EXTRA_COLUMNS)
+    @note_columns     = cached_collection_column_keys(@node.notes) | EXTRA_COLUMNS
+    @evidence_columns = cached_collection_column_keys(@node.evidence) | EXTRA_COLUMNS
   end
 
   # GET /nodes/<id>/edit


### PR DESCRIPTION
### Summary

As records go up in quantity the dynamic key generation takes it's toll.

Any record type that allows the use of Dradis Fields is inherently
dynamic. This makes drawing the table complicated because we need to
know all possible values for table headers. Focusing on issues as an
example: Currently we load every issue into memory examine the fields
and build the list of known columns.

I ran some bench marking on this query and the amount of records that
need to be scanned are positively correlated to the amount of time it
takes to process the query.

We do lots of caching on the page already but those very cache keys use
this expensive query as their key. Caching won't help if the key is the
problem.

This commit CACHES the expensive query used to later make the keys. I
heard you like caches so I cached your cache key.

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
