### PR TITLE
Use main_app.root_path in tylium sidebar

### DIFF
--- a/app/views/layouts/tylium/_sidebar_header.html.erb
+++ b/app/views/layouts/tylium/_sidebar_header.html.erb
@@ -1,5 +1,5 @@
 <div class="sidebar-header">
-  <%= link_to root_path, class: 'd-flex' do %>
+  <%= link_to main_app.root_path, class: 'd-flex' do %>
     <div class="team-logo">
       <%= image_tag('logo_small.png', alt: 'Dradis CE logo') %>
     </div>


### PR DESCRIPTION
### Summary

Use main_app.root_path in tylium sidebar for integrations that render the sidebar


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
