### PR TITLE
Nokogiri lock

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,10 +6,10 @@
   - Web-server: Replace unicorn with puma in production
   - Upgraded gems:
     - rails
-    - nokogiri (lock to 1.14.5)
   - Bugs fixes:
     - Evidence: Prevent loading old Evidence template content at the Issue level
     - Methodologies: validate presence of content
+    - Burp: Temporarily lock nokogiri to 1.14.5 to avoid XML parsing error
   - New integrations:
     - [integration]
   - Integration enhancements:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,9 +7,9 @@
   - Upgraded gems:
     - rails
   - Bugs fixes:
+    - Burp: Temporarily lock nokogiri to 1.14.5 to avoid XML parsing error
     - Evidence: Prevent loading old Evidence template content at the Issue level
     - Methodologies: validate presence of content
-    - Burp: Temporarily lock nokogiri to 1.14.5 to avoid XML parsing error
   - New integrations:
     - [integration]
   - Integration enhancements:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
   - Web-server: Replace unicorn with puma in production
   - Upgraded gems:
     - rails
+    - nokogiri (lock to 1.14.5)
   - Bugs fixes:
     - Evidence: Prevent loading old Evidence template content at the Issue level
     - Methodologies: validate presence of content

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ gem 'bcrypt', '3.1.12'
 gem 'json', '2.3.0'
 
 # XML manipulation
-gem 'nokogiri', '>= 1.14.3'
+gem 'nokogiri', '~> 1.14.5'
 
 # MySQL backend
 # gem 'mysql2', '~> 0.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
     matrix (0.4.2)
     method_source (0.9.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     mini_racer (0.6.2)
       libv8-node (~> 16.10.0.0)
     minitest (5.20.0)
@@ -306,14 +306,14 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.4)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.14.5)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.15.4-arm64-darwin)
+    nokogiri (1.14.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-darwin)
+    nokogiri (1.14.5-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.14.5-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -334,7 +334,7 @@ GEM
     public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rack-mini-profiler (2.3.0)
       rack (>= 1.2.0)
@@ -580,7 +580,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri (>= 1.14.3)
+  nokogiri (~> 1.14.5)
   paper_trail (~> 12.2.0)
   parslet (~> 1.6.0)
   pg


### PR DESCRIPTION
### Spec
#### Problem
While uploading a burp file, there was a parsing issue that was not letting the upload to complete.

#### Solution
Locking Nokogiri to version 1.14.5 solves this issue.

Check List
- [x] Added a CHANGELOG entry