### PR TITLE
Upgrade Puma for CVE-2022-24790

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v4.3.0 ([month] 2022)
   - Setup Wizard: initial content choice.
   - Uploads: do not reset form so you can keep uploading output files from the same scanner
   - Upgraded gems:
-    - nokogiri, rails
+    - nokogiri, puma, rails
   - Bugs fixes:
     - Tables: Prevent columns state from resetting after 2 hours
     - [entity]:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (4.0.6)
-    puma (5.6.2)
+    puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)


### PR DESCRIPTION
### Summary

Upgrade Puma for CVE-2022-24790. An issue where certain http proxies and Puma won't agree on the start and end of http requests and a proxy that doesn't validate to the RFC7230 standard could be problematic. 

### Other Information

https://github.com/advisories/GHSA-h99w-9q5r-gjq9

Thanks for contributing to Dradis!


### Copyright assignment

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
