### PR TITLE
Render Issue titles with liquid conditionals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
     - [gem]
   - Bugs fixes:
     - Tylium: Fix redirection when updating an issue or content block
+    - Issues: Render liquid content within the title throughout the app
     - Bug tracker items:
       - [item]
   - New integrations:
@@ -47,7 +48,7 @@ v4.11.0 (January 2024)
     - Qualys: Add support for the output for Qualys WAS API 3.13 and later
   - Security Fixes:
     - Low: Authenticated (author) information disclosure
-      - After a user has been removed from a project, they may still get 
+      - After a user has been removed from a project, they may still get
         notifications for Issues they were subscribed to, resulting in the
         disclosure of Issue titles.
     - Low: Authenticated (author) information disclosure in the output console of upload manager

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,6 +2,7 @@
 # users.
 
 class ActivitiesController < AuthenticatedController
+  include LiquidEnabledResource
   include ProjectScoped
 
   def index

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -6,6 +6,7 @@ class EvidenceController < NestedNodeResourceController
   include MultipleDestroy
   include NodesSidebar
   include NotificationsReader
+  include ProjectScoped
 
   before_action :set_or_initialize_evidence, except: [ :index, :create_multiple ]
   before_action :initialize_nodes_sidebar, only: [ :edit, :new, :show ]

--- a/app/controllers/issues/evidence_controller.rb
+++ b/app/controllers/issues/evidence_controller.rb
@@ -2,6 +2,7 @@ class Issues::EvidenceController < AuthenticatedController
   include ActivityTracking
   include ContentFromTemplate
   include DynamicFieldNamesCacher
+  include LiquidEnabledResource
   include MultipleDestroy
   include ProjectScoped
 

--- a/app/controllers/nested_node_resource_controller.rb
+++ b/app/controllers/nested_node_resource_controller.rb
@@ -2,6 +2,7 @@
 class NestedNodeResourceController < AuthenticatedController
   include ActivityTracking
   include ContentFromTemplate
+  include LiquidEnabledResource
   include ProjectScoped
 
   before_action :find_or_initialize_node

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,5 @@
 class ProjectsController < AuthenticatedController
+  include LiquidEnabledResource
   include NotificationsReader
 
   before_action :set_project
@@ -16,12 +17,12 @@ class ProjectsController < AuthenticatedController
     @authors       = [current_user]
     @boards        = current_project.methodology_library.boards
     @issues        = current_project.issues.includes(:tags).sort
-    @methodologies = current_project.methodology_library.notes.map{|n| Methodology.new(filename: n.id, content: n.text)}
+    @methodologies = current_project.methodology_library.notes.map { |n| Methodology.new(filename: n.id, content: n.text) }
     @nodes         = current_project.nodes.in_tree
     @tags          = current_project.tags
 
     @count_by_tag  = { unassigned: 0 }
-    @issues_by_tag = Hash.new{|h,k| h[k] = [] }
+    @issues_by_tag = Hash.new { |h, k| h[k] = [] }
 
     @tag_names = @tags.map do |tag|
       @count_by_tag[tag.name] = 0
@@ -41,7 +42,7 @@ class ProjectsController < AuthenticatedController
     end
 
     respond_to do |format|
-      format.html { render layout: 'tylium' if !request.xhr?}
+      format.html { render layout: 'tylium' if !request.xhr? }
       format.json { render json: @boards }
     end
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,5 @@
 class SearchController < AuthenticatedController
+  include LiquidEnabledResource
   include ProjectScoped
   include SearchHelper
 
@@ -15,11 +16,13 @@ class SearchController < AuthenticatedController
 
   private
   def set_scope
-    @scope = if params[:scope].blank? ||
-                  !%{all evidence issues nodes notes}.include?(params[:scope])
-               :all
-             else
-               params[:scope].to_sym
-             end
+    @scope =
+      if params[:scope].blank? ||
+         !%{all cards content_blocks evidence issues nodes notes}.\
+           include?(params[:scope])
+        :all
+      else
+        params[:scope].to_sym
+      end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper # :nodoc:
-  def markup(text, options={})
+  def markup(text, options = {})
     return unless text.present?
 
     context = {}
