### PR TITLE
Remove YAML methods from user preferences and spec

### DIFF
--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -5,8 +5,6 @@
 # call as we can inspect the attributes and add additional logic without
 # bloating the User model.
 #
-# The Class methods deal with ActiveRecord dump() and load(), and the Instance
-# methods deal with user preferences.
 #
 # See:
 #   http://viget.com/extend/how-i-used-activerecord-serialize-with-a-custom-data-type
@@ -27,34 +25,6 @@ class UserPreferences
     }
 
   # -- Class Methods ----------------------------------------------------------
-  # Used for `serialize` method in ActiveRecord
-  def self.dump(obj)
-    return if obj.nil?
-
-    unless obj.is_a?(self)
-      raise ::ActiveRecord::SerializationTypeMismatch,
-        "Attribute was supposed to be a #{self}, but was a #{obj.class}. -- #{obj.inspect}"
-    end
-
-    YAML.dump(obj)
-  end
-
-  def self.load(yaml)
-    return self.new if self != Object && yaml.nil?
-    return yaml unless yaml.is_a?(String) && yaml =~ /^---/
-
-    obj = YAML.unsafe_load(yaml)
-
-    unless obj.is_a?(self) || obj.nil?
-      raise SerializationTypeMismatch,
-        "Attribute was supposed to be a #{self}, but was a #{obj.class}"
-    end
-
-    obj ||= self.new if self != Object
-
-    # self.new(obj)
-    obj
-  end
 
   # -- Instance Methods -------------------------------------------------------
 

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -62,4 +62,19 @@ describe UserPreferences do
         in_array(described_class::DIGEST_FREQUENCIES.map(&:to_sym))
     end
   end
+
+  context 'as user preferences' do
+    it 'saves the user preferences' do
+      time = Time.now
+      user = create(:user)
+      user.preferences.last_first_sign_in = time
+      user.preferences.last_projects_show = time
+      user.preferences.digest_frequency = :daily
+      user.save
+
+      expect(user.preferences.last_first_sign_in).to eq(time)
+      expect(user.preferences.last_projects_show).to eq(time)
+      expect(user.preferences.digest_frequency).to eq(:daily)
+    end
+  end
 end

--- a/spec/models/user_preferences_spec.rb
+++ b/spec/models/user_preferences_spec.rb
@@ -13,38 +13,6 @@ describe UserPreferences do
     expect(preferences.digest_frequency).to eq 'daily'
   end
 
-  context "loading from YAML" do
-    context "valid tour name" do
-      it "returns 0 for a fresh set of preferences for a valid tour" do
-        preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours: {}\n"
-
-        expect do
-          preferences.last_first_sign_in
-        end.not_to raise_error
-
-        expect(preferences.last_first_sign_in).to eq('0')
-      end
-
-      it "returns the last tour version of XXX type that was visited for a valid tour" do
-        preferences = subject.class.load "--- !ruby/object:UserPreferences\ntours:\n :first_sign_in: '2.0.0'\n"
-
-        expect do
-          preferences.last_first_sign_in
-        end.not_to raise_error
-
-        expect(preferences.last_first_sign_in).to eq('2.0.0')
-      end
-    end
-
-    it "only serializes designated attributes" do
-      preferences = UserPreferences.new
-      yaml = UserPreferences.dump(preferences)
-
-      expect(yaml).to eq "--- !ruby/object:UserPreferences\ndigest_frequency: instant\ntours: {}\n"
-      expect(yaml).not_to include 'errors'
-    end
-  end
-
   context "#last_tour_XXX" do
     context "invalid tour name" do
       it "raises an exception if the tour name isn't valid" do


### PR DESCRIPTION
### Spec
It seems we don't need the #dump and #load methods from YAML in our custom serializers. The passed serializer class is wrapped around Coders::YAMLColumn which has its own dump and load methods.

**Proposed solution**
Remove the methods from UserPreferences and FieldList.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
