### PR TITLE
Fix datatables resetting intermittently

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v4.3.0 ([month] 2022)
   - Upgraded gems:
     - nokogiri, rails
   - Bugs fixes:
+    - Tables: Prevent columns state from resetting intermittently
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ v4.3.0 ([month] 2022)
   - Upgraded gems:
     - nokogiri, rails
   - Bugs fixes:
-    - Tables: Prevent columns state from resetting intermittently
+    - Tables: Prevent columns state from resetting after 2 hours
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -200,14 +200,14 @@ class DradisDatatable {
       //
       // To prevent a reset from happening, we just have to ensure that the number of columns on the page
       // matches the length of columns array in the saved state object.
-      stateLoadCallback: function(_settings) {
+      stateLoadCallback: function(_settings, callback) {
         var localStorageData = JSON.parse(localStorage.getItem(that.localStorageKey));
 
-        if (localStorageData !== null) {
-          return that.rebuildSavedStateColumnsFromLocalStorage(localStorageData);
-        } else {
+        if (!localStorageData) {
           return null;
         }
+
+        callback(that.rebuildSavedStateColumnsFromLocalStorage(localStorageData));
       },
       select: {
         selector: 'td.select-checkbox',

--- a/app/assets/javascripts/shared/datatable/main.js
+++ b/app/assets/javascripts/shared/datatable/main.js
@@ -121,6 +121,7 @@ class DradisDatatable {
       ],
       pageLength: 25,
       stateSave: true,
+      stateDuration: 0, // https://datatables.net/reference/option/stateDuration#Default
       // https://datatables.net/reference/option/stateSaveCallback
       // DataTables will call stateSaveCallback() whenever a state change event
       // happens (paging, searching, sorting, showing/hiding columns, etc).
@@ -200,14 +201,14 @@ class DradisDatatable {
       //
       // To prevent a reset from happening, we just have to ensure that the number of columns on the page
       // matches the length of columns array in the saved state object.
-      stateLoadCallback: function(_settings, callback) {
+      stateLoadCallback: function(_settings) {
         var localStorageData = JSON.parse(localStorage.getItem(that.localStorageKey));
 
-        if (!localStorageData) {
+        if (localStorageData !== null) {
+          return that.rebuildSavedStateColumnsFromLocalStorage(localStorageData);
+        } else {
           return null;
         }
-
-        callback(that.rebuildSavedStateColumnsFromLocalStorage(localStorageData));
       },
       select: {
         selector: 'td.select-checkbox',


### PR DESCRIPTION
### Summary
Currently, DataTables reset its state after 2 hours.

### Proposed solution
Add stateDuration: 0 to when initializing DataTables https://datatables.net/reference/option/stateDuration

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
