### PR TITLE
Move state enum from issue to note

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -10,8 +10,6 @@ class Issue < Note
 
   include Taggable
 
-  enum state: [:draft, :ready_for_review, :published]
-
   # -- Relationships --------------------------------------------------------
   has_many :evidence, dependent: :destroy
   has_many :affected, through: :evidence, source: :node

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -34,6 +34,14 @@ class Note < ApplicationRecord
 
   dradis_has_fields_for :text
 
+  # FIXME - ISSUE?/NOTE INHERITANCE
+  # Issues have QA states but notes don't currently use states.
+  # Since Issue is an extension of Note, notes have a state column too.
+  # We need to define the enum here so that states can be referenced whether
+  # the Note or the Issue is pulled when calling Activity.includes(:trackable).
+  # (Since we're not using STI, .includes only joins the class of the most recent
+  # Activity instead of pulling the correct class (Note/Issue) for each activity)
+  enum state: [:draft, :ready_for_review, :published]
 
   # -- Relationships --------------------------------------------------------
   belongs_to :category
@@ -61,13 +69,11 @@ class Note < ApplicationRecord
   validates :node, presence: true
   validates :text, length: { maximum: DB_MAX_TEXT_LENGTH }
 
-
   # -- Scopes ---------------------------------------------------------------
   scope :recently_created, -> { where(['notes.created_at > ?', 1.day.ago]) }
   scope :recently_updated, -> { where(['notes.updated_at > ?', 1.day.ago]) }
 
   # -- Class Methods --------------------------------------------------------
-
 
   # -- Instance Methods -----------------------------------------------------
 


### PR DESCRIPTION
### Summary
Since we're not using true STI with notes/issues, `.includes(:trackable)` doesn't work as expected. 
When using the `:latest` scope on `Activity`, Rails loads all of the associated Notes or Issues as the same object type as the most recent `trackable_type` instead of pulling the correct type for each activity.

Ex. if the most recent note/issue Activity has `trackable_type` of `'Note'`, then all Activities of type note/issue will be loaded as Notes

This is noticeable when trying to interact with an Issue's state if the issue has been loaded as a Note because notes have an integer state and issues have an enum state. 

This solution moves the state enum to the Note model from the Issue model


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
