### PR TITLE
Use a shared helper to store flash attributes and alert types, to allow for customization

### DIFF
--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -2,18 +2,19 @@ module FlashHelper
   # In general controllers use :error, but :alert is used with redirect_to
   # http://guides.rubyonrails.org/action_controller_overview.html#the-flash
   ALERT_TYPES = {
-    'alert'   => 'alert-danger',
-    'error'   => 'alert-danger',
-    'info'    => 'alert-info',
-    'notice'  => 'alert-success',
-    'warning' => 'alert-warning'
+    'alert'               => 'alert-danger',
+    'error'               => 'alert-danger',
+    'info'                => 'alert-info',
+    'notice'              => 'alert-success',
+    'warning'             => 'alert-warning',
+    'warning_dismissible' => 'alert-warning'
   }
 
-  def flash_attrs(name)
+  def flash_attrs(msg, name)
     attrs = {}
-    attrs[:flash_css] = "alert #{ALERT_TYPES.fetch(name)} alert-dismissible"
+    attrs[:flash_css]  = "alert #{ALERT_TYPES.fetch(name)} alert-dismissible"
     attrs[:data_attrs] = { bs_dismiss: 'alert' }
-    attrs = flash_attrs_pro(name, attrs) if defined? Dradis::Pro
+    attrs = flash_attrs_pro(attrs, msg, name) if defined? Dradis::Pro
     attrs
   end
 

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -17,6 +17,6 @@ module FlashHelper
     attrs
   end
 
-  def flash_attrs_pro(name)
+  def flash_attrs_pro(name, attrs)
   end
 end

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -18,6 +18,6 @@ module FlashHelper
     attrs
   end
 
-  def flash_attrs_pro(name, attrs)
+  def flash_attrs_pro(attrs, msg, name)
   end
 end

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -1,0 +1,18 @@
+module FlashHelper
+  # In general controllers use :error, but :alert is used with redirect_to
+  # http://guides.rubyonrails.org/action_controller_overview.html#the-flash
+  ALERT_TYPES = {
+    'alert'   => 'alert-danger',
+    'error'   => 'alert-danger',
+    'info'    => 'alert-info',
+    'notice'  => 'alert-success',
+    'warning' => 'alert-warning'
+  }
+
+  def flash_attrs(name)
+    attrs = {}
+    attrs[:flash_css] = "alert #{ALERT_TYPES.fetch(name)} alert-dismissible"
+    attrs[:data_attrs] = { bs_dismiss: 'alert' }
+    attrs
+  end
+end

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -13,6 +13,10 @@ module FlashHelper
     attrs = {}
     attrs[:flash_css] = "alert #{ALERT_TYPES.fetch(name)} alert-dismissible"
     attrs[:data_attrs] = { bs_dismiss: 'alert' }
+    attrs = flash_attrs_pro(name, attrs) if defined? Dradis::Pro
     attrs
+  end
+
+  def flash_attrs_pro(name)
   end
 end

--- a/app/helpers/tylium_helper.rb
+++ b/app/helpers/tylium_helper.rb
@@ -12,22 +12,12 @@ module TyliumHelper
   end
 
   def flash_messages
-    # In general controllers use :error, but :alert is used with redirect_to
-    #   http://guides.rubyonrails.org/action_controller_overview.html#the-flash
-    alert_types = {
-      'alert'   => 'alert-danger',
-      'error'   => 'alert-danger',
-      'info'    => 'alert-info',
-      'notice'  => 'alert-success',
-      'warning' => 'alert-warning'
-    }
+    flash.select { |key, _| FlashHelper::ALERT_TYPES.keys.include?(key) }.collect do |name, msg|
+      flash_attrs = flash_attrs(name)
 
-    flash.select { |key, _| alert_types.keys.include?(key) }.collect do |name, msg|
-      flash_css = "alert #{alert_types.fetch(name)} alert-dismissible"
-
-      content_tag :div, class: flash_css do
+      content_tag :div, class: flash_attrs[:flash_css] do
         [
-          button_tag(class: 'btn-close', data: { bs_dismiss: 'alert' }) do
+          button_tag(class: 'btn-close', data: flash_attrs[:data_attrs]) do
             '<span class="visually-hidden">Close alert</span>'.html_safe
           end,
           h(msg)

--- a/app/helpers/tylium_helper.rb
+++ b/app/helpers/tylium_helper.rb
@@ -13,7 +13,7 @@ module TyliumHelper
 
   def flash_messages
     flash.select { |key, _| FlashHelper::ALERT_TYPES.keys.include?(key) }.collect do |name, msg|
-      flash_attrs = flash_attrs(name)
+      flash_attrs = flash_attrs(msg, name)
 
       content_tag :div, class: flash_attrs[:flash_css] do
         [


### PR DESCRIPTION
### Summary
Use flash_helper to store alert types and flash attributes


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
