### PR TITLE
Adds liquid display support for issue titles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
   - Bugs fixes:
     - Evidence: Prevent loading old Evidence template content at the Issue level
     - Methodologies: validate presence of content
+    - Issues: Displays liquid content within the title throughout the app
   - New integrations:
     - [integration]
   - Integration enhancements:

--- a/app/views/issues/_breadcrumbs.html.erb
+++ b/app/views/issues/_breadcrumbs.html.erb
@@ -1,6 +1,6 @@
 <nav>  
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><%= link_to 'All issues', project_issues_path(current_project) %></li>
-    <li class="breadcrumb-item active"><%= (@issue.title? ? @issue.title : "Issue ##{@issue.id}")%></li>
+    <li class="breadcrumb-item active"><%= (@issue.title? ? markup(@issue.title, liquid: true) : "Issue ##{@issue.id}")%></li>
   </ol>
 </nav>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -4,9 +4,9 @@
 %>
 
 <%= content_tag :div, id: "#{dom_id(issue)}_link", class: item_css.join do %>
-  <%= link_to  main_app.project_issue_path(current_project, issue) do %>
+  <%= link_to main_app.project_issue_path(current_project, issue) do %>
     <%= colored_icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
-    <%= issue.title %>
+    <%= strip_tags markup(issue.title, liquid: true) %>
   <% end %>
 
   <div class="list-item-actions">

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -25,10 +25,11 @@
           <tr id="issue-<%= issue.id %>" data-tag-url="<%= project_issue_path(current_project, issue) %>">
             <td class="select-checkbox" data-behavior="select-checkbox"></td>
             <% @all_columns.each do |column| %>
+              <% title = strip_tags(markup(issue.title, liquid: true)) %>
               <% sort, display =
                 case column
                 when 'Title'
-                  [issue.title, (link_to(issue.title, [current_project, issue], data: { qa_visible: false } ) + link_to(issue.title, project_qa_issue_path(current_project, issue), class: 'd-none', data: { qa_visible: true }))]
+                  [title, (link_to(title, [current_project, issue], data: { qa_visible: false } ) + link_to(title, project_qa_issue_path(current_project, issue), class: 'd-none', data: { qa_visible: true }))]
                 when 'Tags'
                   [
                     issue.tags.any? ? issue.tags.first.display_name : '',

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, @issue.title %>
+<% content_for :title, strip_tags(markup(@issue.title, liquid: true)) %>
 
 <% content_for :sidebar do %>
   <%= render 'sidebar'%>
@@ -32,7 +32,7 @@
           <% cache ['issue-information-tab', @issue] do %>
             <div class="note-text-inner">
               <h4 class="mb-4 header-underline">
-                <span class="text-truncate" title="<%= @issue.title %>"><%= @issue.title %></span>
+              <span class="text-truncate" title="<%= strip_tags(markup(@issue.title, liquid: true)) %>"><%= strip_tags(markup(@issue.title, liquid: true)) %></span>
                 <%= render partial: 'actions' %>
               </h4>
               <div class="content-textile" data-behavior="content-textile">


### PR DESCRIPTION
### Summary

When an `Issue` has liquid content in the title, it is not being displayed properly in some parts of the app.

### Solution

Parse liquid content where the `Issue` titles are being displayed

### Check List

- [x] Added a CHANGELOG entry
