### PR TITLE
Top nav redesign

### DIFF
--- a/app/assets/stylesheets/tylium/modules/_navbar.scss
+++ b/app/assets/stylesheets/tylium/modules/_navbar.scss
@@ -126,8 +126,8 @@
           outline: none;
         }
 
-        i {
-          margin-right: .25rem;
+        span {
+          margin-left: .25rem;
         }
       }
 

--- a/app/assets/stylesheets/tylium/modules/_navbar.scss
+++ b/app/assets/stylesheets/tylium/modules/_navbar.scss
@@ -125,6 +125,10 @@
           color: $linkColorHover;
           outline: none;
         }
+
+        i {
+          margin-right: .25rem;
+        }
       }
 
       &:hover:not(.search),

--- a/app/assets/stylesheets/tylium/modules/_navbar.scss
+++ b/app/assets/stylesheets/tylium/modules/_navbar.scss
@@ -136,6 +136,12 @@
         }
       }
     }
+
+    &-right {
+      border-left: solid 1px $borderColor;
+      padding-left: 12px;
+      margin-left: 12px;
+    }
   }
 
   .navbar-toggler {

--- a/app/assets/stylesheets/tylium/modules/_navbar.scss
+++ b/app/assets/stylesheets/tylium/modules/_navbar.scss
@@ -143,8 +143,8 @@
 
     &-right {
       border-left: solid 1px $borderColor;
-      padding-left: 12px;
       margin-left: 12px;
+      padding-left: 12px;
     }
   }
 

--- a/app/assets/stylesheets/tylium/modules/_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_sidebar.scss
@@ -151,7 +151,7 @@
       }
 
       i {
-        font-size: 1.6rem;
+        font-size: 1.25rem;
         transition: transform 0.5s ease-in-out;
       }
     }
@@ -162,6 +162,7 @@
     height: calc(100vh - #{$navbarHeight});
     flex-direction: column;
     overflow-y: auto;
+    padding-bottom: 360px;
 
     &:has(.secondary-sidebar) {
       .version {
@@ -257,7 +258,7 @@
     }
 
     .sidebar-link-icon {
-      font-size: 1.6rem;
+      font-size: 1.25rem;
       transition: transform 0.5s ease-in-out;
     }
 
@@ -265,6 +266,41 @@
       margin-left: 1rem;
       white-space: nowrap;
       transition: transform 0.5s ease-in-out;
+    }
+  }
+
+  .footer {
+    position: fixed;
+    bottom: 0;
+    background-color: $sidebarBackground;
+    width: $sidebarExpanded;
+    padding-top: .8rem;
+
+    ul {
+      padding: 0;
+      margin: 0;
+
+      li {
+        @include active-nav;
+
+        i {
+          width: 24px;
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  .dropdown-menu {
+    border: none;
+    border-bottom: 1px solid $borderColor;
+    border-radius: 0;
+    margin-top: 0;
+    position: initial;
+    border-radius: 0.5rem;
+
+    .dropdown-item {
+      padding-right: 1rem;
     }
   }
 
@@ -328,6 +364,10 @@
         background-color: $sidebarActiveColor;
         color: $white;
       }
+    }
+
+    .footer {
+      width: $sidebarCollapsed;
     }
   }
 

--- a/app/assets/stylesheets/tylium/modules/_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_sidebar.scss
@@ -207,6 +207,43 @@
     }
   }
 
+  .project {
+    padding: 0 1rem;
+    margin-bottom: 1.5rem;
+
+    &-inner {
+      padding: 1.5rem 0;
+      border-top: solid 1px rgba(140, 206, 140, .2);
+      border-bottom: solid 1px rgba(140, 206, 140, .2);
+
+      .project-title {
+        color: $white;
+      }
+
+      .change-project-link {
+        font-size: 0.9rem;
+      }
+
+      .change-project-link {
+        margin-top: .5rem;
+      }
+
+      .project-emblem {
+        height: 35px;
+        min-width: 35px;
+        border: 1px solid $borderColor;
+        border-radius: 50%;
+        background: #fff;
+        font-weight: 600;
+        color: $linkColor;
+
+        &:hover {
+          color: $linkColorHover;
+        }
+      }
+    }
+  }
+
   .sidebar-link {
     display: flex;
     position: relative;
@@ -251,6 +288,31 @@
       padding-left: 0.8rem;
     }
 
