### PR TITLE
Fix issue evidence form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
   - Upgraded gems:
     - acts_as_tree, bootsnap, bundler-audit, factory_bot, paper_trail, rails, rails-html-sanitizer, timecop, thor, unicorn
   - Bugs fixes:
+    - Evidence: Add validation for creating evidences in the issue view
     - Nodes: Prevent evidence labels linking to external resources
     - Bug tracker items:
       - [item]

--- a/app/assets/javascripts/tylium/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/tylium/modules/issues/evidence.js.coffee
@@ -32,6 +32,8 @@ document.addEventListener "turbolinks:load", ->
         $('[data-behavior~=view-content]').animate
           scrollTop: $('[data-behavior~=validation-messages]').scrollTop()
 
+        $(this).find('input[type="submit"]').attr('disabled', false).val('Create Evidence')
+
         return false
 
   if $('body.issues.show').length

--- a/app/assets/javascripts/tylium/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/tylium/modules/issues/evidence.js.coffee
@@ -25,17 +25,6 @@ document.addEventListener "turbolinks:load", ->
       $(this).prop 'selected', !$(this).prop('selected')
       $(this).parent().focus()
 
-    $('#add-evidences').submit ->
-      # If no nodes are selected/specified
-      if $('#evidence_node_ids').val().length == 0 && $('#evidence_node_list').val().length == 0
-        $('[data-behavior=missing-node-message]').removeClass('d-none')
-        $('[data-behavior~=view-content]').animate
-          scrollTop: $('[data-behavior~=validation-messages]').scrollTop()
-
-        $(this).find('input[type="submit"]').attr('disabled', false).val('Create Evidence')
-
-        return false
-
   if $('body.issues.show').length
     $table = $('[data-behavior~=dradis-datatable]')
     $table.on 'dradis:datatable:bulkDelete', ->

--- a/app/assets/javascripts/tylium/modules/issues/evidence.js.coffee
+++ b/app/assets/javascripts/tylium/modules/issues/evidence.js.coffee
@@ -25,6 +25,15 @@ document.addEventListener "turbolinks:load", ->
       $(this).prop 'selected', !$(this).prop('selected')
       $(this).parent().focus()
 
+    $('#add-evidences').submit ->
+      # If no nodes are selected/specified
+      if $('#evidence_node_ids').val().length == 0 && $('#evidence_node_list').val().length == 0
+        $('[data-behavior=missing-node-message]').removeClass('d-none')
+        $('[data-behavior~=view-content]').animate
+          scrollTop: $('[data-behavior~=validation-messages]').scrollTop()
+
+        return false
+
   if $('body.issues.show').length
     $table = $('[data-behavior~=dradis-datatable]')
     $table.on 'dradis:datatable:bulkDelete', ->

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -50,7 +50,7 @@ class EvidenceController < NestedNodeResourceController
     issue = current_project.issues.find(evidence_params[:issue_id])
 
     if node_params_empty?
-      redirect_to project_issue_path(current_project, evidence_params[:issue_id], tab: 'evidence-tab'), alert: 'Evidence cannot be created.'
+      redirect_to project_issue_path(current_project, evidence_params[:issue_id], tab: 'evidence-tab'), alert: 'No node was selected.'
       return
     end
 

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -49,6 +49,11 @@ class EvidenceController < NestedNodeResourceController
     # validate Issue
     issue = current_project.issues.find(evidence_params[:issue_id])
 
+    if node_params_empty?
+      redirect_to project_issue_path(current_project, evidence_params[:issue_id], tab: 'evidence-tab'), alert: 'Evidence cannot be created.'
+      return
+    end
+
     if params[:evidence][:node_ids]
       params[:evidence][:node_ids].reject(&:blank?).each do |node_id|
         node = current_project.nodes.find(node_id)
@@ -166,6 +171,11 @@ class EvidenceController < NestedNodeResourceController
 
   def evidence_params
     params.require(:evidence).permit(:author, :content, :issue_id, :node_id)
+  end
+
+  def node_params_empty?
+    params[:evidence][:node_list].blank? &&
+      (params[:evidence][:node_ids].reject(&:empty?).empty?)
   end
 
   def set_auto_save_key

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -45,53 +45,6 @@ class EvidenceController < NestedNodeResourceController
     end
   end
 
