### PR TITLE
Ignore Liquid syntax in links by wrapping them in Liquid {% raw %} tags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - Liquid: ignore liquid syntax in urls
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/lib/dradis/ce.rb
+++ b/lib/dradis/ce.rb
@@ -8,9 +8,9 @@ module Dradis
   end
 end
 
-require 'html/ignore_liquid_in_textile_block_codes'
 require 'html/ignore_liquid'
 require 'html/ignore_liquid_in_links'
+require 'html/ignore_liquid_in_textile_block_codes'
 require 'html/no_inline_code_textile_formatter'
 
 require 'html/pipeline/dradis/code_highlight_filter'

--- a/lib/dradis/ce.rb
+++ b/lib/dradis/ce.rb
@@ -9,6 +9,8 @@ module Dradis
 end
 
 require 'html/ignore_liquid_in_textile_block_codes'
+require 'html/ignore_liquid'
+require 'html/ignore_liquid_in_links'
 require 'html/no_inline_code_textile_formatter'
 
 require 'html/pipeline/dradis/code_highlight_filter'

--- a/lib/html/ignore_liquid.rb
+++ b/lib/html/ignore_liquid.rb
@@ -1,0 +1,27 @@
+module HTML
+  class IgnoreLiquid
+    class << self
+      def call(text)
+        @lines = text.lines
+        # Initialize a flag to identify block codes in the loop,
+        # possible values are "bc. ", "bc.. ", nil
+        current_block_code_type = nil
+        output = []
+
+        @lines.each_with_index do |line, index|
+          current_block_code_type = IgnoreLiquidInTextileBlockCodes.call(text, index, line, @lines)
+          current_link_type = IgnoreLiquidInLinks.call(line)
+
+          if current_block_code_type
+            output << "{% raw %}#{line.chomp}{% endraw %}\n"
+          elsif current_link_type
+            output << "{% raw %}#{line.chomp}{% endraw %}\n"
+          else
+            output << line
+          end
+        end
+        output.join
+      end
+    end
+  end
+end

--- a/lib/html/ignore_liquid.rb
+++ b/lib/html/ignore_liquid.rb
@@ -2,25 +2,9 @@ module HTML
   class IgnoreLiquid
     class << self
       def call(text)
-        @lines = text.lines
-        # Initialize a flag to identify block codes in the loop,
-        # possible values are "bc. ", "bc.. ", nil
-        current_block_code_type = nil
-        output = []
-
-        @lines.each_with_index do |line, index|
-          current_block_code_type = IgnoreLiquidInTextileBlockCodes.call(text, index, line, @lines)
-          current_link_type = IgnoreLiquidInLinks.call(line)
-
-          if current_block_code_type
-            output << "{% raw %}#{line.chomp}{% endraw %}\n"
-          elsif current_link_type
-            output << "{% raw %}#{line.chomp}{% endraw %}\n"
-          else
-            output << line
-          end
-        end
-        output.join
+        # first escape code blocks, then escape links
+        escaped_code_blocks = IgnoreLiquidInTextileBlockCodes.call(text)
+        IgnoreLiquidInLinks.call(escaped_code_blocks)
       end
     end
   end

--- a/lib/html/ignore_liquid_in_links.rb
+++ b/lib/html/ignore_liquid_in_links.rb
@@ -13,7 +13,8 @@ module HTML
         output = []
 
         lines.each_with_index do |line, index|
-          if line !~ LIQUID_RAW_RE && line =~ LINK_RE # check that it's a link and is not already escaped
+          # check that it doesn't yet have {% raw %} tags and is a url
+          if line !~ LIQUID_RAW_RE && line =~ LINK_RE
             output << "{% raw %}#{line.chomp}{% endraw %}\n"
           else
             output << line

