### PR TITLE
Add Deploy to Heroku button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,8 @@ gem 'rinku'
 gem 'sanitize', '5.2.1'
 
 # SQLite3 DB driver
-gem 'sqlite3'#,  '1.4.2'
+gem 'sqlite3' unless ENV['HEROKU']
+gem 'pg' if ENV['HEROKU']
 
 # --------------------------------------------------------- Dradis Professional
 # Authorisation

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Dradis is an open-source collaboration framework, tailored to InfoSec teams.
 
+<a href="https://heroku.com/deploy?template=https://github.com/dradis/dradis-ce/tree/develop" target="_blank"><img src="https://www.herokucdn.com/deploy/button.svg" height="40"></a>
+<a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/dradis/dradis-ce/tree/develop" target="_blank"><img src="https://www.deploytodo.com/do-btn-blue.svg" height="40"></a>
+
+To try Dradis Community, you can deploy your own instance (you will need accounts in the cloud providers to get started).
 
 ## Our goals
 
@@ -51,13 +55,6 @@ There are two editions of Dradis Framework:
 
 
 ## Getting started: Community Edition
-
-### Deploy your own
-
-To try Dradis Community, you can deploy your own instance (you will need accounts in the cloud providers to get started):
-
-[![Deploy to Digital Ocean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/dradis/dradis-ce/tree/develop)
-
 
 ### From Git (recommended)
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "description": "The original open-source reporting and collaboration tool trusted by InfoSec professionals around the world.",
+  "env": {
+    "HEROKU": {
+      "description": "Tell Dradis we're on Heroku",
+      "value": "1"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "description": "Ask Rails to serve static assets",
+      "value": "1"
+    }
+  },
+  "keywords": ["infosec", "pentest", "osint"],
+  "logo": "https://github.com/dradis/dradis-ce/raw/deploy-to-heroku/app/assets/images/logo_small.png",
+  "name": "Dradis Framework - Community Edition",
+  "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
+  "scripts": {
+    "heroku-prebuild": "bin/heroku",
+    "postdeploy": "bundle exec thor dradis:setup:welcome"
+  },
+  "website": "http://drad.is"
+}

--- a/bin/heroku
+++ b/bin/heroku
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  puts "\n== Copying sample files =="
+  unless File.exist?('config/database.yml')
+    FileUtils.cp 'config/database.yml.template', 'config/database.yml'
+  end
+
+  unless File.exist?('config/secrets.yml')
+    FileUtils.cp 'config/secrets.yml.template', 'config/secrets.yml'
+  end
+
+  unless File.exist?('config/smtp.yml')
+    FileUtils.cp 'config/smtp.yml.template', 'config/smtp.yml'
+  end
+
+  puts "\n== Replace sqlite3 for postgresql in database.yml =="
+  system("sed -i '/adapter: sqlite3/adapter: postgresql/' config/database.yml")
+
+  puts "\n== Replace sqlite3 for pg in Gemfile.lock =="
+  # to test in macOS replace -E with -r in the sed command
+  system("sed -r -i 's/sqlite3 \([0-9]+\.[0-9]+\.[0-9]+\)/pg (1.2.3)/' Gemfile.lock")
+  system("sed -i 's/sqlite3/pg/' Gemfile.lock")
+end


### PR DESCRIPTION
### Summary

Alternative approach to https://github.com/dradis/dradis-ce/pull/943

Here we don't have a custom `database.yml.heroku` and we don't commit the `pg` change to `Gemfile.lock` but rely on `bin/heroku` to make those changes as a `heroku-prebuild` script.


### Check List

- [x] Added a CHANGELOG entry

Deploy to Heroku button added to README. 