### PR TITLE
Table actions

### DIFF
--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -36,6 +36,10 @@ div.dataTables_wrapper {
       }
     }
 
+    a {
+      width: 100%;
+    }
+
     tbody {
       tr {
         .select-checkbox {

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -5,6 +5,7 @@ div.dataTables_wrapper {
     .column-actions {
       position: sticky;
       right: 0;
+      opacity: 0;
       box-shadow: -8px 0px 10px 0px rgba(82, 63, 105, 0.08);
 
       a {
@@ -85,6 +86,11 @@ div.dataTables_wrapper {
               background-color: $checkboxFill;
               border-color: $checkboxFill;
             }
+          }
+        }
+        &:hover {
+          td.column-actions {
+            opacity: 1;
           }
         }
       }

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -2,6 +2,14 @@ div.dataTables_wrapper {
   .dataTable {
     margin-top: 0 !important;
 
+    tr.odd .column-actions {
+      background-color: rgba(242, 242, 242, 0.8);
+    }
+
+    tr.even .column-actions {
+      background-color: rgba(255, 255, 255, 0.8);
+    }
+
     .column-actions {
       position: sticky;
       right: 0;

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -3,6 +3,9 @@ div.dataTables_wrapper {
     margin-top: 0 !important;
 
     .column-actions {
+      position: sticky;
+      right: 0;
+      box-shadow: -8px 0px 10px 0px rgba(82, 63, 105, 0.08);
 
       a {
         visibility: hidden;

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -3,7 +3,6 @@ div.dataTables_wrapper {
     margin-top: 0 !important;
 
     .column-actions {
-      min-width: 8rem;
 
       a {
         visibility: hidden;

--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -15,14 +15,6 @@ div.dataTables_wrapper {
       right: 0;
       opacity: 0;
       box-shadow: -8px 0px 10px 0px rgba(82, 63, 105, 0.08);
-
-      a {
-        visibility: hidden;
-
-        &:first-of-type {
-          padding-right: 0.5rem;
-        }
-      }
     }
 
     .no-sort {
@@ -149,15 +141,6 @@ div.dataTables_wrapper {
               opacity: 1;
             }
           }
-        }
-      }
-    }
-
-    tr {
-      &:focus-within,
-      &:hover {
-        .column-actions a {
-          visibility: visible;
         }
       }
     }

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -62,8 +62,8 @@
               %>
             <% end %>
             <td class="column-actions">
-              <div class="dropdown">
-                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <div class="dropstart">
+                <button class="btn btn-primary" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <i class="fa-solid fa-ellipsis-vertical"></i>
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -62,15 +62,28 @@
               %>
             <% end %>
             <td class="column-actions">
-              <%= link_to edit_project_issue_path(current_project, issue), data: { qa_visible: false } do %>
-                <i class="fa-solid fa-pencil"></i> Edit
-              <% end %>
-              <%= link_to edit_project_qa_issue_path(current_project, issue), class: 'd-none', data: { qa_visible: true } do %>
-                <i class="fa-solid fa-pencil"></i> Edit
-              <% end %>
-              <%= link_to [current_project, issue], method: :delete, data: { confirm: "Are you sure?\n\nProceeding will delete this issue and any associated evidence.", qa_visible: false }, class: 'text-error-hover' do %>
-                <i class="fa-solid fa-trash"></i> Delete
-              <% end %>
+              <div class="dropdown">
+                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <i class="fa-solid fa-ellipsis-vertical"></i>
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                  <li class="dropdown-item">
+                    <%= link_to edit_project_issue_path(current_project, issue), data: { qa_visible: false } do %>
+                      <i class="fa-solid fa-pencil"></i> Edit
+                    <% end %>
+                  </li>
+                  <li class="dropdown-item d-none">
+                    <%= link_to edit_project_qa_issue_path(current_project, issue), class: 'd-none', data: { qa_visible: true } do %>
+                      <i class="fa-solid fa-pencil"></i> Edit
+                    <% end %>
+                  </li>
+                  <li class="dropdown-item">
+                    <%= link_to [current_project, issue], method: :delete, data: { confirm: "Are you sure?\n\nProceeding will delete this issue and any associated evidence.", qa_visible: false }, class: 'text-error-hover' do %>
+                      <i class="fa-solid fa-trash"></i> Delete
+                    <% end %>
+                  </li>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
### Summary

Currently, tables have an actions column on the far right. This comes with a few problems, most notably:
- The actions column becomes "hidden" unless users horizontally scroll over to the last column
- The actions column may be shown just enough to confuse users into thinking there is just one action
- The action column takes up too much white space when there are multiple actions

### Fix description

This solution is to make the far right column float, make it invisible by default and visible on row hover. All the actions are wrapped in a drop-down menu activated with an ellipsis button. This solution is scalable, is valid with accessibility standards, and is responsive. It prevents any overlay no matter the screen size.

### Hover effects alternatives

The request stated: 
> “the visual cue should always be […] visible […] regardless if the row is being hovered over or not”

The issue with this is visual clutter. Tables are inherently data intensive, especially when rows are compact. As the "more" button had to overlay the row, making all of them constantly visible would take some screen real estate, partially hide some data, and make the interface visually heavy. This is why I made them visible on hover only.

This can easily be reverted by deleting the lines `16` and `95-99` of `datatables.scss`.

### Testing instructions

- Navigate to [http://localhost:3000/projects/1/issues](http://localhost:3000/projects/1/issues) ("all issues" from the left menu)
- In the table that appears, activate more columns from the column dropdown to enable horizontal scroll
- Hover over any row to see the related "more" button
- Each "more" button has a dropdown menu containing all actions (currently Edit and Delete)

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.