### PR TITLE
prevent rubocop checking all files on PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
     name: RuboCop
     needs: [audits]
     runs-on: ubuntu-latest
-    env:
-      TARGET_BRANCH: ${{ github.base_ref }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
@@ -36,8 +34,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Lint changed files
-        run: bin/rubocop-ci ${{ env.TARGET_BRANCH }}
+      - name: Lint changed files (for Merge)
+        if: ${{ !github.base_ref }}
+        run: bin/rubocop-ci ${{ github.event.before }}
+      - name: Lint changed files (for PR)
+        if: ${{ github.base_ref }}
+        run: bin/rubocop-ci origin/${{ github.base_ref }}
   rspec:
     name: RSpec
     needs: [audits, rubocop]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
     name: RuboCop
     needs: [audits]
     runs-on: ubuntu-latest
+    env:
+      IS_MERGE: ${{ github.base_ref == '' }}
+      PREV_SHA: ${{ github.event.before }}
+      TARGET_BRANCH: ${{ github.base_ref }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
@@ -34,12 +38,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Lint changed files (for Merge)
-        if: ${{ !github.base_ref }}
-        run: bin/rubocop-ci ${{ github.event.before }}
-      - name: Lint changed files (for PR)
-        if: ${{ github.base_ref }}
-        run: bin/rubocop-ci origin/${{ github.base_ref }}
+      - name: Lint changed files
+        run: bin/rubocop-ci ${{ env.TARGET_BRANCH || env.PREV_SHA }} ${{ env.IS_MERGE }}
   rspec:
     name: RSpec
     needs: [audits, rubocop]

--- a/bin/rubocop-ci
+++ b/bin/rubocop-ci
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 set -e
-target=$1
+
+if [[ $2 = true ]]
+then
+  target=$1
+else
+  target="origin/$1"
+fi
+
 result_info="bundle exec rubocop --force-exclusion --format simple $(git diff-tree -r --no-commit-id --name-only $target..HEAD)"
 files_inspected=`$result_info | grep "files inspected\|file inspected" | cut -d " " -f1`
 warning_count=`$result_info | grep "offenses detected\|offense detected" | cut -d " " -f4`

--- a/bin/rubocop-ci
+++ b/bin/rubocop-ci
@@ -1,25 +1,18 @@
 #!/bin/bash
 
 set -e
-
-if [ $1 ]
-then
-  target_branch=$1
-else
-  target_branch="develop"
-fi
-
-result_info="bundle exec rubocop --force-exclusion --format simple $(git diff-tree -r --no-commit-id --name-only origin/$target_branch..HEAD)"
+target=$1
+result_info="bundle exec rubocop --force-exclusion --format simple $(git diff-tree -r --no-commit-id --name-only $target..HEAD)"
 files_inspected=`$result_info | grep "files inspected\|file inspected" | cut -d " " -f1`
 warning_count=`$result_info | grep "offenses detected\|offense detected" | cut -d " " -f4`
 
 if [ $warning_count == 'no' ]
 then
-  echo "✅ Clean code! No rubocop offenses detected in $files_inspected changed file(s). Compared to $target_branch branch. Great job ಠ_ಠ"
+  echo "✅ Clean code! No rubocop offenses detected in $files_inspected changed file(s). Compared to $target. Great job ಠ_ಠ"
   exit 0
 elif [ $warning_count -ge '1' ]
 then
-  echo -e "❌ Inspected $files_inspected file(s) and detected $warning_count offense(s). Compared to $target_branch branch"
+  echo -e "❌ Inspected $files_inspected file(s) and detected $warning_count offense(s). Compared to $target"
   $result_info
   exit 1
 else


### PR DESCRIPTION
### Summary

This PR fixes rubocop running on the entire repo when a PR is merged (rather than just the changed files)

### Check List

~- [ ] Added a CHANGELOG entry~
