### PR TITLE
QA export all

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -211,7 +211,7 @@ end
 #
 
 # Base framework classes required by other plugins
-gem 'dradis-plugins', github: 'dradis/dradis-plugins', branch: 'qa-feature'
+gem 'dradis-plugins', github: 'dradis/dradis-plugins', branch: 'qa-export-all'
 
 gem 'dradis-api', path: 'engines/dradis-api'
 

--- a/Gemfile
+++ b/Gemfile
@@ -211,7 +211,7 @@ end
 #
 
 # Base framework classes required by other plugins
-gem 'dradis-plugins', github: 'dradis/dradis-plugins', branch: 'qa-export-all'
+gem 'dradis-plugins', github: 'dradis/dradis-plugins', branch: 'qa-feature'
 
 gem 'dradis-api', path: 'engines/dradis-api'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/dradis/dradis-plugins.git
-  revision: 5505010dfa3c625e86641ffbe4a15a52a8c65f45
-  branch: qa-export-all
+  revision: 8b39422a7b275952e7bdeb7d171726ae0e50c405
+  branch: qa-feature
   specs:
     dradis-plugins (4.7.0)
 
 GIT
   remote: https://github.com/dradis/dradis-projects.git
-  revision: 718f0d4787aa28637da9a3e31c778e85fa307abb
+  revision: d8c7e94fe405210dfd8737fb1d8004c6e93ce101
   branch: qa-feature
   specs:
     dradis-projects (4.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/dradis/dradis-plugins.git
-  revision: 3e7677d309fff8044e3a3c154f80dd91d56b3b5b
-  branch: qa-feature
+  revision: 5505010dfa3c625e86641ffbe4a15a52a8c65f45
+  branch: qa-export-all
   specs:
     dradis-plugins (4.7.0)
 

--- a/app/assets/javascripts/tylium/modules/state_button.js
+++ b/app/assets/javascripts/tylium/modules/state_button.js
@@ -1,6 +1,6 @@
 document.addEventListener('turbolinks:load', function () {
   if ($('[data-behavior~=state-radio]').length) {
-    function updateBtnText($selectedRadio) {
+    function updateBtn($selectedRadio) {
       var selectedState = $selectedRadio
         .parent()
         .find('[data-behavior~=state-label]');
@@ -14,7 +14,7 @@ document.addEventListener('turbolinks:load', function () {
     }
 
     $('[data-behavior~=state-radio]').on('change', function () {
-      updateBtnText($(this));
+      updateBtn($(this));
     });
   }
 });

--- a/app/assets/javascripts/tylium/modules/state_button.js
+++ b/app/assets/javascripts/tylium/modules/state_button.js
@@ -1,13 +1,17 @@
 document.addEventListener('turbolinks:load', function () {
   if ($('[data-behavior~=state-radio]').length) {
     function updateBtnText($selectedRadio) {
-      selectedState = $selectedRadio
+      var selectedState = $selectedRadio
         .parent()
         .find('[data-behavior~=state-label]');
-      $('[data-behavior~=state-button]').text(selectedState.text());
-    }
 
-    updateBtnText($('[data-behavior~=state-radio]:checked'));
+      var $stateBtn = $selectedRadio
+        .closest('[data-behavior~=btn-states]')
+        .find('[data-behavior~=state-button]');
+
+      $stateBtn.text(selectedState.text());
+      $stateBtn.parent().attr('data-state', $selectedRadio.val());
+    }
 
     $('[data-behavior~=state-radio]').on('change', function () {
       updateBtnText($(this));

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -103,9 +103,9 @@ class ExportController < AuthenticatedController
   def validate_scope
     return if @exporter.to_s.include?('::Projects')
 
-    if params[:scope] == 'all' || params[:scope] == 'published'
-      @scope = params[:scope]
-    else
+    @scope = params[@exporter::Engine::plugin_name.to_s][:scope]
+
+    unless @scope == 'all' || @scope == 'published'
       redirect_to project_export_manager_path(current_project), alert: 'Something fishy is going on...'
     end
   end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -42,7 +42,7 @@ class ExportController < AuthenticatedController
   def validation_status
     @log_uid = params[:log_uid].to_i
     @job_id  = params[:job_id]
-    @logs    = Log.where("uid = ? and id > ?", @log_uid, params[:after].to_i)
+    @logs    = Log.where('uid = ? and id > ?', @log_uid, params[:after].to_i)
 
     status = Resque::Plugins::Status::Hash.get(@job_id)
     render json: status.reverse_merge({
@@ -58,8 +58,8 @@ class ExportController < AuthenticatedController
   def find_plugins
     @plugins = Dradis::Plugins::with_feature(:export).collect do |plugin|
       path = plugin.to_s
-      path[0..path.rindex('::')-1].constantize
-    end.sort{|a,b| a.name <=> b.name }
+      path[0..path.rindex('::') - 1].constantize
+    end.sort { |a, b| a.name <=> b.name }
   end
 
   # In case something goes wrong with the export, fail graciously instead of
@@ -69,7 +69,7 @@ class ExportController < AuthenticatedController
     redirect_to project_upload_manager_path(current_project)
   end
 
-  def templates_dir_for(args={})
+  def templates_dir_for(args = {})
     plugin = args[:plugin]
     File.join(::Configuration::paths_templates_reports, plugin::Engine.plugin_name.to_s)
   end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -12,7 +12,7 @@ class ExportController < AuthenticatedController
   def create
     # FIXME: check the Routing guide to find a better way.
     action_path = "#{params[:route]}_path"
-    redirect_to eval(@exporter::Engine::engine_name).send(
+    redirect_to send(@exporter::Engine::engine_name).send(
       action_path,
       project_id: current_project.id,
       scope: @scope,
@@ -98,9 +98,8 @@ class ExportController < AuthenticatedController
   end
 
   def validate_scope
-    return if @exporter.to_s.include?('::Projects')
-
-    @scope = params[@exporter::Engine::plugin_name.to_s][:scope]
+    @scope =
+      params.fetch(@exporter::Engine::plugin_name.to_s, { scope: 'published' })[:scope]
 
     unless Dradis::Plugins::ContentService::Base::VALID_SCOPES.include?(@scope)
       redirect_to project_export_manager_path(current_project), alert: 'Something fishy is going on...'

--- a/app/controllers/upload_controller.rb
+++ b/app/controllers/upload_controller.rb
@@ -118,9 +118,9 @@ class UploadController < AuthenticatedController
   end
 
   def validate_state
-    if Issue.states.keys.include?(params[:state]) ||
-        (@uploader.to_s.include?('::Projects') && params[:state].nil?)
+    return if @uploader.to_s.include?('::Projects')
 
+    if Issue.states.keys.include?(params[:state])
       @state = params[:state]
     else
       redirect_to project_upload_manager_path(current_project), alert: 'Something fishy is going on...'

--- a/app/views/export/_submit_button.html.erb
+++ b/app/views/export/_submit_button.html.erb
@@ -1,4 +1,4 @@
-<div class="btn-group btn-states mt-4" data-behavior="btn-states">
+<div class="btn-group btn-states" data-behavior="btn-states">
   <button id="export-button" class="btn btn-lg btn-primary">Export <span data-behavior="state-button">Published</span> Records</button>
   <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <span class="sr-only">Toggle Dropdown</span>

--- a/app/views/export/_submit_button.html.erb
+++ b/app/views/export/_submit_button.html.erb
@@ -1,0 +1,25 @@
+<div class="btn-group btn-states mt-4" data-behavior="btn-states">
+  <button id="export-button" class="btn btn-lg btn-primary">Export <span data-behavior="state-button">Published</span> Records</button>
+  <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="sr-only">Toggle Dropdown</span>
+  </button>
+  <div class="dropdown-menu">
+    <%= collection_radio_buttons(plugin_name, :scope, [['published', 'published'], ['all', 'all']], :first, :first) do |b| %>
+      <span>
+        <%= b.label class: 'state' do %>
+          <%= b.radio_button class: 'd-none', data: { behavior: 'state-radio'}, checked: b.value == 'published' %>
+          <i class="fa fa-check fa-fw"></i>
+          <div class="state-label">
+            <p data-behavior="state-label"><%= b.text.humanize %></p>
+            <% case b.value %>
+            <% when 'published' %>
+            <span>Only records that have been reviewed and published.</span>
+            <% when 'all' %>
+            <span>All records, regardless if they are draft, ready for review, or published.</span>
+            <% end %>
+          </div>
+        <% end %>
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -116,29 +116,6 @@
       "note": "False positive: Attachment.pwd is set by the admin to specify the directory for the attachments"
     },
     {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "5b341c9edb2f75700ba8102f481ac63faae79d3b13cdf0cb1ecdfe230fd46cb7",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/controllers/export_controller.rb",
-      "line": 23,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\", :scope => params[valid_exporters[params[:plugin]]::Engine.plugin_name.to_s][:scope])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ExportController",
-        "method": "create"
-      },
-      "user_input": "params[:route]",
-      "confidence": "High",
-      "cwe_id": [
-        77
-      ],
-      "note": "False positive: There are no routes in engines with _path that is destructive"
-    },
-    {
       "warning_type": "Denial of Service",
       "warning_code": 76,
       "fingerprint": "6f64eb88c9651a86dbf00fca38c6c78c4be01606919636ff1e1b2f8043fc360a",
@@ -210,13 +187,36 @@
       "note": "False positive: Attachment.pwd is set by the admin to specify the directory for the attachments"
     },
     {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "bbacf533907f89d7f15f542afc395a5939369037c2d80e3bd57d3dbddda0c387",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/export_controller.rb",
+      "line": 16,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\", :project_id => current_project.id, :scope => params[valid_exporters[params[:plugin]]::Engine.plugin_name.to_s][:scope], :template => File.expand_path(File.join(templates_dir_for(:plugin => valid_exporters[params[:plugin]]), params[:template])))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ExportController",
+        "method": "create"
+      },
+      "user_input": "params[:route]",
+      "confidence": "High",
+      "cwe_id": [
+        77
+      ],
+      "note": "False positive: There are no routes in engines with _path that is destructive"
+    },
+    {
       "warning_type": "Dangerous Eval",
       "warning_code": 13,
       "fingerprint": "bfab1d02061750dba3cb5c11af62323693ca1670dd58f0a0583845134c1eca78",
       "check_name": "Evaluation",
       "message": "User input in eval",
       "file": "app/controllers/export_controller.rb",
-      "line": 23,
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
       "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name)",
       "render_path": null,
@@ -314,6 +314,6 @@
       "note": "False positive: The params is used to fetch the boards and cannot be manipulated by user input"
     }
   ],
-  "updated": "2023-03-24 20:01:55 +0800",
+  "updated": "2023-03-29 17:30:02 +0800",
   "brakeman_version": "5.4.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -187,53 +187,6 @@
       "note": "False positive: Attachment.pwd is set by the admin to specify the directory for the attachments"
     },
     {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "bbacf533907f89d7f15f542afc395a5939369037c2d80e3bd57d3dbddda0c387",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/controllers/export_controller.rb",
-      "line": 16,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\", :project_id => current_project.id, :scope => params[valid_exporters[params[:plugin]]::Engine.plugin_name.to_s][:scope], :template => File.expand_path(File.join(templates_dir_for(:plugin => valid_exporters[params[:plugin]]), params[:template])))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ExportController",
-        "method": "create"
-      },
-      "user_input": "params[:route]",
-      "confidence": "High",
-      "cwe_id": [
-        77
-      ],
-      "note": "False positive: There are no routes in engines with _path that is destructive"
-    },
-    {
-      "warning_type": "Dangerous Eval",
-      "warning_code": 13,
-      "fingerprint": "bfab1d02061750dba3cb5c11af62323693ca1670dd58f0a0583845134c1eca78",
-      "check_name": "Evaluation",
-      "message": "User input in eval",
-      "file": "app/controllers/export_controller.rb",
-      "line": 15,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
-      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ExportController",
-        "method": "create"
-      },
-      "user_input": "params[:plugin]",
-      "confidence": "High",
-      "cwe_id": [
-        913,
-        95
-      ],
-      "note": "False positive: params[:plugin] here is being validated in the controller"
-    },
-    {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
       "fingerprint": "d3a81096726714c53976f61643ecb37f04b12e15ce5b923e21f9aec989d9f69d",
@@ -314,6 +267,6 @@
       "note": "False positive: The params is used to fetch the boards and cannot be manipulated by user input"
     }
   ],
-  "updated": "2023-03-29 17:30:02 +0800",
+  "updated": "2023-03-30 20:21:19 +0800",
   "brakeman_version": "5.4.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -116,6 +116,29 @@
       "note": "False positive: Attachment.pwd is set by the admin to specify the directory for the attachments"
     },
     {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "5b341c9edb2f75700ba8102f481ac63faae79d3b13cdf0cb1ecdfe230fd46cb7",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/export_controller.rb",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\", :scope => params[valid_exporters[params[:plugin]]::Engine.plugin_name.to_s][:scope])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ExportController",
+        "method": "create"
+      },
+      "user_input": "params[:route]",
+      "confidence": "High",
+      "cwe_id": [
+        77
+      ],
+      "note": "False positive: There are no routes in engines with _path that is destructive"
+    },
+    {
       "warning_type": "Denial of Service",
       "warning_code": 76,
       "fingerprint": "6f64eb88c9651a86dbf00fca38c6c78c4be01606919636ff1e1b2f8043fc360a",
@@ -234,29 +257,6 @@
       "note": "False positive: params[:uploader] here is being validated in the controller"
     },
     {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "d5ae0d28647fcb3472e4f29674fdd3379b9668dbdb4a4af15ffecfdb846c3b85",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/controllers/export_controller.rb",
-      "line": 23,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\", :scope => params[:scope])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ExportController",
-        "method": "create"
-      },
-      "user_input": "params[:route]",
-      "confidence": "High",
-      "cwe_id": [
-        77
-      ],
-      "note": "False positive: There are no routes in engines with \\\"_path\\\" that is destructive"
-    },
-    {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
       "fingerprint": "d770dd85f99cd870dfc8bdd9723722b31d84135f55133cf2907dff47b854c98d",
@@ -314,6 +314,6 @@
       "note": "False positive: The params is used to fetch the boards and cannot be manipulated by user input"
     }
   ],
