### PR TITLE
Ensure urls in labels point to evidence

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,8 +6,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - Nodes: Prevent evidence labels linking to external resources
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -26,6 +26,8 @@
               <%
               sort, display =
               case column
+              when 'Label'
+                [item.node.label, link_to(item.node.label, [current_project, @node, item])]
               when 'Title'
                 [
                   item.title,


### PR DESCRIPTION
### Summary

Prevent evidence labels linking to external resources

### Check List

- [x] Added a CHANGELOG entry