-  def create_multiple
-    # validate Issue
-    issue = current_project.issues.find(evidence_params[:issue_id])
-
-    if node_params_empty?
-      redirect_to project_issue_path(current_project, evidence_params[:issue_id], tab: 'evidence-tab'), alert: 'No node was selected.'
-      return
-    end
-
-    if params[:evidence][:node_ids]
-      params[:evidence][:node_ids].reject(&:blank?).each do |node_id|
-        node = current_project.nodes.find(node_id)
-        evidence = Evidence.create!(
-          author: current_user.email,
-          content: evidence_params[:content],
-          issue_id: issue.id,
-          node_id: node.id
-        )
-        track_created(evidence)
-      end
-    end
-    if params[:evidence][:node_list]
-      if params[:evidence][:node_list_parent_id].present?
-        parent = current_project.nodes.find(params[:evidence][:node_list_parent_id])
-      end
-      params[:evidence][:node_list].lines.map(&:strip).reject(&:blank?).each do |label|
-        unless (node = current_project.nodes.find_by(label: label))
-          node = current_project.nodes.create!(
-            type_id: Node::Types::HOST,
-            label: label,
-            parent: parent,
-          )
-          track_created(node)
-        end
-
-        evidence = Evidence.create!(
-          author: current_user.email,
-          content: evidence_params[:content],
-          issue_id: issue.id,
-          node_id: node.id
-        )
-        track_created(evidence)
-      end
-    end
-    redirect_to project_issue_path(current_project, evidence_params[:issue_id], tab: 'evidence-tab'), notice: 'Evidence added for selected nodes.'
-  end
-
   def edit
   end
 
@@ -171,11 +124,6 @@ class EvidenceController < NestedNodeResourceController
 
   def evidence_params
     params.require(:evidence).permit(:author, :content, :issue_id, :node_id)
-  end
-
-  def node_params_empty?
-    params[:evidence][:node_list].blank? &&
-      (params[:evidence][:node_ids].reject(&:empty?).empty?)
   end
 
   def set_auto_save_key

--- a/app/controllers/issues/evidence_controller.rb
+++ b/app/controllers/issues/evidence_controller.rb
@@ -1,10 +1,11 @@
 class Issues::EvidenceController < AuthenticatedController
+  include ActivityTracking
   include ContentFromTemplate
   include DynamicFieldNamesCacher
   include MultipleDestroy
   include ProjectScoped
 
-  before_action :set_issues, only: [:index, :new]
+  before_action :set_issues, only: [:create_multiple, :index, :new]
   before_action :set_affected_nodes, only: :index
   before_action :set_columns, only: :index
 
@@ -18,7 +19,67 @@ class Issues::EvidenceController < AuthenticatedController
     @template_content = template_content if params[:template]
   end
 
+  def create_multiple
+    # validate Issue
+    @issue = current_project.issues.find(evidence_params[:issue_id])
+
+    if node_params_empty?
+      @content = evidence_params[:content]
+      @nodes_for_add_evidence = current_project.nodes.user_nodes.order(:label)
+
+      flash.now[:alert] = 'A node must be selected.'
+      render :new
+    else
+      if params[:evidence][:node_ids]
+        params[:evidence][:node_ids].reject(&:blank?).each do |node_id|
+          node = current_project.nodes.find(node_id)
+          evidence = Evidence.create!(
+            author: current_user.email,
+            content: evidence_params[:content],
+            issue_id: @issue.id,
+            node_id: node.id
+          )
+          track_created(evidence)
+        end
+      end
+      if params[:evidence][:node_list]
+        if params[:evidence][:node_list_parent_id].present?
+          parent = current_project.nodes.find(params[:evidence][:node_list_parent_id])
+        end
+        params[:evidence][:node_list].lines.map(&:strip).reject(&:blank?).each do |label|
+          unless (node = current_project.nodes.find_by(label: label))
+            node = current_project.nodes.create!(
+              type_id: Node::Types::HOST,
+              label: label,
+              parent: parent,
+            )
+            track_created(node)
+          end
+
+          evidence = Evidence.create!(
+            author: current_user.email,
+            content: evidence_params[:content],
+            issue_id: @issue.id,
+            node_id: node.id
+          )
+          track_created(evidence)
+        end
+      end
+
+      redirect_to project_issue_path(current_project, evidence_params[:issue_id], tab: 'evidence-tab'), notice: 'Evidence added for selected nodes.'
+    end
+  end
+
   private
