### PR TITLE
Context menu cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v4.3.0 ([month] 2022)
   - Upgraded gems:
     - nokogiri, rails
   - Bugs fixes:
+    - Issues: Fixes incorret links in the "Send To" menu
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/app/views/issues/_send_to_menu.html.erb
+++ b/app/views/issues/_send_to_menu.html.erb
@@ -1,25 +1,26 @@
 <span class="dropdown-item dots-dropdown-header" tabindex="-1">Send to...</span>
+
 <% sync_plugins = Dradis::Plugins::with_feature(:issue_sync) %>
 
-<% cache ['send-to', sync_plugins.map(&:plugin_name)] do %>
-  <% if sync_plugins.any? %>
-    <% sync_plugins.each do |plugin| %>
-      <%=
-        plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
-        render partial: "#{plugin_path}/issues/send_to_menu"
-      %>
-    <% end %>
+<% if sync_plugins.any? %>
+  <% sync_plugins.each do |plugin| %>
+    <%=
+      plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
+      render partial: "#{plugin_path}/issues/send_to_menu"
+    %>
   <% end %>
-  <% unless defined?(Dradis::Pro) && defined?(Dradis::Pro::Plugins::Issuelib) %>
-    <% if sync_plugins.any? %>
+<% end %>
+
+<% unless defined?(Dradis::Pro) %>
+  <% if sync_plugins.any? %>
     <div class="divider"></div>
-    <% end %>
+  <% end %>
+
+  <% if defined?(Dradis::Pro::Plugins::Issuelib) %>
     <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="issuelib" data-url="https://dradisframework.com/pro/pages/issuelib.html"><i class="fa fa-book fa-fw"></i> Built-in IssueLibrary</a>
   <% end %>
-  <% unless defined?(Dradis::Pro) && defined?(Dradis::Pro::Plugins::Remediationtracker) %>
-    <% if sync_plugins.any? %>
-    <div class="divider"></div>
-    <% end %>
+
+  <% if defined?(Dradis::Pro::Plugins::Remediationtracker) %>
     <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="remediation" data-url="https://dradisframework.com/pro/add-ons/remediation.html"><i class="fa fa-tasks fa-fw"></i> Built-in Remediation Tracker</a>
   <% end %>
 <% end %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -27,20 +27,20 @@
     <div class="content-container mt-0 pb-3 mr-xxl-3">
       <div class="tab-content mt-0">
         <div class="tab-pane <%= class_names(active: !params[:tab]) %>" id="info-tab">
-          <% cache ['issue-information-tab', @issue] do %>
-            <div class="note-text-inner">
-              <h4 class="mb-4 header-underline">
-                <span class="text-truncate" title="Issue information">Issue information</span>
-                  <%= render partial: 'actions' %>
-              </h4>
+          <div class="note-text-inner">
+            <h4 class="mb-4 header-underline">
+              <span class="text-truncate" title="Issue information">Issue information</span>
+                <%= render partial: 'actions' %>
+            </h4>
+            <% cache ['issue-information-tab', @issue] do %>
               <div class="content-textile" data-behavior="content-textile">
                 <%= markup(@issue.text, liquid: true) %>
               </div>
               <div class="author-info">
                 <span class="ml-auto">Author: <%= @issue.author || 'n/a' %></span>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
 
         <div class="tab-pane <%= class_names(active: params[:tab] == 'evidence-tab') %>" id="evidence-tab">

--- a/app/views/subscriptions/_actions.html.erb
+++ b/app/views/subscriptions/_actions.html.erb
@@ -15,7 +15,6 @@
 <% end %>
 <%= link_to \
       main_app.subscriptions_path(
-        subscribable,
         subscription: {
           subscribable_type: subscribable.class.to_s,
           subscribable_id: subscribable.id


### PR DESCRIPTION
### Summary

We only used a specific cache on the context menu to ensure changes to
plugins would invalidate the nested cache item and update the menu. This
failed us in a couple of ways because the menu contains multiple items:

    Plugins based on instance
    Links to Send To items based on project
    Access to the links based on user permissions

This means the cache would become so user specific it defeats it's own
purpose. Instead, we can simply move the wider "page content" cache down
the tree and skip caching the context menu.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
