### PR TITLE
Add Deploy to Heroku button

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+libsqlite3-dev
+libsqlite3-0

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,8 @@ gem 'rinku'
 gem 'sanitize', '5.2.1'
 
 # SQLite3 DB driver
-gem 'sqlite3'#,  '1.4.2'
+gem 'sqlite3'
+gem 'pg'
 
 # --------------------------------------------------------- Dradis Professional
 # Authorisation

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'rinku'
 gem 'sanitize', '5.2.1'
 
 # SQLite3 DB driver
-gem 'sqlite3' unless ENV['HEROKU']
+gem 'sqlite3'
 gem 'pg'
 
 # --------------------------------------------------------- Dradis Professional

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'rinku'
 gem 'sanitize', '5.2.1'
 
 # SQLite3 DB driver
-gem 'sqlite3' unless env['HEROKU']
+gem 'sqlite3' unless ENV['HEROKU']
 gem 'pg'
 
 # --------------------------------------------------------- Dradis Professional

--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem 'rinku'
 gem 'sanitize', '5.2.1'
 
 # SQLite3 DB driver
-gem 'sqlite3'
+gem 'sqlite3' unless env['HEROKU']
 gem 'pg'
 
 # --------------------------------------------------------- Dradis Professional

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,7 @@ GEM
       ast (~> 2.4.1)
     parslet (1.6.2)
       blankslate (>= 2.0, <= 4.0)
+    pg (1.2.3)
     popper_js (1.16.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -533,6 +534,7 @@ DEPENDENCIES
   nokogiri (= 1.12.5)
   paper_trail (~> 12.0.0)
   parslet (~> 1.6.0)
+  pg
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4.3)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Dradis is an open-source collaboration framework, tailored to InfoSec teams.
 
+<a href="https://heroku.com/deploy?template=https://github.com/dradis/dradis-ce/tree/develop" target="_blank"><img src="https://www.herokucdn.com/deploy/button.svg" height="40"></a>
+<a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/dradis/dradis-ce/tree/develop" target="_blank"><img src="https://www.deploytodo.com/do-btn-blue.svg" height="40"></a>
+
+To try Dradis Community, you can deploy your own instance (you will need accounts in the cloud providers to get started).
 
 ## Our goals
 
@@ -51,13 +55,6 @@ There are two editions of Dradis Framework:
 
 
 ## Getting started: Community Edition
-
-### Deploy your own
-
-To try Dradis Community, you can deploy your own instance (you will need accounts in the cloud providers to get started):
-
-[![Deploy to Digital Ocean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/dradis/dradis-ce/tree/develop)
-
 
 ### From Git (recommended)
 

--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "postdeploy": "bin/heroku"
+    "postdeploy": "rails /bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -26,8 +26,9 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-postbuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
-    "postdeploy": "bin/setup"
+    "heroku-prebuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
+    "heroku-postbuild": "cp config/database.yml.template config/database.yml",
+    "postdeploy": "bundle exec rake db:prepare"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -26,8 +26,6 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-prebuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
-    "heroku-postbuild": "cp config/database.yml.template config/database.yml",
     "postdeploy": "bin/heroku"
   },
   "website": "http://drad.is"

--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-prebuild": "bin/heroku"
+    "postdeploy": "bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -26,7 +26,8 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-postbuild": "bin/heroku"
+    "heroku-postbuild": "bundle exec rake db:prepare"
+    "postdeploy": "bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -26,9 +26,7 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-prebuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
-    "heroku-postbuild": "cp config/database.yml.template config/database.yml",
-    "postdeploy": "bundle exec rake db:prepare"
+    "heroku-prebuild": "bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -15,7 +15,8 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-prebuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
+    "heroku-prebuild": "sed -i 's/sqlite3//g' Gemfile.lock",
+    "heroku-postbuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
     "postdeploy": "bin/setup"
   },
   "website": "http://drad.is"

--- a/app.json
+++ b/app.json
@@ -26,7 +26,6 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-postbuild": "bundle exec rake db:prepare",
     "postdeploy": "bin/heroku"
   },
   "website": "http://drad.is"