+
+  def evidence_params
+    params.require(:evidence).permit(:author, :content, :issue_id, :node_id)
+  end
+
+  def node_params_empty?
+    params[:evidence][:node_list].blank? &&
+      (params[:evidence][:node_ids].reject(&:empty?).empty?)
+  end
 
   def set_columns
     default_field_names = ['Label', 'Title'].freeze
@@ -51,6 +112,6 @@ class Issues::EvidenceController < AuthenticatedController
 
   def set_issues
     @issues = current_project.issues.order(:text)
-    @issue = @issues.find(params[:issue_id])
+    @issue = @issues.find(params[:issue_id]) if params[:issue_id]
   end
 end

--- a/app/views/issues/evidence/new.html.erb
+++ b/app/views/issues/evidence/new.html.erb
@@ -14,6 +14,12 @@
   <%= render 'issues/sidebar', issues: @issues %>
 <% end %>
 
+<div data-behavior="validation-messages">
+  <div class="alert alert-danger d-none" data-behavior="missing-node-message">
+    A node must be selected.
+  </div>
+</div>
+
 <%= form_for(
   :evidence,
   url: project_create_multiple_evidence_path(current_project),

--- a/app/views/issues/evidence/new.html.erb
+++ b/app/views/issues/evidence/new.html.erb
@@ -14,12 +14,6 @@
   <%= render 'issues/sidebar', issues: @issues %>
 <% end %>
 
-<div data-behavior="validation-messages">
-  <div class="alert alert-danger d-none" data-behavior="missing-node-message">
-    A node must be selected.
-  </div>
-</div>
-
 <%= form_for(
   :evidence,
   url: project_create_multiple_evidence_path(current_project),
@@ -90,7 +84,7 @@
         <div class="row">
           <div class="col-12">
             <h5>Evidence Content</h5>
-            <% cache [@issue, @nodes_for_add_evidence ] do %>
+            <% cache [@content, @issue, @nodes_for_add_evidence] do %>
               <%= f.hidden_field :issue_id, value: @issue.id %>
               <%= f.hidden_field :node_id, value: @issue.node_id %>
 
@@ -107,7 +101,7 @@
                   'rich-toolbar-uploader': '[data-behavior~=jquery-upload]',
                 },
                 rows: 20,
-                value: @template_content
+                value: (@template_content || @content)
               %>
             <% end %>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
       resources :configurations, only: [:index, :update]
     end
 
-    post :create_multiple_evidence, to: 'evidence#create_multiple'
+    post :create_multiple_evidence, to: 'issues/evidence#create_multiple'
 
     resources :issues, concerns: :multiple_destroy do
       collection do

--- a/spec/features/evidence_pages/new_page_spec.rb
+++ b/spec/features/evidence_pages/new_page_spec.rb
@@ -83,6 +83,13 @@ describe 'Evidence new page' do
       expect(@node.reload.evidence.last.author).to eq(@logged_in_as.email)
     end
 
+    context 'invalid form', js: true do
+      it 'displays an error when no nodes are selected' do
+        click_button 'Create Evidence'
+        expect(page).to have_text('A node must be selected.')
+      end
+    end
+
     # we need to filter by job class because a NotificationsReaderJob
     # will also be enqueued
     def enqueued_activity_tracking_jobs


### PR DESCRIPTION
### Spec
When creating an Evidence for an Issue via the Evidence tab in the Issue details and not selecting a node, the form submits correctly and a flash message "Evidence added for selected nodes." appears but no Evidence is created.

**Proposed solution**
There needs to be validation in both the frontend and backend. In the frontend, the form should not be submittable if no nodes are selected. In the backend, the EvidenceController#create_multiple action should be updated to handle if the node params are missing, and if so, re-render the form with an error message.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
