### PR TITLE
use hotfix version of dradis-html_export

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
+    - Export: Show first tab if no other tabs are shown on page load
     - QA: Enable @mentions and formatting toolbar for comments in QA show views
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile
+++ b/Gemfile
@@ -235,7 +235,7 @@ gem 'dradis-calculator_dread', '~> 4.9.0'
 
 # ---------------------------------------------------------------------- Export
 gem 'dradis-csv_export', '~> 4.9.0'
-gem 'dradis-html_export', '~> 4.9.0'
+gem 'dradis-html_export', '~> 4.9'
 
 # ---------------------------------------------------------------------- Import
 gem 'dradis-csv', '~> 4.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,7 +529,7 @@ DEPENDENCIES
   dradis-coreimpact (~> 4.9.0)
   dradis-csv (~> 4.9.0)
   dradis-csv_export (~> 4.9.0)
-  dradis-html_export (~> 4.9.0)
+  dradis-html_export (~> 4.9)
   dradis-metasploit (~> 4.9.0)
   dradis-nessus (~> 4.9.0)
   dradis-netsparker (~> 4.9.0)

--- a/app/assets/javascripts/tylium/modules/export.js.coffee
+++ b/app/assets/javascripts/tylium/modules/export.js.coffee
@@ -11,3 +11,8 @@ document.addEventListener "turbolinks:load", ->
       $form.attr('action', $action.val())
       # $action.remove()
       $form.submit()
+
+  if !$('[data-bs-toggle~=tab].active').length
+    firstTab = $('[data-bs-toggle~=tab]:first')[0]
+    new (bootstrap.Tab)(firstTab)
+    bootstrap.Tab.getInstance(firstTab).show()


### PR DESCRIPTION
### Summary

A change was added to dradis-html_export to enable the correct tabs in the export view. This PR updates the gemfile to use the new version

### Check List

~- [ ] Added a CHANGELOG entry~
