### PR TITLE
Implement inline diff for manually created findings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
   - Upgrade to Rails 7.0.8
   - Replace unicorn with puma in production
   - Add importmap-rails to handle js libraries
+  - Tylium:
+    - Added inline diff to version history for manually created findings
   - Upgraded gems:
     - [gem]
   - Bugs fixes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,7 @@
   - Upgrade to Rails 7.0.8
   - Replace unicorn with puma in production
   - Add importmap-rails to handle js libraries
-  - Tylium:
-    - Added inline diff to version history for manually created findings
+  - Revision history: Improve version history for content with carriage return
   - Upgraded gems:
     - [gem]
   - Bugs fixes:

--- a/app/models/diffed_revision.rb
+++ b/app/models/diffed_revision.rb
@@ -9,9 +9,10 @@ class DiffedRevision
 
   def diff
     @diff ||=
-      Differ.diff_by_line(
-        after[content_attribute],
-        before[content_attribute]
+      Differ.diff(
+        after[content_attribute].gsub(/\r/, ''),
+        before[content_attribute].gsub(/\r/, ''),
+        /(\s)/
       )
   end
 

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -427,8 +427,7 @@ describe 'Issues pages' do
           visit project_issue_revisions_path(current_project, issue)
 
           within '.js-diff-body' do
-            expect(page).to have_text('issue text')
-            expect(page).to have_text('updated text')
+            expect(page).to have_text('issue[0m[32mupdated[0m text') # match the format of the inline diff
           end
         end
       end


### PR DESCRIPTION
### Summary

This PR improves the existing version history to show diffs inline rather than wrapping around the entire changed line. 


### Other Information

This change will apply to manually-created findings, not tool-created findings. 


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
