### PR TITLE
Track user events using event_tracking_job

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -20,7 +20,7 @@ class ExportController < AuthenticatedController
     # FIXME: check the Routing guide to find a better way.
     action_path = "#{params[:route]}_path"
     redirect_to eval(@exporter::Engine::engine_name).send(action_path)
-    EventTrackingJob.perform_later(event_name: 'Project Exported', properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
+    EventTrackingJob.perform_later(visit: current_visit, event_name: 'Project Exported', properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
   end
 
   # Runs a pre-export validation of the contents of the project

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -20,7 +20,7 @@ class ExportController < AuthenticatedController
     # FIXME: check the Routing guide to find a better way.
     action_path = "#{params[:route]}_path"
     redirect_to eval(@exporter::Engine::engine_name).send(action_path)
-    AhoyTrackingJob.perform_later(event_name: "Project Exported", properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
+    EventTrackingJob.perform_later(event_name: "Project Exported", properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
   end
 
   # Runs a pre-export validation of the contents of the project

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -20,6 +20,7 @@ class ExportController < AuthenticatedController
     # FIXME: check the Routing guide to find a better way.
     action_path = "#{params[:route]}_path"
     redirect_to eval(@exporter::Engine::engine_name).send(action_path)
+    AhoyTrackingJob.perform_later(event_name: "Project Exported", properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
   end
 
   # Runs a pre-export validation of the contents of the project

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -20,7 +20,7 @@ class ExportController < AuthenticatedController
     # FIXME: check the Routing guide to find a better way.
     action_path = "#{params[:route]}_path"
     redirect_to eval(@exporter::Engine::engine_name).send(action_path)
-    EventTrackingJob.perform_later(event_name: "Project Exported", properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
+    EventTrackingJob.perform_later(event_name: 'Project Exported', properties: { exporter: @exporter.to_s,  issue_count: current_project.issues.count, evidence_count: current_project.evidence.count, node_count: current_project.nodes.count })
   end
 
   # Runs a pre-export validation of the contents of the project
@@ -42,7 +42,7 @@ class ExportController < AuthenticatedController
   def validation_status
     @log_uid = params[:log_uid].to_i
     @job_id  = params[:job_id]
-    @logs    = Log.where("uid = ? and id > ?", @log_uid, params[:after].to_i)
+    @logs    = Log.where('uid = ? and id > ?', @log_uid, params[:after].to_i)
 
     status = Resque::Plugins::Status::Hash.get(@job_id)
     render json: status.reverse_merge({
@@ -58,8 +58,8 @@ class ExportController < AuthenticatedController
   def find_plugins
     @plugins = Dradis::Plugins::with_feature(:export).collect do |plugin|
       path = plugin.to_s
-      path[0..path.rindex('::')-1].constantize
-    end.sort{|a,b| a.name <=> b.name }
+      path[0..path.rindex('::') - 1].constantize
+    end.sort { |a, b| a.name <=> b.name }
   end
 
   # In case something goes wrong with the export, fail graciously instead of
@@ -69,7 +69,7 @@ class ExportController < AuthenticatedController
     redirect_to project_upload_manager_path(current_project)
   end
 
-  def templates_dir_for(args={})
+  def templates_dir_for(args = {})
     plugin = args[:plugin]
     File.join(::Configuration::paths_templates_reports, plugin::Engine.plugin_name.to_s)
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,7 @@ class SessionsController < ApplicationController
 
   def create
     warden.authenticate!
+    EventTrackingJob.perform_later(visit: current_visit, event_name: 'User login')
     redirect_to_target_or_default root_url
   end
 

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -17,7 +17,7 @@ module Setup
         User.create!(email: 'adama@dradisframework.com')
         KitImportJob.perform_later(kit_folder, logger: logger)
       end
-
+      AhoyTrackingJob.perform_later(event_name: "Setup Completed")
       flash[:notice] = 'All done. May the findings for this project be plentiful!'
       redirect_to login_path
     end

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -17,7 +17,7 @@ module Setup
         User.create!(email: 'adama@dradisframework.com')
         KitImportJob.perform_later(kit_folder, logger: logger)
       end
-      EventTrackingJob.perform_later(event_name: 'Setup Completed')
+      EventTrackingJob.perform_later(visit: current_visit, event_name: 'CE Setup Completed')
       flash[:notice] = 'All done. May the findings for this project be plentiful!'
       redirect_to login_path
     end

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -17,7 +17,7 @@ module Setup
         User.create!(email: 'adama@dradisframework.com')
         KitImportJob.perform_later(kit_folder, logger: logger)
       end
-      AhoyTrackingJob.perform_later(event_name: "Setup Completed")
+      EventTrackingJob.perform_later(event_name: "Setup Completed")
       flash[:notice] = 'All done. May the findings for this project be plentiful!'
       redirect_to login_path
     end

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -11,7 +11,7 @@ module Setup
         # weaksauce alert: this creates a Node which flags the Setup as done.
         Project.new.issue_library
       when :welcome
-        kit_folder = Rails.root.join('lib','tasks','templates','welcome').to_s
+        kit_folder = Rails.root.join('lib','tasks', 'templates','welcome').to_s
         logger = Log.new.info('Loading Welcome kit...')
         # Before we import the Kit we need at least 1 user
         User.create!(email: 'adama@dradisframework.com')

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -11,13 +11,13 @@ module Setup
         # weaksauce alert: this creates a Node which flags the Setup as done.
         Project.new.issue_library
       when :welcome
-        kit_folder = Rails.root.join('lib','tasks', 'templates','welcome').to_s
+        kit_folder = Rails.root.join('lib', 'tasks', 'templates', 'welcome').to_s
         logger = Log.new.info('Loading Welcome kit...')
         # Before we import the Kit we need at least 1 user
         User.create!(email: 'adama@dradisframework.com')
         KitImportJob.perform_later(kit_folder, logger: logger)
       end
-      EventTrackingJob.perform_later(event_name: "Setup Completed")
+      EventTrackingJob.perform_later(event_name: 'Setup Completed')
       flash[:notice] = 'All done. May the findings for this project be plentiful!'
       redirect_to login_path
     end

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -11,7 +11,7 @@ module Setup
         # weaksauce alert: this creates a Node which flags the Setup as done.
         Project.new.issue_library
       when :welcome
-        kit_folder = Rails.root.join('lib', 'tasks', 'templates', 'welcome').to_s
+        kit_folder = Rails.root.join('lib','tasks','templates','welcome').to_s
         logger = Log.new.info('Loading Welcome kit...')
         # Before we import the Kit we need at least 1 user
         User.create!(email: 'adama@dradisframework.com')

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -17,7 +17,7 @@ module Setup
         User.create!(email: 'adama@dradisframework.com')
         KitImportJob.perform_later(kit_folder, logger: logger)
       end
-      EventTrackingJob.perform_later(visit: current_visit, event_name: 'CE Setup Completed')
+
       flash[:notice] = 'All done. May the findings for this project be plentiful!'
       redirect_to login_path
     end

--- a/app/jobs/event_tracking_job.rb
+++ b/app/jobs/event_tracking_job.rb
@@ -1,8 +1,8 @@
 class EventTrackingJob < ApplicationJob
   queue_as :dradis_project
 
-  def perform(event_name:, properties: {})
-    ahoy = Ahoy::Tracker.new
+  def perform(visit:, event_name:, properties: {})
+    ahoy = Ahoy::Tracker.new(visit_token: visit.visit_token)
     ahoy.track(event_name, properties)
   end
 end

--- a/app/jobs/event_tracking_job.rb
+++ b/app/jobs/event_tracking_job.rb
@@ -1,0 +1,8 @@
+class EventTrackingJob < ApplicationJob
+  queue_as :dradis_project
+
+  def perform(event_name:, properties: {})
+    ahoy = Ahoy::Tracker.new
+    ahoy.track(event_name, properties)
+  end
+end


### PR DESCRIPTION
### Summary

We want to track user events so that we can analyze and make decisions based on this data. This will ultimately provide the users with a better application, as we will be able to draw conclusions based on data such as most used/least used exporters, for example.

In this PR: 
- Add a background job for tracking user events
- Track setup completion in kitscontroller#create 
- Track exports and some data about them in exportcontroller#create


Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