-  "updated": "2023-03-23 16:07:28 +0800",
+  "updated": "2023-03-24 20:01:55 +0800",
   "brakeman_version": "5.4.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -140,29 +140,6 @@
       "note": "False positive: Attachment.pwd is set by the admin to specify the directory for the attachments"
     },
     {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "71724a8ebcbb13ab74d4e57240838b3d42c19cf55743cd5d2b6cfdefef1a3dc9",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/controllers/export_controller.rb",
-      "line": 22,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ExportController",
-        "method": "create"
-      },
-      "user_input": "params[:route]",
-      "confidence": "High",
-      "cwe_id": [
-        77
-      ],
-      "note": "False positive: There are no routes in engines with \"_path\" that is destructive"
-    },
-    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "7ada3bdeb90b2dc5426fa0256610c44d5c3ac233e029fa4af5c705fb5741d14d",
@@ -216,7 +193,7 @@
       "check_name": "Evaluation",
       "message": "User input in eval",
       "file": "app/controllers/export_controller.rb",
-      "line": 22,
+      "line": 23,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
       "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name)",
       "render_path": null,
@@ -240,7 +217,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called on parameter value",
       "file": "app/controllers/upload_controller.rb",
-      "line": 123,
+      "line": 136,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "params[:uploader].constantize",
       "render_path": null,
