### PR TITLE
Add url encoding for attachment filenames

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
   - Upgraded gems:
     - acts_as_tree, bootsnap, bundler-audit, factory_bot, paper_trail, rails, rails-html-sanitizer, timecop, thor, unicorn
   - Bugs fixes:
+    - Attachments: Fix attachments not showing or being validated correctly
     - Nodes: Prevent evidence labels linking to external resources
     - Bug tracker items:
       - [item]

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -234,4 +234,8 @@ class Attachment < File
       created_at: self.ctime
     }.to_json(options)
   end
+
+  def url_encoded_filename
+    ERB::Util.url_encode(@filename)
+  end
 end

--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -56,7 +56,7 @@
                     <td rowspan="2" align="right" class="copy-link">
                       <button
                         class="btn btn-copy btn-transparent js-attachment-url-copy"
-                        data-clipboard-text="!<%= main_app.project_node_attachment_path(node.project, node, attachment.filename) %>!"
+                        data-clipboard-text="!<%= main_app.project_node_attachment_path(node.project, node, '') + attachment.url_encoded_filename %>!"
                       >
                         <i class="fa fa-link"></i>
                       </button>

--- a/spec/features/attachments_spec.rb
+++ b/spec/features/attachments_spec.rb
@@ -46,6 +46,24 @@ describe "Describe attachments" do
 
       expect(Dir["#{node_attachments}/*"].count).to eq(2)
     end
+
+    it 'builds a URL encoded link for attachments' do
+      FileUtils.mkdir_p( Attachment.pwd.join(@node.id.to_s) )
+
+      filenames = ['attachment with space.png', 'attachmentwith&.png', 'attachmentwith+.png']
+
+      filenames.each do |filename|
+        attachment = Attachment.pwd.join(@node.id.to_s, filename)
+        FileUtils.cp(Rails.root.join('spec/fixtures/files/rails.png'), attachment)
+      end
+
+      visit project_node_path(current_project, @node)
+
+      filenames.each do |filename|
+        url_encoded_filename = ERB::Util.url_encode(filename)
+        expect(page).to have_css("button[data-clipboard-text='!/projects/#{current_project.id}/nodes/#{@node.id}/attachments/#{url_encoded_filename}!']")
+      end
+    end
   end
 end
 #


### PR DESCRIPTION
### Spec
The following url helper produces inconsistent results:
```
main_app.project_node_attachment_path(node.project, node, attachment.filename)
```
(not sure why yet)

If given a filename with no special characters, no problem.
If given a filename with spaces, it escapes as expected:
```
/projects/137/nodes/973/attachments/name%20with%20spaces.png
```
We account for this escape by unescaping the filename when exporting, validating, and displaying the attachment.

If given a filename with '+' and '&', it does not escape:
```
/projects/137/nodes/973/attachments/namewith+.png
/projects/137/nodes/973/attachments/namewith&.png
```
This introduces 2 problems:

1. The unescaping that we do for spaces fails for the case with a '+' in the filename. This is because unescaping a '+' turns into a whitespace.
2. The unescaped '+' and '&' symbols are passed to the XML for nokogiri as attribute values and are promptly unescaped/removed

**Proposed Solution**
We can build the link manually to bypass Rails own escaping and use ERB::Util.url_encode instead:
```
main_app.project_node_attachment_path(node.project, node, '') + ERB::Util.url_encode(attachment.filename)
```

This means, for filenames with '&' and '+', it will result in the following links:
```
!/projects/137/nodes/973/attachments/namewith%26.png!
!/projects/137/nodes/973/attachments/namewith%2B.png!
```
This link will survive the Nokogiri parsing and be exported successfully.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