+    .project {
+
+      &-inner {
+        align-items: center;
+
+        .project-title {
+          display: none;
+        }
+
+        .project-emblem {
+          @extend .d-flex;
+          @extend .align-items-center;
+          @extend .justify-content-center;
+        }
+
+        .change-project-link {
+          font-size: .75rem;
+
+          span {
+            display: none;
+          }
+        }
+      }
+    }
+
     .tree-header {
       cursor: pointer;
       transition: all 0.2s ease-in-out;
@@ -281,6 +343,10 @@
     .team-name,
     .nodes-list {
       display: block;
+    }
+
+    .project-emblem {
+      display: none;
     }
   }
 
@@ -316,6 +382,10 @@
         top: unset;
         width: 100%;
       }
+    }
+
+    .project {
+      display: none;
     }
 
     .scrollable-content {

--- a/app/assets/stylesheets/tylium/modules/_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_sidebar.scss
@@ -221,7 +221,7 @@
       }
 
       .change-project-link {
-        font-size: 0.9rem;
+        font-size: .75rem;
       }
 
       .change-project-link {
@@ -304,8 +304,6 @@
         }
 
         .change-project-link {
-          font-size: .75rem;
-
           span {
             display: none;
           }

--- a/app/assets/stylesheets/tylium/modules/_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_sidebar.scss
@@ -18,7 +18,7 @@
   }
 
   .main-menu {
-    padding: 0;
+    padding: 1rem 0 0 0;
 
     li {
       @include active-nav;
@@ -159,15 +159,19 @@
 
   .scrollable-content {
     display: flex;
-    height: calc(100vh - #{$navbarHeight});
+    // height of nav bar + project area + footer
+    height: calc(100vh - #{$navbarHeight + 260px});
     flex-direction: column;
     overflow-y: auto;
-    padding-bottom: 360px;
 
     &:has(.secondary-sidebar) {
       .version {
         background-color: $sidebarActiveColor;
       }
+    }
+
+    .inner-content {
+      padding-bottom: 0.25rem;
     }
   }
 
@@ -210,7 +214,6 @@
 
   .project {
     padding: 0 1rem;
-    margin-bottom: 1.5rem;
 
     &-inner {
       padding: 1.5rem 0;

--- a/app/assets/stylesheets/tylium/modules/_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_sidebar.scss
@@ -159,9 +159,9 @@
 
   .scrollable-content {
     display: flex;
+    flex-direction: column;
     // height of nav bar + project area + footer
     height: calc(100vh - #{$navbarHeight + 260px});
-    flex-direction: column;
     overflow-y: auto;
 
     &:has(.secondary-sidebar) {
@@ -216,9 +216,9 @@
     padding: 0 1rem;
 
     &-inner {
-      padding: 1.5rem 0;
       border-top: solid 1px rgba(140, 206, 140, .2);
       border-bottom: solid 1px rgba(140, 206, 140, .2);
+      padding: 1.5rem 0;
 
       .project-title {
         color: $white;
@@ -233,13 +233,13 @@
       }
 
       .project-emblem {
-        height: 35px;
-        min-width: 35px;
+        background: $lightColor;
         border: 1px solid rgba(255, 255, 255, .2);
         border-radius: 5px;
-        background: $lightColor;
-        font-weight: 600;
         color: $linkColor;
+        font-weight: 600;
+        height: 35px;
+        min-width: 35px;
 
         &:hover {
           color: $linkColorHover;
@@ -273,22 +273,22 @@
   }
 
   .footer {
-    position: fixed;
-    bottom: 0;
     background-color: $sidebarBackground;
-    width: $sidebarExpanded;
+    bottom: 0;
     padding-top: .8rem;
+    position: fixed;
+    width: $sidebarExpanded;
 
     ul {
-      padding: 0;
       margin: 0;
+      padding: 0;
 
       li {
         @include active-nav;
 
         i {
-          width: 24px;
           text-align: center;
+          width: 24px;
         }
       }
     }
@@ -297,10 +297,9 @@
   .dropdown-menu {
     border: none;
     border-bottom: 1px solid $borderColor;
-    border-radius: 0;
+    border-radius: 0.5rem;
     margin-top: 0;
     position: initial;
-    border-radius: 0.5rem;
 
     .dropdown-item {
       padding-right: 1rem;
@@ -337,8 +336,8 @@
         }
 
         .project-emblem {
-          @extend .d-flex;
           @extend .align-items-center;
+          @extend .d-flex;
           @extend .justify-content-center;
         }
 

--- a/app/assets/stylesheets/tylium/modules/_sidebar.scss
+++ b/app/assets/stylesheets/tylium/modules/_sidebar.scss
@@ -235,9 +235,9 @@
       .project-emblem {
         height: 35px;
         min-width: 35px;
-        border: 1px solid $borderColor;
-        border-radius: 50%;
-        background: #fff;
+        border: 1px solid rgba(255, 255, 255, .2);
+        border-radius: 5px;
+        background: $lightColor;
         font-weight: 600;
         color: $linkColor;
 
@@ -414,6 +414,7 @@
     .main-menu {
       display: inline-flex;
       margin-bottom: 0;
+      padding: 0;
 
       li.active::after {
         border-bottom: 3px solid $white;

--- a/app/assets/stylesheets/tylium/modules/search.scss
+++ b/app/assets/stylesheets/tylium/modules/search.scss
@@ -1,121 +1,149 @@
-.navbar-collapse {
+.navbar {
   .form-search {
-    height: 40px;
-    margin-left: 0.25rem;
-    position: relative;
-    transition: width 0.2s ease-in-out;
-    width: 0px;
-    z-index: 1;
+    font-size: .75em;
+    @extend .d-flex;
+    @extend .flex-row-reverse;
 
-    .btn {
-      background: initial;
-      border-radius: 50%;
-      color: $linkColor;
-      display: flex;
-      font-size: 1.2em;
-      height: 38px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      width: 38px;
-
-      .fa-search {
-        position: absolute;
-        top: 10px;
-      }
+    .search-query {
+      border: 0;
+      outline: 0;
+      color: $defaultText;
     }
 
-    &:hover {
-      width: 9.5rem;
-      cursor: pointer;
+    .btn {
+      color: $linkColor;
+      background: initial;
+      border-radius: 50%;
 
-      .btn {
+      &:hover {
         background: $activeFillColor;
         color: $linkColorHover;
         transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
       }
-
-      .search-query {
-        border-bottom-color: $linkColor;
-        opacity: 1;
-        right: 1.25rem;
-        width: 9rem;
-      }
-    }
-
-    .search-query {
-      border: 0;
-      border-bottom: 1px solid transparent;
-      color: $defaultText;
-      height: 38px;
-      opacity: 0;
-      outline: 0;
-      padding: 0 1.25rem 0 0.5rem;
-      position: absolute;
-      right: 0;
-      top: 0;
-      transition: opacity 0.2s ease-in-out, width 0.2s ease-in-out,
-        right 0.2s ease-in-out, border-bottom 0.2s 0.15s ease-in-out;
-      width: 0;
-    }
-  }
-
-  @media (max-width: 991px) {
-    &.show {
-      .form-search {
-        margin: 0 0 0.5rem;
-        width: 100%;
-
-        .btn {
-          left: 0.25rem;
-          right: initial;
-        }
-
-        &:hover {
-          .btn {
-            background: initial;
-            color: $linkColor;
-          }
-        }
-
-        .search-query {
-          border-bottom: 1px solid $linkColor;
-          margin: 0 0.5rem;
-          opacity: 1;
-          padding: 0 0.5rem 0 2rem;
-          position: initial;
-          width: 160px;
-        }
-      }
     }
   }
 }
 
-body.search.index {
-  .inset-button-wrapper {
-    max-width: 300px;
-  }
-
-  .match-snippet {
-    background-color: $secondaryBgColor;
-    border: 1px solid $borderColor;
-    padding: 0.25rem 0.5rem;
-  }
-
-  tr:first-child td {
-    border-top: none;
-  }
-
-  .result-details {
-    color: $mutedText;
-    margin: 10px 0;
-
-    p {
-      margin-bottom: 0;
-    }
-  }
-
-  .search-match-title {
-    font-weight: 600;
-  }
-}
+// Leaving this styling for re-implementing search to mobile navigation
+//
+// .navbar-collapse {
+//   .form-search {
+//     height: 40px;
+//     margin-left: 0.25rem;
+//     position: relative;
+//     transition: width 0.2s ease-in-out;
+//     width: 0px;
+//     z-index: 1;
+//
+//     .btn {
+//       background: initial;
+//       border-radius: 50%;
+//       color: $linkColor;
+//       display: flex;
+//       font-size: 1.2em;
+//       height: 38px;
+//       position: absolute;
+//       right: 0;
+//       top: 0;
+//       width: 38px;
+//
+//       .fa-search {
+//         position: absolute;
+//         top: 10px;
+//       }
+//     }
+//
+//     &:hover {
+//       width: 9.5rem;
+//       cursor: pointer;
+//
+//       .btn {
+//         background: $activeFillColor;
+//         color: $linkColorHover;
+//         transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+//       }
+//
+//       .search-query {
+//         border-bottom-color: $linkColor;
+//         opacity: 1;
+//         right: 1.25rem;
+//         width: 9rem;
+//       }
+//     }
+//
+//     .search-query {
+//       border: 0;
+//       border-bottom: 1px solid transparent;
+//       color: $defaultText;
+//       height: 38px;
+//       opacity: 0;
+//       outline: 0;
+//       padding: 0 1.25rem 0 0.5rem;
+//       position: absolute;
+//       right: 0;
+//       top: 0;
+//       transition: opacity 0.2s ease-in-out, width 0.2s ease-in-out,
+//         right 0.2s ease-in-out, border-bottom 0.2s 0.15s ease-in-out;
+//       width: 0;
+//     }
+//   }
+//
+//   @media (max-width: 991px) {
+//     &.show {
+//       .form-search {
+//         margin: 0 0 0.5rem;
+//         width: 100%;
+//
+//         .btn {
+//           left: 0.25rem;
+//           right: initial;
+//         }
+//
+//         &:hover {
+//           .btn {
+//             background: initial;
+//             color: $linkColor;
+//           }
+//         }
+//
+//         .search-query {
+//           border-bottom: 1px solid $linkColor;
+//           margin: 0 0.5rem;
+//           opacity: 1;
+//           padding: 0 0.5rem 0 2rem;
+//           position: initial;
+//           width: 160px;
+//         }
+//       }
+//     }
+//   }
+// }
+//
+// body.search.index {
+//   .inset-button-wrapper {
+//     max-width: 300px;
+//   }
+//
+//   .match-snippet {
+//     background-color: $secondaryBgColor;
+//     border: 1px solid $borderColor;
+//     padding: 0.25rem 0.5rem;
+//   }
+//
+//   tr:first-child td {
+//     border-top: none;
+//   }
+//
+//   .result-details {
+//     color: $mutedText;
+//     margin: 10px 0;
+//
+//     p {
+//       margin-bottom: 0;
+//     }
+//   }
+//
+//   .search-match-title {
+//     font-weight: 600;
+//   }
+// }

--- a/app/assets/stylesheets/tylium/modules/search.scss
+++ b/app/assets/stylesheets/tylium/modules/search.scss
@@ -1,13 +1,13 @@
 .navbar {
   .form-search {
-    font-size: .75em;
     @extend .d-flex;
     @extend .flex-row-reverse;
+    font-size: .75em;
 
     .search-query {
       border: 0;
-      outline: 0;
       color: $defaultText;
+      outline: 0;
     }
 
     .btn {

--- a/app/views/layouts/tylium/_navbar.html.erb
+++ b/app/views/layouts/tylium/_navbar.html.erb
@@ -27,42 +27,11 @@
                 <i class="fa-regular fa-handshake fa-lg"></i> QA
               <% end %>
             </li>
-            <li class="nav-item">
-              <%= link_to main_app.project_configurations_path(current_project), class: 'nav-link', title: 'Configuration' do %><i class="fa-solid fa-cog fa-lg"></i> Configuration<% end %>
-            </li>
             <li class="nav-item notifications dropdown">
               <%= link_to main_app.project_notifications_path(current_project), class: 'nav-link dropdown-toggle', data: { bs_toggle: 'dropdown',  behavior: 'notifications-dropdown close-collapse', project_id: current_project.id }, role: 'button', title: 'Notifications' do %>
                 <i class="notifications-bell fa-solid fa-bell fa-lg"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i> Notifications
               <% end %>
               <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>"></div>
-            </li>
-            <li class="nav-item dropdown">
-              <%= link_to '#', class: 'nav-link dropdown-toggle', data: { bs_toggle: 'dropdown', behavior: 'close-collapse' }, role: 'button', title: 'Help' do %>
-                <i class="fa-solid fa-question fa-lg"></i> Help
-              <% end %>
-              <div class="dropdown-menu dropdown-menu-end">
-                <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="training-course" data-url="https://dradisframework.com/academy/dradis-course/?utm_source=ce&utm_medium=app&utm_campaign=try-pro&utm_term=training-course">Free training course</a>
-                <a href="https://dradisframework.com/pro/support/guides/projects/index.html?utm_source=ce&utm_medium=app" target="_blank" class="dropdown-item">Projects 101</a>
-                <a href="https://dradisframework.com/pro/support/guides/troubleshooting/index.html?utm_source=ce&utm_medium=app" target="_blank" class="dropdown-item">Troubleshooting</a>
-                <div class="divider"></div>
-                <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="contact-support" data-url="https://dradisframework.com/pro/pages/support.html">Contact support</a>
-                <a href="https://evening-hamlet-4416.herokuapp.com/" target="_blank" class="dropdown-item">Chat on Slack</a>
-                <a href="https://github.com/dradis/dradis-ce/issues" class="js-hs-beacon dropdown-item">Report an issue</a>
-                <a href="http://dradisframework.org/documentation/" target="_blank" class="dropdown-item">Support website</a>
-                <a href="https://discuss.dradisframework.org" target="_blank" class="dropdown-item">Community forums</a>
-                <div class="divider"></div>
-                <a href="https://dradisframework.com/careers/" target="_blank" class="dropdown-item">We're hiring</a>
-                <%# FIXME: re-enable Tour %>
-                <!--
-              <div class="divider"></div>
-              <a href="javascript:void(0)" class="js-tour-start dropdown-item">Show Tour</a>
-              -->
-                <div class="divider"></div>
-                <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="try-pro" data-url="https://dradisframework.com/pro/pages/upgrade.html">Try Dradis Pro</a>
-              </div>
-            </li>
-            <li class="nav-item">
-              <%= link_to main_app.logout_path, class: 'nav-link', title: 'Logout', data: { turbolinks: false }  do %><i class="fa-solid fa-sign-out fa-lg"></i> Logout<% end %>
             </li>
           </ul>
         </div>

--- a/app/views/layouts/tylium/_navbar.html.erb
+++ b/app/views/layouts/tylium/_navbar.html.erb
@@ -19,14 +19,14 @@
         <div class="collapse navbar-collapse" id="navbar">
           <ul class="navbar-nav ms-auto mt-lg-0">
             <li class="nav-item">
-              <%= link_to main_app.project_upload_manager_path(current_project), class: 'nav-link', title: 'Upload' do %><i class="fa-solid fa-cloud-upload fa-lg"></i> Upload<% end %>
+              <%= link_to main_app.project_upload_manager_path(current_project), class: 'nav-link', title: 'Upload' do %><i class="fa-solid fa-cloud-upload fa-lg"></i> <span>Upload</span><% end %>
             </li>
             <li class="nav-item mx-lg-1">
-              <%= link_to main_app.project_export_manager_path(current_project), class: 'nav-link', title: 'Export' do %><i class="fa-regular fa-file-text fa-lg"></i> Export<% end %>
+              <%= link_to main_app.project_export_manager_path(current_project), class: 'nav-link', title: 'Export' do %><i class="fa-regular fa-file-text fa-lg"></i> <span>Export</span><% end %>
             </li>
             <li class="nav-item">
               <%= link_to main_app.project_qa_issues_path(current_project), class: 'nav-link', title: 'QA' do %>
-                <i class="fa-regular fa-handshake fa-lg"></i> QA
+                <i class="fa-regular fa-handshake fa-lg"></i> <span>QA</span>
               <% end %>
             </li>
             <li class="nav-item d-lg-none">

--- a/app/views/layouts/tylium/_navbar.html.erb
+++ b/app/views/layouts/tylium/_navbar.html.erb
@@ -21,7 +21,7 @@
             <li class="nav-item">
               <%= link_to main_app.project_upload_manager_path(current_project), class: 'nav-link', title: 'Upload' do %><i class="fa-solid fa-cloud-upload fa-lg"></i> Upload<% end %>
             </li>
-            <li class="nav-item">
+            <li class="nav-item mx-lg-1">
               <%= link_to main_app.project_export_manager_path(current_project), class: 'nav-link', title: 'Export' do %><i class="fa-regular fa-file-text fa-lg"></i> Export<% end %>
             </li>
             <li class="nav-item">

--- a/app/views/layouts/tylium/_navbar.html.erb
+++ b/app/views/layouts/tylium/_navbar.html.erb
@@ -2,10 +2,15 @@
   <div class="container-fluid">
     <div class="d-flex justify-content-between w-100">
       <div class="navbar-brand" data-behavior="navbar-brand">
-        <%= link_to current_project.name, main_app.project_path(current_project), class: 'project-title' %>
-        <%= link_to 'javascript:void(0)', class: 'js-try-pro change-project-link', data: { term: 'projects', url: 'https://dradisframework.com/pro/pages/projects.html'}, title: 'Change Project' do %>
-          <i class="fa-solid fa-random fa-fw"></i> Change Project
-        <% end %>
+        <div class="d-lg-none">
+          <%= link_to current_project.name, main_app.project_path(current_project), class: 'project-title' %>
+          <%= link_to 'javascript:void(0)', class: 'js-try-pro change-project-link', data: { term: 'projects', url: 'https://dradisframework.com/pro/pages/projects.html'}, title: 'Change Project' do %>
+            <i class="fa-solid fa-random fa-fw"></i> Change Project
+          <% end %>
+        </div>
+        <div class="search d-none d-lg-inline-block">
+          <%= render "layouts/tylium/search" %>
+        </div>
       </div>
       <div class="d-inline-flex">
         <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation" data-behavior="navbar-toggler">
@@ -13,9 +18,6 @@
         </button>
         <div class="collapse navbar-collapse" id="navbar">
           <ul class="navbar-nav ms-auto mt-lg-0">
-            <li class="nav-item search">
-              <%= render "layouts/tylium/search" %>
-            </li>
             <li class="nav-item">
               <%= link_to main_app.project_upload_manager_path(current_project), class: 'nav-link', title: 'Upload' do %><i class="fa-solid fa-cloud-upload fa-lg"></i> Upload<% end %>
             </li>

--- a/app/views/layouts/tylium/_navbar.html.erb
+++ b/app/views/layouts/tylium/_navbar.html.erb
@@ -27,9 +27,48 @@
                 <i class="fa-regular fa-handshake fa-lg"></i> QA
               <% end %>
             </li>
-            <li class="nav-item notifications dropdown">
+            <li class="nav-item d-lg-none">
+              <%= link_to main_app.project_configurations_path(current_project), class: 'nav-link', title: 'Configuration' do %><i class="fa-solid fa-cog fa-lg"></i> Configuration<% end %>
+            </li>
+            <li class="nav-item notifications dropdown d-lg-none">
               <%= link_to main_app.project_notifications_path(current_project), class: 'nav-link dropdown-toggle', data: { bs_toggle: 'dropdown',  behavior: 'notifications-dropdown close-collapse', project_id: current_project.id }, role: 'button', title: 'Notifications' do %>
                 <i class="notifications-bell fa-solid fa-bell fa-lg"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i> Notifications
+              <% end %>
+              <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>"></div>
+            </li>
+            <li class="nav-item dropdown d-lg-none">
+              <%= link_to '#', class: 'nav-link dropdown-toggle', data: { bs_toggle: 'dropdown', behavior: 'close-collapse' }, role: 'button', title: 'Help' do %>
+                <i class="fa-solid fa-question fa-lg"></i> Help
+              <% end %>
+              <div class="dropdown-menu dropdown-menu-end">
+                <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="training-course" data-url="https://dradisframework.com/academy/dradis-course/?utm_source=ce&utm_medium=app&utm_campaign=try-pro&utm_term=training-course">Free training course</a>
+                <a href="https://dradisframework.com/pro/support/guides/projects/index.html?utm_source=ce&utm_medium=app" target="_blank" class="dropdown-item">Projects 101</a>
+                <a href="https://dradisframework.com/pro/support/guides/troubleshooting/index.html?utm_source=ce&utm_medium=app" target="_blank" class="dropdown-item">Troubleshooting</a>
+                <div class="divider"></div>
+                <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="contact-support" data-url="https://dradisframework.com/pro/pages/support.html">Contact support</a>
+                <a href="https://evening-hamlet-4416.herokuapp.com/" target="_blank" class="dropdown-item">Chat on Slack</a>
+                <a href="https://github.com/dradis/dradis-ce/issues" class="js-hs-beacon dropdown-item">Report an issue</a>
+                <a href="http://dradisframework.org/documentation/" target="_blank" class="dropdown-item">Support website</a>
+                <a href="https://discuss.dradisframework.org" target="_blank" class="dropdown-item">Community forums</a>
+                <div class="divider"></div>
+                <a href="https://dradisframework.com/careers/" target="_blank" class="dropdown-item">We're hiring</a>
+                <%# FIXME: re-enable Tour %>
+                <!--
+              <div class="divider"></div>
+              <a href="javascript:void(0)" class="js-tour-start dropdown-item">Show Tour</a>
+              -->
+                <div class="divider"></div>
+                <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="try-pro" data-url="https://dradisframework.com/pro/pages/upgrade.html">Try Dradis Pro</a>
+              </div>
+            </li>
+            <li class="nav-item d-lg-none">
+              <%= link_to main_app.logout_path, class: 'nav-link', title: 'Logout', data: { turbolinks: false }  do %><i class="fa-solid fa-sign-out fa-lg"></i> Logout<% end %>
+            </li>
+          </ul>
+          <ul class="navbar-nav navbar-nav-right mt-lg-0 d-none d-lg-inline-block">
+            <li class="nav-item notifications dropdown">
+              <%= link_to main_app.project_notifications_path(current_project), class: 'nav-link dropdown-toggle', data: { bs_toggle: 'dropdown',  behavior: 'notifications-dropdown close-collapse', project_id: current_project.id }, role: 'button', title: 'Notifications' do %>
+                <i class="notifications-bell fa-solid fa-bell fa-lg"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
               <% end %>
               <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>"></div>
             </li>

--- a/app/views/layouts/tylium/_sidebar.html.erb
+++ b/app/views/layouts/tylium/_sidebar.html.erb
@@ -43,9 +43,49 @@
         <%= yield :sidebar %>
       </div>
     <% end %>
-
-    <div class="version">
-      <span>v<%= Dradis::CE.version %></span>
-    </div>
   </div>
+
+  <div class="footer">
+    <ul>
+      <%= content_tag :li, :class => controller_path == 'configurations' ? 'active' : '' do %>
+        <%= link_to main_app.project_configurations_path(current_project), class: 'sidebar-link', data: { behavior: 'sidebar-link' } do %>
+          <i class="fa-solid fa-cog sidebar-link-icon"></i> <span class="sidebar-link-label">Configuration</span>
+        <% end %>
+      <% end %>
+      <li>
+        <%= link_to '#', class: 'sidebar-link dropdown-toggle', data: { bs_toggle: 'dropdown', behavior: 'close-collapse' }, role: 'button', title: 'Help' do %>
+          <i class="fa-solid fa-question sidebar-link-icon"></i> <span class="sidebar-link-label">Help</span>
+        <% end %>
+        <div class="dropdown-menu dropdown-menu-end">
+          <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="training-course" data-url="https://dradisframework.com/academy/dradis-course/?utm_source=ce&utm_medium=app&utm_campaign=try-pro&utm_term=training-course">Free training course</a>
+          <a href="https://dradisframework.com/pro/support/guides/projects/index.html?utm_source=ce&utm_medium=app" target="_blank" class="dropdown-item">Projects 101</a>
+          <a href="https://dradisframework.com/pro/support/guides/troubleshooting/index.html?utm_source=ce&utm_medium=app" target="_blank" class="dropdown-item">Troubleshooting</a>
+          <div class="divider"></div>
+          <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="contact-support" data-url="https://dradisframework.com/pro/pages/support.html">Contact support</a>
+          <a href="https://evening-hamlet-4416.herokuapp.com/" target="_blank" class="dropdown-item">Chat on Slack</a>
+          <a href="https://github.com/dradis/dradis-ce/issues" class="js-hs-beacon dropdown-item">Report an issue</a>
+          <a href="http://dradisframework.org/documentation/" target="_blank" class="dropdown-item">Support website</a>
+          <a href="https://discuss.dradisframework.org" target="_blank" class="dropdown-item">Community forums</a>
+          <div class="divider"></div>
+          <a href="https://dradisframework.com/careers/" target="_blank" class="dropdown-item">We're hiring</a>
+          <%# FIXME: re-enable Tour %>
+          <!--
+        <div class="divider"></div>
+        <a href="javascript:void(0)" class="js-tour-start dropdown-item">Show Tour</a>
+        -->
+          <div class="divider"></div>
+          <a href="javascript:void(0)" class="js-try-pro dropdown-item" data-term="try-pro" data-url="https://dradisframework.com/pro/pages/upgrade.html">Try Dradis Pro</a>
+        </div>
+      </li>
+      <li>
+        <%= link_to main_app.logout_path, class: 'sidebar-link', data: { behavior: 'sidebar-link' } do %>
+          <i class="fa-solid fa-sign-out sidebar-link-icon"></i> <span class="sidebar-link-label">Logout</span>
+        <% end %>
+      </li>
+      <li class="version">
+        <span>v<%= Dradis::CE.version %></span>
+      </li>
+    </ul>
+  </div>
+
 </div>

--- a/app/views/layouts/tylium/_sidebar.html.erb
+++ b/app/views/layouts/tylium/_sidebar.html.erb
@@ -2,6 +2,16 @@
 
   <%= render 'layouts/tylium/sidebar_header' %>
 
+  <div class="project" data-behavior="navbar-brand">
+    <div class="project-inner d-flex flex-column">
+      <%= link_to current_project.name, main_app.project_path(current_project), class: 'project-title block text-truncate' %>
+      <%= link_to current_project.name[0...2], main_app.project_path(current_project), class: 'project-emblem', title: current_project.name %>
+      <%= link_to 'javascript:void(0)', class: 'js-try-pro change-project-link', data: { term: 'projects', url: 'https://dradisframework.com/pro/pages/projects.html'}, title: 'Change Project' do %>
+        <i class="fa-solid fa-random fa-fw"></i> Change<span> Project</span>
+      <% end %>
+    </div>
+  </div>
+
   <div class="scrollable-content">
     <ul id="main-menu" class="main-menu">
       <%= content_tag :li, :class => controller_path == 'projects' ? 'active' : '' do %>

--- a/app/views/layouts/tylium/_sidebar.html.erb
+++ b/app/views/layouts/tylium/_sidebar.html.erb
@@ -7,7 +7,7 @@
       <%= link_to current_project.name, main_app.project_path(current_project), class: 'project-title block text-truncate' %>
       <%= link_to current_project.name[0...2], main_app.project_path(current_project), class: 'project-emblem', title: current_project.name %>
       <%= link_to 'javascript:void(0)', class: 'js-try-pro change-project-link', data: { term: 'projects', url: 'https://dradisframework.com/pro/pages/projects.html'}, title: 'Change Project' do %>
-        <i class="fa-solid fa-random fa-fw"></i> Change<span> Project</span>
+        <i class="fa-solid fa-random fa-fw"></i> <span>Change</span> Project
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/tylium/_sidebar.html.erb
+++ b/app/views/layouts/tylium/_sidebar.html.erb
@@ -45,7 +45,7 @@
     <% end %>
   </div>
 
-  <div class="footer">
+  <div class="footer d-none d-lg-block">
     <ul>
       <%= content_tag :li, :class => controller_path == 'configurations' ? 'active' : '' do %>
         <%= link_to main_app.project_configurations_path(current_project), class: 'sidebar-link', data: { behavior: 'sidebar-link' } do %>


### PR DESCRIPTION
### Summary

The aim of this PR is to make better use of space within the top navigation. Many links and long project names create a very cluttered experience. Users will now be able to focus on primary actions and there is now room to add other actions if necessary.

Desktop:
- Moved project name and 'change project' from top nav to left nav
- Created 'emblem' for project name when collapsing the side nav
- Moved Configuration, Help and Logout from top nav to left nav
- Created sticky footer for side navigation
- Moved search to left side of top nav and made input always visible
- Increased spacing in and around top nav icon links
- Removed notification label and added divider to separate from other links

Mobile:
- Removed search from navigation

<img width="1436" alt="pr-ss-2" src="https://github.com/dradis/dradis-ce/assets/17826416/f86accf7-bdcf-44e9-8396-45bfa83ef6eb">

<img width="1438" alt="pr-ss" src="https://github.com/dradis/dradis-ce/assets/17826416/c02cbb5e-0c26-4f32-9a02-30f52ac4b15f">

### Other Information

- Please be vigilant of bugs regarding the overflow behaviour of the left navigation. I believe I've fixed all the issues but please test.
- I've removed search from the mobile experience for now as I could not get the search bar to behave the way I needed for both desktop and mobile and having two instances was causing bugs.
- The notification bell and dropdown has not been tested with an active notification

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
