### PR TITLE
KitImportJob - do not delete kit file

### DIFF
--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -8,11 +8,13 @@ module Setup
     def create
       case @kit
       when :none
-        ;
+        # weaksauce alert: this creates a Node which flags the Setup as done.
+        Project.new.issue_library
       when :welcome
-        kit_file = ''
-        logger = nil
+        kit_file = '/tmp/welcome.zip'
+        logger = Log.new.info('Loading Welcome kit...')
         KitImportJob.perform_later(file: kit_file, logger: logger)
+        # KitImportJob.perform_now(file: kit_file, logger: logger)
       end
 
       flash[:notice] = 'All done. May the findings for this project be plentiful!'

--- a/app/jobs/kit_import_job.rb
+++ b/app/jobs/kit_import_job.rb
@@ -38,7 +38,6 @@ class KitImportJob < ApplicationJob
   ensure
     logger.info('Worker process completed.')
     FileUtils.remove_entry temporary_dir
-    File.unlink(file) if File.exists?(file)
   end
 
   private

--- a/lib/tasks/thor/setup.rb
+++ b/lib/tasks/thor/setup.rb
@@ -53,10 +53,11 @@ class DradisTasks < Thor
     desc 'welcome', 'adds initial content to the repo for demonstration purposes'
     def welcome
       kit_file = prepare_kit
-
       # Before we import the Kit we need at least 1 user
       User.create!(email: 'adama@dradisframework.com').id
       invoke 'dradis:setup:kit', [], file: kit_file.path
+    ensure
+      File.unlink(kit_file)
     end
 
     private

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -3,18 +3,23 @@ require 'rails_helper'
 describe 'Sessions' do
   subject { page }
 
+  # This matches fixtures/configurations.yml value.
   let(:password) { 'rspec_pass' }
   let(:user) do
     create(
       :user,
       :author,
-      password_hash: ::BCrypt::Password.create('rspec_pass')
+      password_hash: ::BCrypt::Password.create(password)
     )
   end
 
   # This needs to be a helper and not a let() block, because let is memoized
   # and reused.
   def login
+    # This gets us past Setup: Step 2
+    project = Project.new
+    project.issue_library
+
     visit login_path
     fill_in 'login', with: user.email
     fill_in 'password', with: password

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -17,7 +17,7 @@ describe 'Sessions' do
   # and reused.
   def login
     # This gets us past Setup: Step 2
-    project = Project.new
+    project = create(:project)
     project.issue_library
 
     visit login_path

--- a/spec/features/setup/kits_spec.rb
+++ b/spec/features/setup/kits_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe 'Setup::Kits' do
+
+  # This Setup step is CE only
+  break if defined?(Dradis::Pro)
+
   context "when shared password is already set" do
     it "enqueues a KitImport job if a valid kit is passed" do
 

--- a/spec/features/setup/kits_spec.rb
+++ b/spec/features/setup/kits_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Setup::Kits', focus: true do
+describe 'Setup::Kits' do
   context "when shared password is already set" do
     it "enqueues a KitImport job if a valid kit is passed" do
 

--- a/spec/requests/exports_spec.rb
+++ b/spec/requests/exports_spec.rb
@@ -1,20 +1,8 @@
 require 'rails_helper'
 
 describe 'export' do
-  let(:ce_login) do
-    @project = create(:project)
-    @user = create(:user, :admin)
-    Configuration.create(name: 'admin:password', value: ::BCrypt::Password.create('rspec_pass'))
-    post session_path, params: { login: @user.email, password: 'rspec_pass' }
-  end
 
-  let(:pro_login) do
-    @project = create(:project)
-    @user = create(:user, :admin)
-    post session_path, params: { login: @user.email, password: @user.password }
-  end
-
-  before { defined?(Dradis::Pro) ? pro_login : ce_login }
+  before { login_to_project_as_user }
 
   it 'prevents invalid templates' do
     export = post project_export_path(

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -16,6 +16,9 @@ module ControllerMacros
     login_as_user
 
     @project = Project.new
+
+    # weaksauce alert: this creates a Node which flags the Setup as done.
+    @project.issue_library
   end
 
   def current_project


### PR DESCRIPTION
The Job didn't create the file it's receiving as an argument, so it
should concern itself with deleting it either.

This change is required in preparation to allow for the Job to receive
either a Kit file or a folder containing the Kit's contents.


### Check List

- [x] Added a CHANGELOG entry

Internal refactor, doesn't modify any user-facing features.
