### PR TITLE
Upload View: Allow user to upload multiple files and system to auto-detect types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,8 +172,6 @@ group :development do
   gem 'bundler-audit', require: false
 
   gem 'rubocop', require: false
-
-  gem 'pry'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -172,6 +172,8 @@ group :development do
   gem 'bundler-audit', require: false
 
   gem 'rubocop', require: false
+
+  gem 'pry'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,7 +533,6 @@ DEPENDENCIES
   paper_trail (~> 12.0.0)
   parslet (~> 1.6.0)
   pg
-  pry
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,8 +242,6 @@ GEM
     letter_opener (1.7.0)
       launchy (~> 2.2)
     libv8-node (16.10.0.0)
-    libv8-node (16.10.0.0-x86_64-darwin-19)
-    libv8-node (16.10.0.0-x86_64-linux)
     liquid (5.0.1)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -535,6 +533,7 @@ DEPENDENCIES
   paper_trail (~> 12.0.0)
   parslet (~> 1.6.0)
   pg
+  pry
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5.1)

--- a/app/assets/javascripts/tylium/modules/uploads.js.coffee
+++ b/app/assets/javascripts/tylium/modules/uploads.js.coffee
@@ -26,14 +26,17 @@ document.addEventListener "turbolinks:load", ->
 
     $(':file').change ->
       ConsoleUpdater.jobId = ConsoleUpdater.jobId + 1
-      fileName = this.value.split('\\').pop()
+      fileNames = Object.values(@files).map((file) ->
+        file.name
+      ).join ', '
+
       $('#console').empty()
-      $('#filename').text(fileName)
+      $('#filenames').text(fileNames)
       $('#spinner').show()
       $('#result').data('id', ConsoleUpdater.jobId)
       $('#result').show()
       $('#item_id').val(ConsoleUpdater.jobId)
-      $('[data-behavior~=file-label]').text(fileName)
+      $('[data-behavior~=file-label]').text(fileNames)
 
       $(this).closest('form').submit()
       # Can't use this, because Rails UJS doesn't kick in (missing CSRF)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -66,6 +66,13 @@ class Attachment < File
   AttachmentPwd = Rails.env.test? ? Rails.root.join('tmp', 'attachments') : Rails.root.join('attachments')
   FileUtils.mkdir_p(AttachmentPwd) unless File.exists?(AttachmentPwd)
 
+  # Supported Plugins
+  SUPPORTED_PLUGINS = {
+    ".nessus" => { name: "Dradis::Plugins::Nessus", description: "Processes Nessus XML v2 format (.nessus)", version: "4.4.0" },
+    ".json" => { name: "Dradis::Plugins::Wpscan", description: "Processes WPScan JSON output", version: "4.4.0" },
+    ".xml" => { name: "Dradis::Plugins::Nmap", description: "Processes Nmap output", version: "4.4.0" }
+  }.freeze
+
   # -- Class Methods  ---------------------------------------------------------
 
   def self.all(*args)

--- a/app/views/upload/create.js.erb
+++ b/app/views/upload/create.js.erb
@@ -1,13 +1,12 @@
 <% if @success -%>
-  $('#filesize').text('<%=j number_to_human_size( File.size(@attachment.fullpath) ) %>');
+  $('#filesize').text('<%=j params[:files].map { |file| number_to_human_size(file.size) }.join(', ') %>');
   $('#spinner').hide();
   ConsoleUpdater.parsing = true;
   url = $('#new_upload').data('parse-url');
   $.post(
     url, {
       item_id: <%= @item_id %>,
-      uploader: '<%= params[:uploader] %>',
-      file: '<%= @attachment.filename %>',
+      files: <%= raw @files %>,
     },
     null,
     'script'

--- a/app/views/upload/index.html.erb
+++ b/app/views/upload/index.html.erb
@@ -8,19 +8,10 @@
 
       <div class="mt-4">
         <%= form_tag project_upload_manager_path(current_project, format: :js), multipart: true, id: 'new_upload', data: { parse_url: project_upload_parse_path(current_project) } do %>
-          <div class="form-group mb-5 mt-4 pt-2">
-            <%= label_tag :uploader do %>
-              <h5>1. Choose a tool</h5>
-            <% end %>
-            <%= select_tag 'uploader', options_from_collection_for_select(@uploaders, :name, :name), { :class => 'form-control' } %>
-          </div>
           <div class="form-group mb-4">
-            <%= label_tag :file do %>
-              <h5>2. Choose a file</h5>
-            <% end %>
             <div class="custom-file">
-              <%= file_field_tag 'file', class: 'custom-file-input' %>
-              <label class="custom-file-label" data-behavior="file-label">Choose file</label>
+              <%= file_field_tag 'files[]', class: 'custom-file-input', multiple: true, accept: @uploaders.keys.join(',') %>
+              <label class="custom-file-label" data-behavior="file-label">Upload files</label>
               <%= hidden_field_tag 'item_id' %>
               <%= hidden_field_tag 'format', 'js' %>
             </div>
@@ -52,11 +43,11 @@
           </tr>
         </thead>
         <tbody>
-          <% @uploaders.each do |uploader| %>
+          <% @uploaders.each do |_file_type, uploader| %>
             <tr>
-              <td><code><%= uploader.name %></code></td>
-              <td><%= uploader.meta[:description] %></td>
-              <td><%= uploader.meta[:version] %></td>
+              <td><code><%= uploader[:name] %></code></td>
+              <td><%= uploader[:description] %></td>
+              <td><%= uploader[:version] %></td>
             </tr>
           <% end %>
         </tbody>
@@ -70,7 +61,7 @@
       <h4 class="header-underline">Output console</h4>
       <div id="status"></div>
       <%= content_tag :div, id: 'result', style: 'display:none', data: { url: status_console_index_path }  do %>
-        <div><strong>Filename</strong>: <span id="filename"></span> <span id="spinner"><%= image_tag 'loading.gif', style: "margin:0;", alt: 'loading spinner' %></span></div>
+        <div><strong>Files</strong>: <span id="filenames"></span> <span id="spinner"><%= image_tag 'loading.gif', style: "margin:0;", alt: 'loading spinner' %></span></div>
         <div><strong>Size</strong>: <span id="filesize"></span></div>
         <div id="console" class="mx-0 mb-0"></div>
       <% end %>

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -11,9 +11,9 @@ describe "upload requests" do
   after { FileUtils.rm_rf(Attachment.pwd.join(@uploads_node.id.to_s)) }
 
   describe "POST #parse" do
-    let(:uploader) { 'Dradis::Plugins::Projects::Upload::Template' }
+    let(:uploader) { 'Dradis::Plugins::Wpscan' }
     let(:send_request) do
-      post project_upload_parse_path(@project), params: { file: "temp", format: :js, uploader: uploader }
+      post project_upload_parse_path(@project), params: { files: [{ name: "temp", uploader: uploader }.to_json], format: :js }
     end
 
     it "creates issues from the uploaded XML" do


### PR DESCRIPTION
### Summary

Today Dradis lets users upload 1 file at a time. Moreover, it requires users to identify the type of file they are uploading. We feel this experience can be improved:

1. Users should be able to drop multiple files into the browser for processing.
2. Dradis should be smart enough to recognize the type of files that were just dropped and auto-detect the type.

Here's the working demo: https://www.loom.com/share/76caa456af274ee3bc7b29a24baa839e

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
