### PR TITLE
Fix QA redirect after changing state in QA Edit views

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - QA: Redirect to correct view when changing states on QA edit views
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -85,7 +85,12 @@ class IssuesController < AuthenticatedController
         check_for_edit_conflicts(@issue, updated_at_before_save)
         track_updated(@issue)
         format.html do
-          redirect_to_target_or_default project_issue_path(current_project, @issue), notice: 'Issue updated.'
+          default_path = project_issue_path(current_project, @issue)
+          if session[:return_to] == project_qa_issue_url(current_project, @issue) && !@issue.ready_for_review?
+            default_path = project_qa_issues_path(current_project)
+            session[:return_to] = nil
+          end
+          redirect_to_target_or_default default_path, notice: 'Issue updated.'
         end
       else
         format.html do

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -85,12 +85,12 @@ class IssuesController < AuthenticatedController
         check_for_edit_conflicts(@issue, updated_at_before_save)
         track_updated(@issue)
         format.html do
-          default_path = project_issue_path(current_project, @issue)
-          if session[:return_to] == project_qa_issue_url(current_project, @issue) && !@issue.ready_for_review?
-            default_path = project_qa_issues_path(current_project)
-            session[:return_to] = nil
+          if session[:return_to] == project_qa_issue_url(current_project, @issue)
+            # State changed. No longer needs QA
+            session[:return_to] = project_qa_issues_path(current_project) unless @issue.ready_for_review?
           end
-          redirect_to_target_or_default default_path, notice: 'Issue updated.'
+
+          redirect_to_target_or_default project_issue_path(current_project, @issue), notice: 'Issue updated.'
         end
       else
         format.html do

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -3,16 +3,19 @@ class QA::IssuesController < AuthenticatedController
   include ProjectScoped
 
   before_action :set_issues
-  before_action :set_issue, only: [:edit, :show, :update]
+  before_action :set_issue, only: [:edit, :update]
   before_action :store_location, only: [:index, :show]
   before_action :validate_state, only: [:multiple_update, :update]
 
   def index
-    @issues = current_project.issues.ready_for_review
     @all_columns = @default_columns = ['Title']
   end
 
-  def show; end
+  def show
+    @issue = current_project.issues.find(params[:id])
+
+    redirect_to project_qa_issues_path(current_project) unless @issue.ready_for_review?
+  end
 
   def edit
     @form_cancel_path = project_qa_issue_path(current_project, @issue)

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -3,7 +3,7 @@ class QA::IssuesController < AuthenticatedController
   include ProjectScoped
 
   before_action :set_issues
-  before_action :set_issue, only: [:edit, :update]
+  before_action :set_issue, only: [:edit, :show, :update]
   before_action :store_location, only: [:index, :show]
   before_action :validate_state, only: [:multiple_update, :update]
 
@@ -11,11 +11,7 @@ class QA::IssuesController < AuthenticatedController
     @all_columns = @default_columns = ['Title']
   end
 
-  def show
-    @issue = current_project.issues.find(params[:id])
-
-    redirect_to project_qa_issues_path(current_project) unless @issue.ready_for_review?
-  end
+  def show; end
 
   def edit
     @form_cancel_path = project_qa_issue_path(current_project, @issue)

--- a/spec/support/qa_shared_examples.rb
+++ b/spec/support/qa_shared_examples.rb
@@ -12,7 +12,7 @@ shared_examples 'qa pages' do |item_type|
       end
     end
 
-    it 'redirects the user back after updating the record' do
+    it 'redirects the user back to #index after updating the record' do
       find('.dataTable tbody tr:first-of-type').hover
       click_link 'Edit'
 
@@ -99,7 +99,7 @@ shared_examples 'qa pages' do |item_type|
       end
     end
 
-    it 'redirects the user back after updating the record' do
+    it 'redirects the user back to #show after updating the record' do
       expect(current_path).to eq polymorphic_path([:edit, current_project, :qa, records.first])
 
       click_button "Update #{item_type.to_s.titleize}"
@@ -108,12 +108,24 @@ shared_examples 'qa pages' do |item_type|
       expect(page).to have_selector('.alert-success', text: "#{item_type.to_s.humanize} updated.")
     end
 
-    it 'redirects the user back after cancelling' do
+    it 'redirects the user back to #show after cancelling' do
       expect(current_path).to eq polymorphic_path([:edit, current_project, :qa, records.first])
 
       click_link 'Cancel'
 
       expect(current_path).to eq polymorphic_path([current_project, :qa, records.first])
+    end
+
+    it 'redirects the user to #index after a state change' do
+      expect(current_path).to eq polymorphic_path([:edit, current_project, :qa, records.first])
+
+      click_button 'Toggle Dropdown'
+      choose "#{item_type}_state_published"
+
+      click_button "Update #{item_type.to_s.titleize}"
+
+      expect(current_path).to eq polymorphic_path([current_project, :qa, item_type.to_s.pluralize.to_sym])
+      expect(page).to have_selector('.alert-success', text: "#{item_type.to_s.humanize} updated.")
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR fixes a bug where users got a 500 after changing a record's state from the QA #edit view.

### Check List

- [x] Added a CHANGELOG entry
