### PR TITLE
Add state to the notes table and state enum to issues

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -28,7 +28,7 @@ class Issue < Note
   #
   # FIXME - ISSUE/NOTE INHERITANCE
   def activities(*params)
-    Activity.where(trackable_type: "Issue", trackable_id: self.id)
+    Activity.where(trackable_type: 'Issue', trackable_id: self.id)
   end
 
   # `has_many :comments` doesn't work as normal here, because we're not
@@ -68,9 +68,7 @@ class Issue < Note
 
   # -- Validations ----------------------------------------------------------
 
-
   # -- Scopes ---------------------------------------------------------------
-
 
   # -- Class Methods --------------------------------------------------------
 
@@ -108,14 +106,14 @@ class Issue < Note
   # This is useful in a number of views to present or hide information about
   # all the instances for a given issue and node/host.
   def evidence_by_node()
-    results = Hash.new{|h,k| h[k] = [] }
+    results = Hash.new { |h, k| h[k] = [] }
 
     self.evidence.includes(:node).each do |evidence|
       results[evidence.node] << evidence
     end
 
     # This sorts nodes by IP address. Non-IPs appear first
-    results.sort_by do |node,_|
+    results.sort_by do |node, _|
       node.label.split('.').map(&:to_i)
     end
   end
@@ -129,7 +127,7 @@ class Issue < Note
     issue_ids = [issue_ids] if issue_ids.is_a?(Integer)
 
     # check all specified ids are integers
-    return merged unless issue_ids.all?{|i| i.is_a? Integer}
+    return merged unless issue_ids.all? { |i| i.is_a? Integer }
 
     # assert current id is not there
     issue_ids -= [id]

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -10,6 +10,8 @@ class Issue < Note
 
   include Taggable
 
+  enum state: [:draft, :ready_for_review, :published]
+
   # -- Relationships --------------------------------------------------------
   has_many :evidence, dependent: :destroy
   has_many :affected, through: :evidence, source: :node

--- a/db/migrate/20230303080209_add_state_to_issues.rb
+++ b/db/migrate/20230303080209_add_state_to_issues.rb
@@ -1,0 +1,13 @@
+class AddStateToIssues < ActiveRecord::Migration[6.1]
+  def up
+    add_column :notes, :state, :integer, default: 0, null: false
+
+    Issue.transaction do
+      Issue.update_all(state: :published)
+    end
+  end
+
+  def down
+    remove_column :notes, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_202870) do
+ActiveRecord::Schema.define(version: 2023_03_03_080209) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2021_03_16_202870) do
     t.integer "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "state", default: 0, null: false
     t.index ["category_id"], name: "index_notes_on_category_id"
     t.index ["node_id"], name: "index_notes_on_node_id"
   end

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     author { "factory_bot" }
     category { Category.issue }
     node { Project.new.issue_library }
+    state { :published }
 
     trait :tagged_issue do
       after :create do |issue|

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :issue do
-    sequence(:text){ |n| "#[Title]#\nRspec multiple Apache bugs #{n}\n\n#[Description]#\nFoo" }
-    author { "factory_bot" }
+    sequence(:text) { |n| "#[Title]#\nRspec multiple Apache bugs #{n}\n\n#[Description]#\nFoo" }
+    author { 'factory_bot' }
     category { Category.issue }
     node { Project.new.issue_library }
     state { :published }


### PR DESCRIPTION
### Spec

We need to add the state column for issues and content blocks.

**Proposed solution**

- Implement a migration that adds the state column for issues and set the state as published for existing ones
- Implement a migration that adds the state column for content blocks and set the state as published for existing ones


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
