### PR TITLE
API specs - add Versioned API shared context

### DIFF
--- a/engines/dradis-api/spec/support/shared_context.rb
+++ b/engines/dradis-api/spec/support/shared_context.rb
@@ -1,17 +1,3 @@
-shared_context "https" do
-  before do
-    @env ||= {}
-    @env["HTTPS"] = "on"
-  end
-end
-
-shared_context "content_type: application/json" do
-  before do
-    @env ||= {}
-    @env["CONTENT_TYPE"] = "application/json"
-  end
-end
-
 shared_context "authorized API user" do
   before do
     @logged_in_as = User.find_or_create_by(email: 'rspec')
@@ -23,6 +9,27 @@ shared_context "authorized API user" do
   end
 end
 
+shared_context "content_type: application/json" do
+  before do
+    @env ||= {}
+    @env["CONTENT_TYPE"] = "application/json"
+  end
+end
+
+shared_context "https" do
+  before do
+    @env ||= {}
+    @env["HTTPS"] = "on"
+  end
+end
+
 shared_context "project scoped API" do
   let(:current_project) { Project.new }
+end
+
+shared_context "versioned API" do
+  before do
+    @env ||= {}
+    @env["ACCEPT"] = "application/vnd.dradisapi; v=#{api_version}"
+  end
 end


### PR DESCRIPTION
### Summary

If we're going to bump the API version w/ breaking changes we need a mechanism to anchor a specific test suite to a given API version.

This PR adds the `versioned API` shared context that sets the right API version HTTP header:

https://github.com/dradis/dradis-ce/blob/develop/engines/dradis-api/lib/dradis/ce/api/routing_constraints.rb#L16

It seems there's more stuff that changed because I :alpha'ed the contexts.

### Check List

- [x] Added a CHANGELOG entry

Internal change, no need for public facing entry.