### PR TITLE
Fix Boards Factory - associate with the right project

### DIFF
--- a/spec/factories/boards.rb
+++ b/spec/factories/boards.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :board do
-    sequence(:name){ |n| "Board-#{n}" }
+    sequence(:name) { |n| "Board-#{n}" }
     association :project
 
     after(:build) do |board|

--- a/spec/factories/boards.rb
+++ b/spec/factories/boards.rb
@@ -1,8 +1,10 @@
 FactoryBot.define do
   factory :board do
     sequence(:name){ |n| "Board-#{n}" }
-    node { create(:project).methodology_library }
-
     association :project
+
+    after(:build) do |board|
+      board.node = board.project.methodology_library unless board.node.present?
+    end
   end
 end

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -20,7 +20,7 @@ describe Card do
 
   describe 'on create' do
     it 'subscribes new assignees' do
-      new_card = build(:card, assignee_ids: create_list(:user, 2).map(&:id))
+      new_card = build(:card, assignee_ids: create_list(:user, 2).map(&:id), list: @parent)
       expect { new_card.save }.to change {
         Subscription.count
       }.by(2)

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Card do
   it { should belong_to(:list).touch(true) }
-  it { should have_and_belong_to_many(:assignees).class_name("User") }
+  it { should have_and_belong_to_many(:assignees).class_name('User') }
   it { should have_many(:comments).dependent(:destroy) }
 
   it { should validate_length_of(:description).is_at_most(DB_MAX_TEXT_LENGTH) }


### PR DESCRIPTION
Before this PR, a Board created via the factory could end up associated with a Node in a different project. We used create(:project) inside the node association which was independent from the board's own :project association.

By using an after-build callback we can ensure that the node belongs to the same project already setup via the :project association.

We guard this assignment to allow the caller to specify a different node (e.g. a host in the project).


### Check List

- [x] Added a CHANGELOG entry

Internal spec refactor, inclined to skip the CHANGELOG.