### PR TITLE
Bump time gem > 0.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Upgraded gems: time (CVE-2023-28756)
 
 v4.7.0 (February 2023)
   - Rubocop CI:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 v4.8.0 (April 2023)
   - Quality Assurance: Review/approve Issues and Content Blocks before including them in reports
   - Upgraded gems:
-    - rack, rails
+    - rack, rails, time
 
 v4.7.0 (February 2023)
   - Rubocop CI:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - rack, rails
+    - rack, rails, time
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]
@@ -25,7 +25,6 @@
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
-    - Upgraded gems: time (CVE-2023-28756)
 
 v4.7.0 (February 2023)
   - Rubocop CI:

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'rubyzip', '>= 1.2.2'
 
 gem 'thor', '~> 1.2.1'
 
+# Ruby dependency, version specified here due to CVE-2023-28756
 gem 'time', '>= 0.2.2'
 
 # ------------------------------------------------------ With native extensions

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ gem 'rubyzip', '>= 1.2.2'
 
 gem 'thor', '~> 1.2.1'
 
+gem 'time', '>= 0.2.2'
+
 # ------------------------------------------------------ With native extensions
 # These require native extensions.
 # Ensure Traveling Ruby provides an appropriate version before bumping.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,6 +462,8 @@ GEM
     sqlite3 (1.4.2)
     thor (1.2.1)
     tilt (2.0.11)
+    time (0.2.2)
+      date
     timecop (0.9.5)
     timeout (0.3.2)
     turbolinks (5.2.1)
@@ -591,6 +593,7 @@ DEPENDENCIES
   spring
   sqlite3
   thor (~> 1.2.1)
+  time (>= 0.2.2)
   timecop
   turbolinks (~> 5)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
### Summary

Bump time gem to resolve [CVE-2023-28756](https://www.ruby-lang.org/en/news/2023/03/30/redos-in-time-cve-2023-28756/)


### Check List

- [x] Added a CHANGELOG entry