--- a/lib/html/ignore_liquid_in_links.rb
+++ b/lib/html/ignore_liquid_in_links.rb
@@ -5,10 +5,21 @@ module HTML
       callto feed svn urn aim rsync tag ssh sftp rtsp afs file
     }.join('|')
     LINK_RE = %r{ (?: ((?:#{PROTOCOLS}):)// | www\. ) [^\s<\u00A0"|]+ }ix
+    LIQUID_RAW_RE = /\{%\s*raw\s*%\}(.*?)\{%\s*endraw\s*%\}/
 
     class << self
-      def call(line)
-        line =~ LINK_RE
+      def call(text)
+        lines = text.lines
+        output = []
+
+        lines.each_with_index do |line, index|
+          if line !~ LIQUID_RAW_RE && line =~ LINK_RE # check that it's a link and is not already escaped
+            output << "{% raw %}#{line.chomp}{% endraw %}\n"
+          else
+            output << line
+          end
+        end
+        output.join
       end
     end
   end

--- a/lib/html/ignore_liquid_in_links.rb
+++ b/lib/html/ignore_liquid_in_links.rb
@@ -17,8 +17,7 @@ module HTML
           else
             line
           end
-        end
-        lines.join
+        end.join
       end
     end
   end

--- a/lib/html/ignore_liquid_in_links.rb
+++ b/lib/html/ignore_liquid_in_links.rb
@@ -1,0 +1,15 @@
+module HTML
+  class IgnoreLiquidInLinks
+    PROTOCOLS = %w{
+      ed2k ftp http https irc mailto news gopher nntp telnet webcal xmpp
+      callto feed svn urn aim rsync tag ssh sftp rtsp afs file
+    }.join('|')
+    LINK_RE = %r{ (?: ((?:#{PROTOCOLS}):)// | www\. ) [^\s<\u00A0"|]+ }ix
+
+    class << self
+      def call(line)
+        line =~ LINK_RE
+      end
+    end
+  end
+end

--- a/lib/html/ignore_liquid_in_links.rb
+++ b/lib/html/ignore_liquid_in_links.rb
@@ -10,17 +10,15 @@ module HTML
     class << self
       def call(text)
         lines = text.lines
-        output = []
 
-        lines.each_with_index do |line, index|
-          # check that it doesn't yet have {% raw %} tags and is a url
+        lines.map do |line|
           if line !~ LIQUID_RAW_RE && line =~ LINK_RE
-            output << "{% raw %}#{line.chomp}{% endraw %}\n"
+            "{% raw %}#{line.chomp}{% endraw %}\n"
           else
-            output << line
+            line
           end
         end
-        output.join
+        lines.join
       end
     end
   end

--- a/lib/html/ignore_liquid_in_textile_block_codes.rb
+++ b/lib/html/ignore_liquid_in_textile_block_codes.rb
@@ -6,23 +6,39 @@ module HTML
     ).freeze
 
     class << self
-      def call(text, index, line, lines)
-        @lines = lines
+      def call(text)
+        @lines = text.lines
+        # Initialize a flag to identify block codes in the loop,
+        # possible values are "bc. ", "bc.. ", nil
         current_block_code_type = nil
-        BLOCK_CODE_TYPES.each do |block_code_type|
-          if line.start_with?(block_code_type)
-            current_block_code_type = block_code_type
+        output = []
+
+        @lines.each_with_index do |line, index|
+          BLOCK_CODE_TYPES.each do |block_code_type|
+            if line.start_with?(block_code_type)
+              current_block_code_type = block_code_type
+            end
+          end
+
+          # If the flag is set previously, check if we can set it to nil
+          if current_block_code_type
+            if can_close_block_code?(
+              block_code_type: current_block_code_type,
+              line: line,
+              index: index
+            )
+              current_block_code_type = nil
+            end
+          end
+
+          # If the flag is still present, ignore liquid
+          if current_block_code_type
+            output << "{% raw %}#{line.chomp}{% endraw %}\n"
+          else
+            output << line
           end
         end
-
-        if can_close_block_code?(
-          block_code_type: current_block_code_type,
-          line: line,
-          index: index
-          )
-          current_block_code_type = nil
-        end
-        current_block_code_type
+        output.join
       end
 
       def can_close_block_code?(block_code_type:, index:, line:)

--- a/lib/html/ignore_liquid_in_textile_block_codes.rb
+++ b/lib/html/ignore_liquid_in_textile_block_codes.rb
@@ -38,6 +38,7 @@ module HTML
             output << line
           end
         end
+
         output.join
       end
 

--- a/lib/html/ignore_liquid_in_textile_block_codes.rb
+++ b/lib/html/ignore_liquid_in_textile_block_codes.rb
@@ -6,40 +6,23 @@ module HTML
     ).freeze
 
     class << self
-      def call(text)
-        @lines = text.lines
-        # Initialize a flag to identify block codes in the loop,
-        # possible values are "bc. ", "bc.. ", nil
+      def call(text, index, line, lines)
+        @lines = lines
         current_block_code_type = nil
-        output = []
-
-        @lines.each_with_index do |line, index|
-          BLOCK_CODE_TYPES.each do |block_code_type|
-            if line.start_with?(block_code_type)
-              current_block_code_type = block_code_type
-            end
-          end
-
-          # If the flag is set previously, check if we can set it to nil
-          if current_block_code_type
-            if can_close_block_code?(
-              block_code_type: current_block_code_type,
-              line: line,
-              index: index
-            )
-              current_block_code_type = nil
-            end
-          end
-
-          # If the flag is still present, ignore liquid
-          if current_block_code_type
-            output << "{% raw %}#{line.chomp}{% endraw %}\n"
-          else
-            output << line
+        BLOCK_CODE_TYPES.each do |block_code_type|
+          if line.start_with?(block_code_type)
+            current_block_code_type = block_code_type
           end
         end
 
-        output.join
+        if can_close_block_code?(
+          block_code_type: current_block_code_type,
+          line: line,
+          index: index
+          )
+          current_block_code_type = nil
+        end
+        current_block_code_type
       end
 
       def can_close_block_code?(block_code_type:, index:, line:)

--- a/lib/html/pipeline/dradis/liquid_filter.rb
+++ b/lib/html/pipeline/dradis/liquid_filter.rb
@@ -3,7 +3,7 @@ module HTML
     module Dradis
       class LiquidFilter < TextFilter
         def call
-          @text = HTML::IgnoreLiquidInTextileBlockCodes.call(@text)
+          @text = HTML::IgnoreLiquid.call(@text)
 
           assigns = context.fetch(:liquid_assigns, {})
 

--- a/spec/lib/html/ignore_liquid_in_links_spec.rb
+++ b/spec/lib/html/ignore_liquid_in_links_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe HTML::IgnoreLiquidInLinks do
+  it 'wraps the line with liquid "raw" tags' do
+    source = 'p.https://hello.world'
+    result = "{% raw %}p.https://hello.world{% endraw %}\n"
+    expect(described_class.call(source)).to eq(result)
+  end
+
+  context "links that contain '{{'" do
+    it 'wraps the line with liquid "raw" tags' do
+      source = 'p.https://he{{o.world'
+      result = "{% raw %}p.https://he{{o.world{% endraw %}\n"
+      expect(described_class.call(source)).to eq(result)
+    end
+  end
+end

--- a/spec/lib/html/ignore_liquid_spec.rb
+++ b/spec/lib/html/ignore_liquid_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe HTML::IgnoreLiquid do
+  describe 'bc. block code' do
+    it 'ignores liquid in both block code and links' do
+      source = "bc. single line single paragraph block code\r\n\r\np.https://hello.world"
+      result = described_class.call(source).to_s
+      expect(result.lines.select { |line| line.include?('{% raw %}') }.size).to eq(2)
+    end
+  end
+
+  describe 'bc.. block code' do
+    it 'ignores liquid in both block code and links' do
+      source = "bc.. multi paragraph\r\nblock code\r\nstill in the block code\r\np.https://hello.world"
+      result = described_class.call(source).to_s
+      expect(result.lines.select { |line| line.include?('{% raw %}') }.size).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
### Summary
A link that contains '{{' interferes with the rest of the liquid content in the issue text, because Liquid tries to parse it but does not find an associated closing '}}'. 

Proposed solution:
Add {% raw %} {% endraw %} tags around urls (like we are doing with code blocks) so that they are not evaluated as liquid content

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
