### PR TITLE
Remove validation code from export controller and routes

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -20,35 +20,6 @@ class ExportController < AuthenticatedController
     )
   end
 
-  # Runs a pre-export validation of the contents of the project
-  def validate
-    @validators = Dradis::Pro::Plugins::Export::Validators::BaseValidator.descendants
-
-    logger = Log.new
-    @log_uid = logger.uid
-
-    @job_id = ProjectValidator.create(
-      plugin: AdvancedWordExport.name,
-      template: params[:template],
-      uid: @log_uid
-    )
-
-    logger.write("Enqueueing pre-export validation job to start in the background. Job id is #{ @log_uid }")
-  end
-
-  def validation_status
-    @log_uid = params[:log_uid].to_i
-    @job_id  = params[:job_id]
-    @logs    = Log.where('uid = ? and id > ?', @log_uid, params[:after].to_i)
-
-    status = Resque::Plugins::Status::Hash.get(@job_id)
-    render json: status.reverse_merge({
-      logs: @logs,
-      validating: nil,
-      validators: []
-    }).to_json(root: false)
-  end
-
   private
 
   # The list of available Export plugins. See the dradis_plugins gem.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,8 +111,6 @@ Rails.application.routes.draw do
     # ------------------------------------------------------- Export Manager
     get  '/export'                   => 'export#index',             as: :export_manager
     post '/export'                   => 'export#create'
-    get  '/export/validate'          => 'export#validate',          as: :validate_export
-    get  '/export/validation_status' => 'export#validation_status', as: :validation_status
 
     # ------------------------------------------------------- Upload Manager
     get  '/upload'        => 'upload#index',  as: :upload_manager


### PR DESCRIPTION
### Summary
There is unused word engine validation code in export_controller. This PR removes it and the associated routes

### Check List

- [ ] Added a CHANGELOG entry
