### PR TITLE
Access tokens - per-user secrets can now be stored securely in the DB

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 [v#.#.#] ([month] [YYYY])
-  - [entity]:
-    - [future tense verb] [feature]
+  - AccessTokens: allow the storage of per-user encrypted tokens
   - Sessions: Store :secret_key_base in encrypted configuration file
   - Upgraded gems:
     - rack, rails

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,7 +1,12 @@
 class AccessToken < ApplicationRecord
-  serialize :token, JSON
-  # Rails 7
+  include EncryptedColumn
+
+  # FIXME: Rails 7 can take care of serialization, for now we do this manually
+  # serialize :token, JSON
+
+  # FIXME: Rails 7
   # encrypts :token
+  encrypted_column :token
 
   # -- Relationships --------------------------------------------------------
   belongs_to :user

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,21 @@
+class AccessToken < ApplicationRecord
+  serialize :token, JSON
+  # Rails 7
+  # encrypts :token
+
+  # -- Relationships --------------------------------------------------------
+  belongs_to :user
+
+  # -- Callbacks ------------------------------------------------------------
+
+  # -- Validations ----------------------------------------------------------
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+  validates :token, presence: true
+  validates :user, presence: true, associated: true
+
+  # -- Scopes -----------------------------------------------------------------
+
+  # -- Class Methods ----------------------------------------------------------
+
+  # -- Instance Methods -------------------------------------------------------
+end

--- a/app/models/concerns/encrypted_column.rb
+++ b/app/models/concerns/encrypted_column.rb
@@ -1,0 +1,98 @@
+# This is a temporary wrapper to provide ActiveRecord Encryption from Rails 7.
+# After we bump to Rails 7 we can delete this file and replace all affected
+# columns with calls to .encrypt
+#
+# We'll also have to replace calls to #set_<column> and #get_<column> with
+# regular setters and getters, as ActiveRecord Encryption handles them
+# transparently.
+#
+# See:
+#   https://guides.rubyonrails.org/active_record_encryption.html
+#   https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/encryption/
+#
+#   ActiveRecord::Encryption::Cipher::Aes256Gcm
+#   ActiveRecord::Encryption::KeyGenerator
+#   ActiveRecord::Encryption::MessageSerializer
+
+module EncryptedColumn
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def encrypted_column(name)
+      serialize name, JSON
+
+      define_method "get_#{name}".to_sym do
+        value = send(name)
+        decrypt(value.with_indifferent_access ) unless value.nil?
+      end
+
+      define_method "set_#{name}".to_sym do |value|
+        send("#{name}=", encrypt(value))
+      end
+    end
+  end
+
+  private
+  CIPHER_TYPE = 'aes-256-gcm'.freeze
+
+  def encrypt(clear_text)
+    validate_keys!
+
+    cipher = OpenSSL::Cipher.new(CIPHER_TYPE)
+    cipher.encrypt
+    cipher.key = key
+    iv = cipher.random_iv
+    cipher.iv = iv
+
+    encrypted_data = clear_text.empty? ? clear_text.dup : cipher.update(clear_text)
+    encrypted_data << cipher.final
+
+    {
+      p: ::Base64::strict_encode64(encrypted_data),
+      h: {
+        iv: ::Base64::strict_encode64(iv),
+        at: ::Base64::strict_encode64(cipher.auth_tag)
+      }
+    }
+  end
+
+  def decrypt(encrypted_message)
+    validate_keys!
+
+    encrypted_data = ::Base64.strict_decode64(encrypted_message[:p])
+    iv = ::Base64.strict_decode64(encrypted_message[:h][:iv])
+    auth_tag = ::Base64.strict_decode64(encrypted_message[:h][:at])
+
+    # Currently the OpenSSL bindings do not raise an error if auth_tag is
+    # truncated, which would allow an attacker to easily forge it. See
+    # https://github.com/ruby/openssl/issues/63
+    raise Exception, 'Encrypted content integrity' if auth_tag.nil? || auth_tag.bytes.length != 16
+
+    cipher = OpenSSL::Cipher.new(CIPHER_TYPE)
+    cipher.decrypt
+    cipher.key = key
+    cipher.iv = iv
+
+    cipher.auth_tag = auth_tag
+    cipher.auth_data = ''
+
+    decrypted_data = encrypted_data.empty? ? encrypted_data : cipher.update(encrypted_data)
+    decrypted_data << cipher.final
+
+    decrypted_data
+  rescue OpenSSL::Cipher::CipherError, TypeError, ArgumentError
+    raise Errors, 'Decryption'
+  end
+
+  def key
+    @key ||= ActiveSupport::KeyGenerator
+      .new(Rails.application.credentials.dig(:active_record_encryption, :primary_key))
+      .generate_key(Rails.application.credentials.dig(:active_record_encryption, :key_derivation_salt), OpenSSL::Cipher.new(CIPHER_TYPE).key_len)
+  end
+
+  def validate_keys!
+    raise Errors::Configuration, ":deterministic_key is missing" unless Rails.application.credentials.dig(:active_record_encryption, :deterministic_key).present?
+    raise Errors::Configuration, ":key_derivation_salt is missing" unless Rails.application.credentials.dig(:active_record_encryption, :key_derivation_salt).present?
+    raise Errors::Configuration, ":primary_key is missing" unless Rails.application.credentials.dig(:active_record_encryption, :primary_key).present?
+  end
+end

--- a/app/models/concerns/encrypted_column.rb
+++ b/app/models/concerns/encrypted_column.rb
@@ -23,7 +23,7 @@ module EncryptedColumn
 
       define_method "get_#{name}".to_sym do
         value = send(name)
-        decrypt(value.with_indifferent_access ) unless value.nil?
+        decrypt(value.with_indifferent_access) unless value.nil?
       end
 
       define_method "set_#{name}".to_sym do |value|
@@ -91,8 +91,8 @@ module EncryptedColumn
   end
 
   def validate_keys!
-    raise Errors::Configuration, ":deterministic_key is missing" unless Rails.application.credentials.dig(:active_record_encryption, :deterministic_key).present?
-    raise Errors::Configuration, ":key_derivation_salt is missing" unless Rails.application.credentials.dig(:active_record_encryption, :key_derivation_salt).present?
-    raise Errors::Configuration, ":primary_key is missing" unless Rails.application.credentials.dig(:active_record_encryption, :primary_key).present?
+    raise Errors::Configuration, ':deterministic_key is missing' unless Rails.application.credentials.dig(:active_record_encryption, :deterministic_key).present?
+    raise Errors::Configuration, ':key_derivation_salt is missing' unless Rails.application.credentials.dig(:active_record_encryption, :key_derivation_salt).present?
+    raise Errors::Configuration, ':primary_key is missing' unless Rails.application.credentials.dig(:active_record_encryption, :primary_key).present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,13 +4,12 @@ class User < ApplicationRecord
   serialize :preferences, UserPreferences
   validates_associated :preferences
 
-  # -- Relationships ------------------------------------------------------------
+  # -- Relationships ----------------------------------------------------------
   has_many :access_tokens, dependent: :destroy
   has_many :activities
   has_many :comments, dependent: :nullify
   has_many :notifications, foreign_key: 'recipient_id', dependent: :destroy
   has_many :subscriptions, dependent: :destroy
-
 
   # -- Callbacks --------------------------------------------------------------
   # -- Validations ------------------------------------------------------------

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   serialize :preferences, UserPreferences
   validates_associated :preferences
 
-  # -- Relationships --------------------------------------------------------
+  # -- Relationships ------------------------------------------------------------
   has_many :access_tokens, dependent: :destroy
   has_many :activities
   has_many :comments, dependent: :nullify
@@ -12,16 +12,16 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
 
 
-  # -- Callbacks ------------------------------------------------------------
-  # -- Validations ----------------------------------------------------------
+  # -- Callbacks --------------------------------------------------------------
+  # -- Validations ------------------------------------------------------------
   validates :email,
     length: { maximum: DB_MAX_STRING_LENGTH },
     uniqueness: { allow_blank: false },
     presence: true
 
-  # -- Scopes ---------------------------------------------------------------
+  # -- Scopes -----------------------------------------------------------------
   scope :enabled, -> { all }
 
-  # -- Class Methods --------------------------------------------------------
-  # -- Instance Methods -----------------------------------------------------
+  # -- Class Methods ----------------------------------------------------------
+  # -- Instance Methods -------------------------------------------------------
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,17 +5,20 @@ class User < ApplicationRecord
   validates_associated :preferences
 
   # -- Relationships --------------------------------------------------------
+  has_many :access_tokens, dependent: :destroy
   has_many :activities
   has_many :comments, dependent: :nullify
   has_many :notifications, foreign_key: 'recipient_id', dependent: :destroy
   has_many :subscriptions, dependent: :destroy
 
-  validates :email,
-    length: { maximum: DB_MAX_STRING_LENGTH },
-    uniqueness: { allow_blank: false }
 
   # -- Callbacks ------------------------------------------------------------
   # -- Validations ----------------------------------------------------------
+  validates :email,
+    length: { maximum: DB_MAX_STRING_LENGTH },
+    uniqueness: { allow_blank: false },
+    presence: true
+
   # -- Scopes ---------------------------------------------------------------
   scope :enabled, -> { all }
 

--- a/db/migrate/20230321085555_create_access_tokens.rb
+++ b/db/migrate/20230321085555_create_access_tokens.rb
@@ -1,0 +1,11 @@
+class CreateAccessTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :access_tokens do |t|
+      t.string :name
+      t.text :token
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_202870) do
+ActiveRecord::Schema.define(version: 2023_03_21_085555) do
+
+  create_table "access_tokens", force: :cascade do |t|
+    t.string "name"
+    t.text "token"
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_access_tokens_on_user_id"
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -221,6 +230,7 @@ ActiveRecord::Schema.define(version: 2021_03_16_202870) do
     t.index ["project_id"], name: "index_versions_on_project_id"
   end
 
+  add_foreign_key "access_tokens", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "boards", "nodes", on_delete: :cascade

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AccessToken, type: :model do
+  subject { AccessToken.new(user: FactoryBot.create(:user)) }
+
+  it { should belong_to :user }
+
+  it { should validate_presence_of :name }
+  it { should validate_presence_of :token }
+  it { should validate_presence_of :user }
+
+  it { should validate_uniqueness_of(:name).scoped_to(:user_id) }
+end


### PR DESCRIPTION
### Summary

AccessTokens allow integrations to store access tokens (e.g. OAuth, PATs, etc.) securely encrypted in the DB.

This PR adds the AccessToken model and also backports the key components of [ActiveRecord Encryption](https://edgeguides.rubyonrails.org/active_record_encryption.html) from Rails 7.


### Check List

- [x] Added a CHANGELOG entry
