### PR TITLE
Migrate templates to db tables

### DIFF
--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -12,7 +12,7 @@ Rails.application.reloader.to_prepare do
     template_dir = Configuration.paths_templates_plugins
 
     Dradis::Plugins::with_feature(:upload).each do |plugin|
-      plugin.copy_templates(to: template_dir)
+      plugin.copy_templates_to_db(from: template_dir)
     end
 
     # ---------------------------------------------------------------- 3.2 Export


### PR DESCRIPTION
### Summary

Because of moving our templates to database-backed tables, this PR migrates existing templates to the table format we will be using upon initialization of the project.

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
