### PR TITLE
Update `pg` to v1.4.5 (solves error in CE dev env)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@
     - Add breadcrumbs to Revision History view
     - Remove `Recent Activity` tabs and add `View History` link to the dots menu
   - Upgraded gems:
-    - nokogiri, rails-html-sanitizer, sinatra
+    - nokogiri, pg, rails-html-sanitizer, sinatra
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       ast (~> 2.4.1)
     parslet (1.6.2)
       blankslate (>= 2.0, <= 4.0)
-    pg (1.2.3)
+    pg (1.4.5)
     popper_js (1.16.0)
     pry (0.12.2)
       coderay (~> 1.1.0)


### PR DESCRIPTION
### Summary

We use the `pg` gem for deployments to heroku but this has caused errors in the dev env on macOS:

```bash
Library not loaded: /usr/local/opt/postgresql/lib/libpq.5.dylib (LoadError)
```

Upgrading to the current v1.4.5 solves this problem.

### Check List

- [x] Added a CHANGELOG entry
