### PR TITLE
Set chrome webdriver version

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -10,7 +10,6 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'paper_trail/frameworks/rspec'
 require 'shoulda/matchers'
-
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -26,7 +25,7 @@ require 'shoulda/matchers'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-["", "engines/**/"].each do |dir|
+['', 'engines/**/'].each do |dir|
   Dir[Rails.root.join("#{dir}spec/support/**/*.rb")].each { |f| require f }
 end
 
@@ -85,7 +84,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   # config.include WaitForAjax, type: :feature
 
-  config.example_status_persistence_file_path = Rails.root.join("spec", ".examples.txt")
+  config.example_status_persistence_file_path = Rails.root.join('spec', '.examples.txt')
 
   config.before(:suite) do
     begin

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ end
 Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :chrome
 
+Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
### Summary

Rspec is erroring with:

```
Webdrivers::VersionError:
         Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: 
```

This change locks the chromedriver to a known working version version so that we do not run into this error

### Check List

- [ ] Added a CHANGELOG entry
