### PR TITLE
Cleanup Configuration fixtures

### DIFF
--- a/spec/fixtures/configurations.yml
+++ b/spec/fixtures/configurations.yml
@@ -1,0 +1,4 @@
+# ::BCrypt::Password.create('rspec_pass')
+password:
+  name: 'admin:password'
+  value: $2a$10$KXgHWzfmtCULbUFYg8XRLOqQLitq6CL6xbXO2gszKbPwRUoRhy6CC

--- a/spec/fixtures/configurations.yml
+++ b/spec/fixtures/configurations.yml
@@ -1,8 +1,0 @@
-# ::BCrypt::Password.create('rspec_pass')
-password:
-  name: 'admin:password'
-  value: $2a$10$KXgHWzfmtCULbUFYg8XRLOqQLitq6CL6xbXO2gszKbPwRUoRhy6CC
-
-plugin_templates:
-  name: 'admin:paths:plugin_templates'
-  value: ./tmp/templates/plugins/

--- a/spec/jobs/kit_import_job_spec.rb
+++ b/spec/jobs/kit_import_job_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe KitImportJob do
     after(:all) do
       FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
       FileUtils.rm_rf(Rails.root.join("tmp", "rspec"))
+      Configuration.delete_by('name LIKE ?', 'admin:paths:%')
     end
 
     it 'imports kit content' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe Attachment do
-  fixtures :configurations
-
   let(:attachment) do
     attachment = Attachment.new(Rails.root.join('public', 'images', 'rails.png'), node_id: node.id)
     attachment.save

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,8 +1,6 @@
 module ControllerMacros
   extend ActiveSupport::Concern
 
-  included { fixtures :configurations }
-
   # Macro to emulate user login
   def login_as_user(user=create(:user))
     allow_any_instance_of(ApplicationController).to \

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,6 +1,8 @@
 module ControllerMacros
   extend ActiveSupport::Concern
 
+  included { fixtures :configurations }
+
   # Macro to emulate user login
   def login_as_user(user=create(:user))
     allow_any_instance_of(ApplicationController).to \


### PR DESCRIPTION
### Summary

Configuration values have become a bit more complex than what Fixtures allow. We can remove the configurations.yml fixtures files.

This PR also addresses some cleanup in the Kit spec where we temporarily set Configuration values that have to be removed afterward.


### Check List

- [x] Added a CHANGELOG entry

Internal rspec refactor, nothing to see here.