### PR TITLE
Validate methodology content so that blank templates cannot be created

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,8 +8,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - Methodologies: validate presence of content
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/models/methodology.rb
+++ b/app/models/methodology.rb
@@ -15,7 +15,7 @@ end
 class Section
   def initialize(xml_node); @node = xml_node; end
   def name(); @name ||= @node.xpath('name')[0].text; end
-  def tasks(); @node.xpath('tasks/task').collect{|t| Task.new(t) }; end
+  def tasks(); @node.xpath('tasks/task').collect { |t| Task.new(t) }; end
 end
 
 class Methodology
@@ -197,7 +197,7 @@ class Methodology
   end
 
   def sections
-    self.doc.xpath('methodology/sections/section').collect{|s| Section.new(s) }
+    self.doc.xpath('methodology/sections/section').collect { |s| Section.new(s) }
   end
 
   # This should be replaced by a has_many association
@@ -210,7 +210,7 @@ class Methodology
   end
 
   def completed_tasks
-    self.tasks.select{|task| task.checked? }
+    self.tasks.select { |task| task.checked? }
   end
 
   private

--- a/app/models/methodology.rb
+++ b/app/models/methodology.rb
@@ -27,6 +27,7 @@ class Methodology
 
   attr_accessor :content, :filename, :name, :updated_at
 
+  validates_presence_of :content
   # validates_presence_of :name
   # validates_format_of :name, :with => /\A\w+[\w\s]*\z/
   validate :xml_syntax
@@ -45,7 +46,6 @@ class Methodology
     @pwd ||= Pathname.new(Configuration.paths_templates_methodologies)
   end
 
-
   # --------------------------------------------------------- ActiveModel::Lint
 
   # ActiveModel expects you to define an id() method to uniquely identify each
@@ -61,7 +61,6 @@ class Methodology
   # def destroyed?()  true end
   def persisted?()  false end
 
-
   # ---------------------------------------------------------------- Enumerable
 
   # When comparing two NoteTemplate instances, sort them alphabetically on their
@@ -70,12 +69,10 @@ class Methodology
     self.name <=> other.name
   end
 
-
   # ------------------------------------------------------ ActiveRecord finders
 
   # Find by :id, which in this case is the file's basename
   def self.find(id)
-
     # Discard any input with weird characters
     if (id =~ /\A[\x00\/\\:\*\?\"<>\|]\z/)
       raise Exception.new('Not found!')
@@ -103,20 +100,19 @@ class Methodology
     end.sort
   end
 
-
   # -------------------------------------------------------------- Constructors
 
   # Creates an instance of Methodology from a given XML file.
   def self.from_file(filename)
     Methodology.new({
-      :filename => File.basename(filename, '.xml'),
-      :content => File.read(filename),
-      :updated_at => File.mtime(filename)
+      filename: File.basename(filename, '.xml'),
+      content: File.read(filename),
+      updated_at: File.mtime(filename)
     })
   end
 
   # Constructor a la ActiveRecord. Attributes: :name, :file
-  def initialize(attributes={})
+  def initialize(attributes = {})
     attributes.each do |name, value|
       send("#{name}=", value)
     end
@@ -178,13 +174,12 @@ class Methodology
   end
 
   def version
-    @version ||= if !doc.root
-                   nil
-                 elsif doc.root[:version].nil?
-                   doc.root.name == 'board' ? 2 : 1
-                 else
-                   doc.root[:version].to_i
-                 end
+    @version ||=
+      if doc.root[:version].nil?
+        doc.root.name == 'board' ? 2 : 1
+      else
+        doc.root[:version].to_i
+      end
   end
 
   # ----------------------------------------------------- Sections, lists, tasks

--- a/spec/models/methodology_spec.rb
+++ b/spec/models/methodology_spec.rb
@@ -6,6 +6,8 @@ require 'rails_helper'
 describe Methodology do
   subject { ::Methodology.new }
 
+  it { should validate_presence_of :content }
+
   # FIXME, right now ActiveModel lint fails because to_params returns the filename even if
   # persisted? is false.
   # The problem is we're using an spurious Methodology object (whose backend is a Note and

--- a/spec/models/methodology_spec.rb
+++ b/spec/models/methodology_spec.rb
@@ -26,8 +26,8 @@ describe Methodology do
     FileUtils.rm_rf('tmp/templates')
   end
 
-  describe "#destroy" do
-    it "deletes file from disk on destroy" do
+  describe '#destroy' do
+    it 'deletes file from disk on destroy' do
       mt = Methodology.new(
         content: '<foo version="2">bar</foo>',
         filename: 'mt_test'
@@ -48,7 +48,7 @@ describe Methodology do
 
       filename = Methodology.pwd.join('foobar.xml')
       FileUtils.mkdir_p(Methodology.pwd)
-      File.open(filename,'w'){ |f| f<<'barfoo' }
+      File.open(filename, 'w') { |f| f << 'barfoo' }
 
       mt = Methodology.from_file(filename)
       expect(mt.content).to eq('barfoo')
@@ -58,8 +58,8 @@ describe Methodology do
     end
   end
 
-  describe "#name=" do
-    it "updates content when setting :name attribute" do
+  describe '#name=' do
+    it 'updates content when setting :name attribute' do
       methodology = Methodology.from_file('spec/fixtures/files/methodologies/webapp.xml')
       methodology.name = 'Foo'
       expect(methodology.name).to eq('Foo')
@@ -67,7 +67,7 @@ describe Methodology do
     end
   end
 
-  describe "#save" do
+  describe '#save' do
     it "creates the base dir if it doesn't exist when saving" do
       FileUtils.rm_rf(Methodology.pwd) if File.exists?(Methodology.pwd)
 
@@ -86,8 +86,7 @@ describe Methodology do
       Timecop.return
     end
 
-
-    it "saves the template contents when saving the instance" do
+    it 'saves the template contents when saving the instance' do
       mt = Methodology.new(
         content: '<foo version="2">bar</foo>',
         filename: 'mt_test'
@@ -100,8 +99,8 @@ describe Methodology do
     end
   end
 
-  describe "#to_html_anchor" do
-    it "discards non-alphanumeric characters in the name" do
+  describe '#to_html_anchor' do
+    it 'discards non-alphanumeric characters in the name' do
       methodology = Methodology.new(filename: 'mt_test')
 
       methodology.name = 'Foo [Bar]'
@@ -115,15 +114,15 @@ describe Methodology do
     end
   end
 
-  context "working with tasks" do
-    it "defines a #tasks method that returns the list of tasks across sections" do
+  context 'working with tasks' do
+    it 'defines a #tasks method that returns the list of tasks across sections' do
       methodology = Methodology.from_file('spec/fixtures/files/methodologies/webapp.xml')
       expect(methodology).to respond_to(:tasks)
       expect(methodology.tasks).to respond_to(:count)
       expect(methodology.tasks.count).to eq(4)
     end
 
-    it "defines a #completed_tasks method that returns the list of tasks already completed" do
+    it 'defines a #completed_tasks method that returns the list of tasks already completed' do
       methodology = Methodology.from_file('spec/fixtures/files/methodologies/webapp.xml')
       expect(methodology).to respond_to(:completed_tasks)
       expect(methodology.completed_tasks).to respond_to(:count)


### PR DESCRIPTION
### Summary

- Disallow blank methodology templates from being created/saved using a validator in the Methodology model
- Remove line that sets methodology version to nil if there is no root node, since root nodes are not permitted as long as the content is not blank
This resolves the error that users are seeing when trying to access methodologies#index with a blank methodology

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