@@ -255,6 +232,29 @@
         470
       ],
       "note": "False positive: params[:uploader] here is being validated in the controller"
+    },
+    {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "d5ae0d28647fcb3472e4f29674fdd3379b9668dbdb4a4af15ffecfdb846c3b85",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/export_controller.rb",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "eval(valid_exporters[params[:plugin]]::Engine.engine_name).send(\"#{params[:route]}_path\", :scope => params[:scope])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ExportController",
+        "method": "create"
+      },
+      "user_input": "params[:route]",
+      "confidence": "High",
+      "cwe_id": [
+        77
+      ],
+      "note": "False positive: There are no routes in engines with \\\"_path\\\" that is destructive"
     },
     {
       "warning_type": "Remote Code Execution",
@@ -314,6 +314,6 @@
       "note": "False positive: The params is used to fetch the boards and cannot be manipulated by user input"
     }
   ],
-  "updated": "2022-11-24 15:12:55 +0100",
+  "updated": "2023-03-23 16:07:28 +0800",
   "brakeman_version": "5.4.0"
 }

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -12,7 +12,7 @@ describe 'upload requests' do
 
   describe 'POST #parse' do
     let(:uploader) { 'Dradis::Plugins::Projects::Upload::Template' }
-    let(:state) { 'published' }
+    let(:state) { nil }
     let(:send_request) do
       post project_upload_parse_path(@project), params: {
         file: 'temp',


### PR DESCRIPTION
### Spec
We need a way for users to export all records regardless if they are set to published or not

**Proposed solution**

- In the export view, split the export button to support exporting all records or just published records (default)
- Pass the selected scope to the exporter
- In the content service, return all/published records depending on the passed scope


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