--- a/app.json
+++ b/app.json
@@ -26,7 +26,9 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "release": "ruby /bin/heroku"
+    "heroku-prebuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
+    "heroku-postbuild": "cp config/database.yml.template config/database.yml",
+    "postdeploy": "bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "postdeploy": "bin/heroku"
+    "heroku-postbuild": "bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "postdeploy": "rails /bin/heroku"
+    "release": "ruby /bin/heroku"
   },
   "website": "http://drad.is"
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "description": "The original open-source reporting and collaboration tool trusted by InfoSec professionals around the world.",
+  "env": {
+    "HEROKU": {
+      "description": "Tell Dradis we're on Heroku",
+      "value": "1"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "description": "Ask Rails to serve static assets",
+      "value": "1"
+    }
+  },
+  "keywords": ["infosec", "pentest", "osint"],
+  "logo": "https://github.com/dradis/dradis-ce/raw/deploy-to-heroku/app/assets/images/logo_small.png",
+  "name": "Dradis Framework - Community Edition",
+  "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
+  "scripts": {
+    "heroku-prebuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
+    "postdeploy": "bin/setup"
+  },
+  "website": "http://drad.is"
+}

--- a/app.json
+++ b/app.json
@@ -1,4 +1,9 @@
 {
+  "buildpacks": [
+    {
+      "url": "heroku-community/apt"
+    }
+  ],
   "description": "The original open-source reporting and collaboration tool trusted by InfoSec professionals around the world.",
   "env": {
     "HEROKU": {
@@ -15,7 +20,6 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-prebuild": "sed -i 's/sqlite3//g' Gemfile.lock",
     "heroku-postbuild": "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml.template",
     "postdeploy": "bin/setup"
   },

--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
   "name": "Dradis Framework - Community Edition",
   "repository": "https://github.com/dradis/dradis-ce/tree/deploy-to-heroku",
   "scripts": {
-    "heroku-postbuild": "bundle exec rake db:prepare"
+    "heroku-postbuild": "bundle exec rake db:prepare",
     "postdeploy": "bin/heroku"
   },
   "website": "http://drad.is"

--- a/app.json
+++ b/app.json
@@ -12,10 +12,6 @@
   ],
   "description": "The original open-source reporting and collaboration tool trusted by InfoSec professionals around the world.",
   "env": {
-    "HEROKU": {
-      "description": "Tell Dradis we're on Heroku",
-      "value": "1"
-    },
     "RAILS_SERVE_STATIC_FILES": {
       "description": "Ask Rails to serve static assets",
       "value": "1"

--- a/app.json
+++ b/app.json
@@ -2,6 +2,12 @@
   "buildpacks": [
     {
       "url": "heroku-community/apt"
+    },
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
     }
   ],
   "description": "The original open-source reporting and collaboration tool trusted by InfoSec professionals around the world.",

--- a/bin/heroku
+++ b/bin/heroku
@@ -4,6 +4,10 @@ require 'fileutils'
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
 
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
 FileUtils.chdir APP_ROOT do
   puts "\n== Copying sample files =="
   # FileUtils.cp 'config/database.yml.template', 'config/database.yml'

--- a/bin/heroku
+++ b/bin/heroku
@@ -16,7 +16,7 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing templates folder =="
   FileUtils.mkdir 'templates'
 
-  its "\n== Preparing database =="
+  puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'
 
   puts "\n== Loading some sample content =="

--- a/bin/heroku
+++ b/bin/heroku
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "\n== Copying sample files =="
+cp config/database.yml.template config/database.yml
+cp config/secrets.yml.template config/secrets.yml
+cp config/smtp.yml.template config/smtp.yml
+
+echo "\n== Replacing DB adapter =="
+sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml
+
+echo "\n== Preparing templates folder =="
+mkdir 'templates'
+
+echo "\n== Preparing database =="
+bin/rails db:prepare
+
+echo "\n== Loading some sample content =="
+bundle exec thor dradis:setup:welcome

--- a/bin/heroku
+++ b/bin/heroku
@@ -21,7 +21,7 @@ FileUtils.chdir APP_ROOT do
   FileUtils.mkdir 'templates'
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
+  # system! 'bin/rails db:prepare'
 
   puts "\n== Loading some sample content =="
   system! 'bundle exec thor dradis:setup:welcome'

--- a/bin/heroku
+++ b/bin/heroku
@@ -10,12 +10,8 @@ end
 
 FileUtils.chdir APP_ROOT do
   puts "\n== Copying sample files =="
-  # FileUtils.cp 'config/database.yml.template', 'config/database.yml'
   FileUtils.cp 'config/secrets.yml.template', 'config/secrets.yml'
   FileUtils.cp 'config/smtp.yml.template', 'config/smtp.yml'
-
-  puts "\n== Replacing DB adapter =="
-  # system! "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml"
 
   puts "\n== Preparing templates folder =="
   FileUtils.mkdir 'templates'

--- a/bin/heroku
+++ b/bin/heroku
@@ -21,7 +21,7 @@ FileUtils.chdir APP_ROOT do
   FileUtils.mkdir 'templates'
 
   puts "\n== Preparing database =="
-  # system! 'bin/rails db:prepare'
+  system! 'bin/rails db:prepare'
 
   puts "\n== Loading some sample content =="
   system! 'bundle exec thor dradis:setup:welcome'

--- a/bin/heroku
+++ b/bin/heroku
@@ -1,18 +1,24 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ruby
+require 'fileutils'
 
-echo "\n== Copying sample files =="
-cp config/database.yml.template config/database.yml
-cp config/secrets.yml.template config/secrets.yml
-cp config/smtp.yml.template config/smtp.yml
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
 
-echo "\n== Replacing DB adapter =="
-sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml
+FileUtils.chdir APP_ROOT do
+  puts "\n== Copying sample files =="
+  FileUtils.cp 'config/database.yml.template', 'config/database.yml'
+  FileUtils.cp 'config/secrets.yml.template', 'config/secrets.yml'
+  FileUtils.cp 'config/smtp.yml.template', 'config/smtp.yml'
 
-echo "\n== Preparing templates folder =="
-mkdir 'templates'
+  puts "\n== Replacing DB adapter =="
+  system! "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml"
 
-echo "\n== Preparing database =="
-bin/rails db:prepare
+  puts "\n== Preparing templates folder =="
+  FileUtils.mkdir 'templates'
 
-echo "\n== Loading some sample content =="
-bundle exec thor dradis:setup:welcome
+  its "\n== Preparing database =="
+  system! 'bin/rails db:prepare'
+
+  puts "\n== Loading some sample content =="
+  system! 'bundle exec thor dradis:setup:welcome'
+end

--- a/bin/heroku
+++ b/bin/heroku
@@ -6,12 +6,12 @@ APP_ROOT = File.expand_path('..', __dir__)
 
 FileUtils.chdir APP_ROOT do
   puts "\n== Copying sample files =="
-  FileUtils.cp 'config/database.yml.template', 'config/database.yml'
+  # FileUtils.cp 'config/database.yml.template', 'config/database.yml'
   FileUtils.cp 'config/secrets.yml.template', 'config/secrets.yml'
   FileUtils.cp 'config/smtp.yml.template', 'config/smtp.yml'
 
   puts "\n== Replacing DB adapter =="
-  system! "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml"
+  # system! "sed -i 's/adapter: sqlite3/adapter: postgresql/' config/database.yml"
 
   puts "\n== Preparing templates folder =="
   FileUtils.mkdir 'templates'


### PR DESCRIPTION
### Summary

Alternative approach to https://github.com/dradis/dradis-ce/pull/943 and https://github.com/dradis/dradis-ce/pull/975

Here we don't have a custom `database.yml.heroku` (we use `sed` to replace the adapter) and make `pg` part of the bundle. It adds another development dependency (easily satisfied in Ubuntu) to simplify parity between Heroku and non-Heroku bundles.

### Check List

- [x] Added a CHANGELOG entry

Deploy to Heroku button added to README.