@@ -25,6 +25,10 @@ module ApplicationHelper # :nodoc:
     textile_pipeline = HTML::Pipeline.new pipeline_filters, context
     result = textile_pipeline.call(text)
     result[:output].to_s.html_safe
+  end
+
+  def liquid_text(text)
+    strip_tags(markup(text, liquid: true))
   end
 
   def render_view_hooks(partial, locals: {}, feature: :addon)

--- a/app/views/evidence/activities/_evidence.html.erb
+++ b/app/views/evidence/activities/_evidence.html.erb
@@ -3,7 +3,7 @@
   <% node  = evidence.node %>
   <%= presenter.verb %> <%= link_to 'a piece of evidence', [current_project, node, evidence] %>
   for
-  <%= link_to issue.title || "Issue #{issue.id}", [current_project, evidence.issue] %> at <%= link_to node.label, [current_project, node] %>.
+  <%= link_to liquid_text(issue.title) || "Issue #{issue.id}", [current_project, evidence.issue] %> at <%= link_to node.label, [current_project, node] %>.
 <% else %>
   <% if activity.action == 'destroy' %>
     deleted a piece of evidence.

--- a/app/views/evidence/edit.html.erb
+++ b/app/views/evidence/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Edit evidence for #{@node.label} / #{@evidence.issue.title}" %>
+<% content_for :title, "Edit evidence for #{@node.label} / #{liquid_text(@evidence.issue.title)}" %>
 
 <% content_for :breadcrumbs do %>
   <nav>

--- a/app/views/evidence/show.html.erb
+++ b/app/views/evidence/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "View evidence for #{@node.label} / #{@evidence.issue.title}" %>
+<% content_for :title, "View evidence for #{@node.label} / #{liquid_text(@evidence.issue.title)}" %>
 
 <% if @conflicting_revisions %>
   <%= render "projects/conflicting_revisions", conflicts: @conflicting_revisions, record: @evidence %>

--- a/app/views/issues/_breadcrumbs.html.erb
+++ b/app/views/issues/_breadcrumbs.html.erb
@@ -1,6 +1,6 @@
 <nav>  
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><%= link_to 'All issues', project_issues_path(current_project) %></li>
-    <li class="breadcrumb-item active"><%= (@issue.title? ? @issue.title : "Issue ##{@issue.id}")%></li>
+    <li class="breadcrumb-item active"><%= (@issue.title? ? liquid_text(@issue.title) : "Issue ##{@issue.id}")%></li>
   </ol>
 </nav>

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -4,9 +4,9 @@
 %>
 
 <%= content_tag :div, id: "#{dom_id(issue)}_link", class: item_css.join do %>
-  <%= link_to  main_app.project_issue_path(current_project, issue) do %>
+  <%= link_to main_app.project_issue_path(current_project, issue) do %>
     <%= colored_icon_for_model(issue, 'fa-bug', 'list-item-icon') %>
-    <%= issue.title %>
+    <%= liquid_text(issue.title) %>
   <% end %>
 
   <div class="list-item-actions">

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -25,10 +25,11 @@
           <tr id="issue-<%= issue.id %>" data-tag-url="<%= project_issue_path(current_project, issue) %>">
             <td class="select-checkbox" data-behavior="select-checkbox"></td>
             <% @all_columns.each do |column| %>
+              <% title = strip_tags(markup(issue.title, liquid: true)) %>
               <% sort, display =
                 case column
                 when 'Title'
