### PR TITLE
Bump selenium-webdriver and remove webdrivers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 [v#.#.#] ([month] [YYYY])
   - Tylium: Consolidate sidebars
   - Upgraded gems:
-    - font-awesome-sass, nokogiri, rails, sanitize
+    - font-awesome-sass, nokogiri, rails, sanitize, webdrivers
   - Bugs fixes:
     - QA: Enable @mentions and formatting toolbar for comments in QA show views
     - [entity]:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 [v#.#.#] ([month] [YYYY])
   - Tylium: Consolidate sidebars
   - Upgraded gems:
-    - font-awesome-sass, nokogiri, puma, rails, sanitize, webdrivers
+    - font-awesome-sass, nokogiri, puma, rails, sanitize, selenium-webdriver
   - Bugs fixes:
     - QA: Enable @mentions and formatting toolbar for comments in QA show views
     - [entity]:

--- a/Gemfile
+++ b/Gemfile
@@ -190,7 +190,7 @@ end
 group :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'capybara', '>= 3.26'
+  gem 'capybara', '~> 3.35.1'
   gem 'guard-rspec', require: false
   gem 'selenium-webdriver', '~> 4.11'
   gem 'shoulda-matchers', '~> 3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -195,7 +195,6 @@ group :test do
   gem 'selenium-webdriver', '~> 4.11'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'timecop'
-  # gem 'webdrivers', '~> 5.3.1'
 
   # Required by capybara
   gem 'matrix'

--- a/Gemfile
+++ b/Gemfile
@@ -192,10 +192,10 @@ group :test do
   gem 'factory_bot_rails'
   gem 'capybara', '>= 3.26'
   gem 'guard-rspec', require: false
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '~> 4.11'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'timecop'
-  gem 'webdrivers', '~> 5.3.1'
+  # gem 'webdrivers', '~> 5.3.1'
 
   # Required by capybara
   gem 'matrix'

--- a/Gemfile
+++ b/Gemfile
@@ -195,7 +195,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'timecop'
-  gem 'webdrivers'
+  gem 'webdrivers', '~> 5.3.1'
 
   # Required by capybara
   gem 'matrix'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -500,10 +500,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -602,7 +598,7 @@ DEPENDENCIES
   rubyzip (>= 1.2.2)
   sanitize (= 6.0.2)
   sass-rails (~> 6.0)
-  selenium-webdriver
+  selenium-webdriver (~> 4.11)
   shoulda-matchers (~> 3.1)
   simple_form
   sinatra (~> 2.2.3)
@@ -616,11 +612,10 @@ DEPENDENCIES
   unicorn (= 6.1.0)
   warden (~> 1.2.3)
   web-console (>= 4.1.0)
-  webdrivers (~> 5.3.1)
   whenever
 
 RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.11
+   2.3.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,15 +104,15 @@ GEM
       thor (~> 1.0)
     byebug (11.1.1)
     cancancan (1.17.0)
-    capybara (3.35.3)
+    capybara (3.39.2)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (3.0.0)
     chronic (0.10.2)
     coderay (1.1.2)
     coffee-rails (5.0.0)
@@ -450,9 +450,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shellany (0.0.1)
     shoulda-matchers (3.1.3)
       activesupport (>= 4.0.0)
@@ -499,11 +500,12 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.2.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
-    websocket-driver (0.7.5)
+      selenium-webdriver (~> 4.0, < 4.11)
+    websocket (1.2.9)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     whenever (1.0.0)
@@ -614,7 +616,7 @@ DEPENDENCIES
   unicorn (= 6.1.0)
   warden (~> 1.2.3)
   web-console (>= 4.1.0)
-  webdrivers
+  webdrivers (~> 5.3.1)
   whenever
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,9 +104,8 @@ GEM
       thor (~> 1.0)
     byebug (11.1.1)
     cancancan (1.17.0)
-    capybara (3.39.2)
+    capybara (3.35.3)
       addressable
-      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
@@ -527,7 +526,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   cancancan (~> 1.10)
-  capybara (>= 3.26)
+  capybara (~> 3.35.1)
   coffee-rails (~> 5.0)
   database_cleaner
   differ (~> 0.1.2)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,7 +43,7 @@ end
 Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :chrome
 
-Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+# Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,8 +43,6 @@ end
 Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :chrome
 
-# Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ end
 
 Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :chrome
+Selenium::WebDriver.logger
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
### Summary

Since Chrome released version 116.0.5845.6, GH actions was [unable to find the correct Chromedriver version](https://github.com/dradis/dradis-ce/actions/runs/5964788032/job/16180850244?pr=1174). 

As per the [Webdrivers Readme](https://github.com/titusfortner/webdrivers), instead of bumping that gem, it should be removed and selenium-webdriver bumped to 4.11.0 instead

### Check List

- [x] Added a CHANGELOG entry
