### PR TITLE
Remove Stryle/HashSyntax cop from rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,10 +46,6 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/FirstArgumentIndentation:
   Enabled: true
 
-# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
-Style/HashSyntax:
-  Enabled: true
-
 # Method definitions after `private` or `protected` isolated calls need one
 # extra level of indentation.
 Layout/IndentationConsistency:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 [v#.#.#] ([month] [YYYY])
   - [entity]:
     - [future tense verb] [feature]
+  - Rubocop CI:
+    - remove Style/HashSyntax cop
   - Upgraded gems:
     - nokogiri, rails-html-sanitizer, sinatra
   - Bugs fixes:


### PR DESCRIPTION
### Summary
Remove `Style/HashSyntax` cop from `.rubocop.yml` so that code is more readable
ex. 
```
method.call(text, param: param)
vs.
method.call(text, param:)
```


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
