### PR TITLE
Fix export tabs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
+    - Export: Show first tab if no other tabs are shown on page load
     - QA: Enable @mentions and formatting toolbar for comments in QA show views
     - [entity]:
       - [future tense verb] [bug fix]

--- a/app/assets/javascripts/tylium/modules/export.js.coffee
+++ b/app/assets/javascripts/tylium/modules/export.js.coffee
@@ -11,3 +11,8 @@ document.addEventListener "turbolinks:load", ->
       $form.attr('action', $action.val())
       # $action.remove()
       $form.submit()
+
+  if !$('[data-bs-toggle~=tab].active').length
+    firstTab = $('[data-bs-toggle~=tab]:first')[0]
+    new (bootstrap.Tab)(firstTab)
+    bootstrap.Tab.getInstance(firstTab).show()


### PR DESCRIPTION
### Summary

In Export Manager, show the first tab on page load, if no other tabs are shown.

### Check List

- [x] Added a CHANGELOG entry
