### PR TITLE
auto detect plugins without file upload

### DIFF
--- a/app/assets/stylesheets/tylium/modules/uploads.scss
+++ b/app/assets/stylesheets/tylium/modules/uploads.scss
@@ -1,9 +1,8 @@
 body.upload {
-
   .progress-bar {
     position: relative;
 
-    .percent { 
+    .percent {
       position: absolute;
       display: inline-block;
       text-align: center;
@@ -13,4 +12,41 @@ body.upload {
       color: transparent;
     }
   }
+}
+
+.drag-area {
+  height: 200px;
+  border: 3px dashed #e0eafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  margin: 10px auto;
+}
+
+h3 {
+  margin-bottom: 20px;
+  font-weight: 500;
+}
+
+.drag-area .icon {
+  font-size: 30px;
+  color: #347934;
+}
+
+.drag-area .prompt {
+  font-size: 20px;
+  font-weight: 500;
+  color: #34495e;
+}
+
+.drag-area .button {
+  font-size: 16px;
+  font-weight: 500;
+  color: #347934;
+  cursor: pointer;
+}
+
+.drag-area.active {
+  border: 2px solid #347934;
 }

--- a/app/views/upload/index.html.erb
+++ b/app/views/upload/index.html.erb
@@ -8,22 +8,14 @@
 
       <div class="mt-4">
         <%= form_tag project_upload_manager_path(current_project, format: :js), multipart: true, id: 'new_upload', data: { parse_url: project_upload_parse_path(current_project) } do %>
-          <div class="form-group mb-5 mt-4 pt-2">
-            <%= label_tag :uploader do %>
-              <h5>1. Choose a tool</h5>
-            <% end %>
-            <%= select_tag 'uploader', options_from_collection_for_select(@uploaders, :name, :name), { :class => 'form-control' } %>
-          </div>
           <div class="form-group mb-4">
-            <%= label_tag :file do %>
-              <h5>2. Choose a file</h5>
-            <% end %>
-            <div class="custom-file">
-              <%= file_field_tag 'file', class: 'custom-file-input' %>
-              <label class="custom-file-label" data-behavior="file-label">Choose file</label>
-              <%= hidden_field_tag 'item_id' %>
-              <%= hidden_field_tag 'format', 'js' %>
+            <div class="custom-file drag-area">
+              <div class="icon"><i class="fa fa-cloud-upload fa-lg mr-2"></i></div>
+              <span class="prompt">Drag & Drop</span>
+              <span class="prompt">or <span class="button upload-input">browse</span></span>
+              <%= file_field_tag 'file', hidden:true, class:'upload-file-input', accept:".xml, .json, .nessus", multiple: true  %>
             </div>
+            <div id="selected-files"></div>
           </div>
         <% end %>
             


### PR DESCRIPTION
### Summary
Instead of having to manually "1. Choose a tool" and manually "2. Choose a file" we want the users to be able to drop a collection of files into the Upload view and have the system auto-detect the file types.

Out of all the possible integrations and file types, for this exercise, we only want to detect 3 different file formats:

Dradis::Plugins::Nessus [sample.xml](https://github.com/dradis/dradis-nessus/blob/main/spec/fixtures/files/example_v2.nessus)
Dradis::Plugins::Wpscan [sample.json](https://github.com/dradis/dradis-wpscan/blob/main/spec/fixtures/files/sample.json)
Dradis::Plugins::Nmap [sample.xml](https://github.com/dradis/dradis-nmap/blob/main/spec/fixtures/files/nse-01.xml)