-                  [issue.title, (link_to(issue.title, [current_project, issue], data: { qa_visible: false } ) + link_to(issue.title, project_qa_issue_path(current_project, issue), class: 'd-none', data: { qa_visible: true }))]
+                  [title, (link_to(title, [current_project, issue], data: { qa_visible: false } ) + link_to(title, project_qa_issue_path(current_project, issue), class: 'd-none', data: { qa_visible: true }))]
                 when 'Tags'
                   [
                     issue.tags.any? ? issue.tags.first.display_name : '',

--- a/app/views/issues/activities/_issue.html.erb
+++ b/app/views/issues/activities/_issue.html.erb
@@ -1,6 +1,6 @@
 <% if issue %>
   <% if issue.title? %>
-    <%= presenter.verb %> the <%= link_to issue.title, project_issue_path(current_project, issue) %> <%= activity.action == 'state_change' ? "issue's state to #{issue.state.humanize.downcase}" : 'issue' %>.
+    <%= presenter.verb %> the <%= link_to liquid_text(issue.title), project_issue_path(current_project, issue) %> <%= activity.action == 'state_change' ? "issue's state to #{issue.state.humanize.downcase}" : 'issue' %>.
   <% else %>
     <%= presenter.verb %> <%= link_to "Issue ##{issue.id}", project_issue_path(current_project, issue) %>.
   <% end %>

--- a/app/views/issues/evidence/_table.html.erb
+++ b/app/views/issues/evidence/_table.html.erb
@@ -31,7 +31,7 @@
               when 'Updated'
                 [evidence.updated_at.to_i, local_time_ago(evidence.updated_at)]
               else
-                [evidence.fields.fetch(column, ''), markup(evidence.fields.fetch(column, ''))]
+                [evidence.fields.fetch(column, ''), liquid_text(evidence.fields.fetch(column, ''))]
               end
             %>
             <td data-sort="<%= sort %>"><%= display %></td>

--- a/app/views/issues/evidence/new.html.erb
+++ b/app/views/issues/evidence/new.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, "Add new evidence for #{@issue.title}" %>
+<% content_for :title, "Add new evidence for #{ liquid_text(@issue.title) }" %>
 
 <% content_for :breadcrumbs do %>
   <nav>
     <ol class="breadcrumb">
       <li class="breadcrumb-item"><%= link_to 'All issues', project_issues_path(current_project) %></li>
-      <li class="breadcrumb-item"><%= link_to @issue.title, project_issue_path(current_project, @issue, tab: 'evidence-tab') %></li>
+      <li class="breadcrumb-item"><%= link_to liquid_text(@issue.title), project_issue_path(current_project, @issue, tab: 'evidence-tab') %></li>
       <li class="breadcrumb-item active">New Evidence</li>
     </ol>
   </nav>
@@ -29,7 +29,7 @@
     <div id="issues_editor">
       <div class="note-text-inner">
         <h4 class="header-underline">Add new evidence</h4>
-        <p class="mb-4 pb-3">Add evidence of <em><%= @issue.title ? @issue.title : "Issue ##{@issue.id}" %></em> by selecting or adding nodes below.</p>
+        <p class="mb-4 pb-3">Add evidence of <em><%= @issue.title ? liquid_text(@issue.title) : "Issue ##{@issue.id}" %></em> by selecting or adding nodes below.</p>
         <div class="row">
 
           <div class="col-xl-4">

--- a/app/views/issues/import.html.erb
+++ b/app/views/issues/import.html.erb
@@ -39,7 +39,7 @@
                     sort, display =
                     case column
                     when 'Title'
-                      [issue.title, issue.title]
+                      [liquid_text(issue.title), liquid_text(issue.title)]
                     when 'Tags'
                       [issue_tags(issue), issue_tags(issue)]
                     else

--- a/app/views/issues/merge/new.html.erb
+++ b/app/views/issues/merge/new.html.erb
@@ -58,7 +58,7 @@
                 <div class="radio">
                   <%= label_tag nil, :class => 'w-100' do %>
                     <%= radio_button_tag "id", issue.id, i == 0 %>
-                    Merge into <%= issue.title %>
+                    Merge into <%= liquid_text(issue.title) %>
                     <%= link_to raw('<i class="fa-solid fa-chevron-down"></i>'), "#preview_issue_#{issue.id}", class: 'issue-toggle pull-right', data: { bs_toggle: 'collapse' } %>
                   <% end %>
                 </div>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, @issue.title %>
+<% content_for :title, liquid_text(@issue.title) %>
 
 <% content_for :sidebar do %>
   <%= render 'sidebar'%>
@@ -32,7 +32,7 @@
           <% cache ['issue-information-tab', @issue] do %>
             <div class="note-text-inner">
               <h4 class="mb-4 header-underline">
-                <span class="text-truncate" title="<%= @issue.title %>"><%= @issue.title %></span>
+              <span class="text-truncate" title="<%= liquid_text(@issue.title) %>"><%= liquid_text(@issue.title) %></span>
                 <%= render partial: 'actions' %>
               </h4>
               <div class="content-textile" data-behavior="content-textile">

--- a/app/views/projects/issues/_summary.html.erb
+++ b/app/views/projects/issues/_summary.html.erb
@@ -16,7 +16,7 @@
                 <ul class="list-group">
                   <% @issues_by_tag[tag.name].each do |issue| %>
                     <%= link_to [current_project, issue], class: 'list-group-item'  do %>
-                      <li><i class="fa-solid fa-bug me-2" style="color: <%= tag.color %>"></i><%= issue.title %></li>
+                      <li><i class="fa-solid fa-bug me-2" style="color: <%= tag.color %>"></i><%= liquid_text(issue.title) %></li>
                     <% end %>
                   <% end %>
                 </ul>
@@ -38,7 +38,7 @@
               <ul class="list-group">
                 <% @issues_by_tag[:unassigned].each do |issue| %>
                   <%= link_to [current_project, issue], class: 'list-group-item'  do %>
-                    <li><i class="fa-solid fa-bug me-2"></i><%= issue.title %></li>
+                    <li><i class="fa-solid fa-bug me-2"></i><%= liquid_text(issue.title) %></li>
                   <% end %>
                 <% end %>
               </ul>

--- a/app/views/qa/issues/_breadcrumbs.html.erb
+++ b/app/views/qa/issues/_breadcrumbs.html.erb
@@ -1,6 +1,6 @@
 <nav>
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><%= link_to 'QA', project_qa_issues_path(current_project) %></li>
-    <li class="breadcrumb-item active"><%= (@issue.title? ? @issue.title : "Issue ##{@issue.id}")%></li>
+    <li class="breadcrumb-item active"><%= (@issue.title? ? liquid_text(@issue.title) : "Issue ##{@issue.id}")%></li>
   </ol>
 </nav>

--- a/app/views/qa/issues/show.html.erb
+++ b/app/views/qa/issues/show.html.erb
@@ -20,7 +20,7 @@
       <% cache ['issue-content', @issue] do %>
         <div class="note-text-inner">
           <h4 class="mb-4 header-underline align-items-center">
-            <span class="text-truncate" title="<%= @issue.title %>"><%= @issue.title %></span>
+            <span class="text-truncate" title="<%= liquid_text(@issue.title) %>"><%= liquid_text(@issue.title) %></span>
             <span class="actions">
               <span class="action">
                 <%= link_to edit_project_qa_issue_path(current_project, @issue) do %>

--- a/app/views/search/results/_evidence.html.erb
+++ b/app/views/search/results/_evidence.html.erb
@@ -4,7 +4,7 @@
 <%= link_to title, project_node_evidence_path(row.node.project, row.node_id, row), class: "search-match-title" %>
 
 <div class="result-details">
-  <p><span>Issue:</span> <%= link_to row.issue.title, project_issue_path(current_project, row.issue) %></p>
+  <p><span>Issue:</span> <%= link_to liquid_text(row.issue.title), project_issue_path(current_project, row.issue) %></p>
   <p><span>Node:</span> <%= link_to row.node.label, project_node_path(row.node.project, row.node) %></p>
   <p><span>Last updated:</span> <%= local_time_ago(row.updated_at) %></p>
 </div>


### PR DESCRIPTION
### Summary

When an `Issue` has liquid content in the title, it is not being displayed properly in some parts of the app.

### Solution

Parse liquid content where the `Issue` titles are being displayed

### Check List

- [x] Added a CHANGELOG entry
