### PR TITLE
Fix evidence spec

### DIFF
--- a/spec/models/evidence_spec.rb
+++ b/spec/models/evidence_spec.rb
@@ -86,11 +86,10 @@ describe Evidence do
     end
 
     context 'when issue is on a different project' do
-      let(:issue_on_another_project) { (create(:issue, node: node_on_another_project)) }
-      let(:node_on_another_project) do
-        node = create(:node)
-        allow(node).to receive(:project).and_return(Project.new(id: 2, name: 'Another Project'))
-        node
+      let(:issue_on_another_project) do
+        new_node = create(:node)
+        allow(new_node).to receive(:project).and_return(Project.new(id: node.project.id + 1, name: 'Another Project'))
+        create(:issue, node: new_node)
       end
 
       it 'is invalid' do


### PR DESCRIPTION
### Spec

`evidence_spec.rb` is randomly failing because we're using exactly `2` as the id for the fake project:
```
Project.new(id: 2, name: 'Another Project')
```

In some cases, the original project can have the same id as `2` even if it's a different project, passing the evidence validation and failing the spec.

**Proposed solution**
Increment the original project's id instead


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
