### PR TITLE
Tags and Node links

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -137,7 +137,7 @@ class IssuesController < AuthenticatedController
     rtp_default_fields = rtp ? rtp.issue_fields.default.field_names : []
 
     @default_columns = rtp_default_fields.presence || default_field_names
-    @all_columns = ['Title'] | rtp_default_fields | dynamic_fields | extra_field_names
+    @all_columns = ['Title'] | rtp_default_fields | default_field_names | dynamic_fields | extra_field_names
   end
 
   def set_issues

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -137,7 +137,7 @@ class IssuesController < AuthenticatedController
     rtp_default_fields = rtp ? rtp.issue_fields.default.field_names : []
 
     @default_columns = rtp_default_fields.presence || default_field_names
-    @all_columns = ['Title'] | rtp_default_fields | default_field_names | dynamic_fields | extra_field_names
+    @all_columns = default_field_names | rtp_default_fields | dynamic_fields | extra_field_names
   end
 
   def set_issues

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -35,9 +35,7 @@
                # this count is coming from the SQL finder in the controller
                [
                  issue.affected_count,
-                 issue.affected.pluck(:id, :label).map { |id, label|
-                   link_to(label, project_node_path(current_project.id, id))
-                 }.join("\n").html_safe
+                 issue.affected.map { |node| link_to(node.label, [current_project, node]) }.join("\n").html_safe
                ]
              when 'Created'
                [issue.created_at.to_i, local_time_ago(issue.created_at)]

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -33,7 +33,12 @@
                ]
              when 'Affected'
                # this count is coming from the SQL finder in the controller
-               [issue.affected_count, issue.affected.pluck(:label).join("\n")]
+               [
+                 issue.affected_count,
+                 issue.affected.pluck(:id, :label).map { |id, label|
+                   link_to(label, project_node_path(current_project.id, id))
+                 }.join("\n").html_safe
+               ]
              when 'Created'
                [issue.created_at.to_i, local_time_ago(issue.created_at)]
              when 'Created by'

--- a/app/views/issues/evidence/_table.html.erb
+++ b/app/views/issues/evidence/_table.html.erb
@@ -22,7 +22,7 @@
             <%
               sort, display =
               case column
-              when 'Affected'
+              when 'Label'
                 [evidence.node.label, link_to(evidence.node.label, [current_project, node, evidence])]
               when 'Created'
                 [evidence.created_at.to_i, local_time_ago(evidence.created_at)]

--- a/spec/features/issue_pages/table_spec.rb
+++ b/spec/features/issue_pages/table_spec.rb
@@ -26,8 +26,8 @@ describe 'issue pages' do
       visit project_issues_path(current_project)
     end
 
-    let(:default_columns) { ['Title'] }
-    let(:hidden_columns) { ['Description', 'Risk', 'Tags'] }
+    let(:default_columns) { ['Title', 'Tags'] }
+    let(:hidden_columns) { ['Description', 'Risk'] }
     let(:filter) { { keyword: @issue.title, filter_count: 1 } }
 
     it_behaves_like 'a DataTable'


### PR DESCRIPTION
### Summary

## Issue table:
Tags weren't included in the set of columns to select from.
Affected wasn't included in the set of columns to select from.

They were both included as default, but if the default didn't render they were missed entirely. 

Nodes were not linked for easy access.

## Evidence table:
No longer used Affected field for node links. Needed updating to use the Label column for node links. 

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] ~Added a CHANGELOG entry~
