### PR TITLE
Add sub nodes from node modal

### DIFF
--- a/app/views/layouts/tylium/_nodes.html.erb
+++ b/app/views/layouts/tylium/_nodes.html.erb
@@ -5,7 +5,7 @@
       <span class="sidebar-link-label">Nodes</span>
       <div class="d-flex align-items-center gap-1">
         <div class="add-node">
-          <div class="dropdown">
+          <div class="dropdown add-node-toggle">
             <a href="#" data-bs-toggle="dropdown" role="button" aria-expanded="false"><i class="fa-solid fa-plus"></i></a>
             <div class="dropdown-menu">
               <a href="#modal_add_branch_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal"> Add top-level node</a>

--- a/app/views/layouts/tylium/_nodes.html.erb
+++ b/app/views/layouts/tylium/_nodes.html.erb
@@ -5,7 +5,13 @@
       <span class="sidebar-link-label">Nodes</span>
       <div class="d-flex align-items-center gap-1">
         <div class="add-node">
-          <a href="#modal_add_branch_node" data-bs-toggle="modal" tabindex="-1"><i class="fa-solid fa-plus" data-behavior="add-node"></i><span class="visually-hidden">Add node</span></a>
+          <div class="dropdown">
+            <a href="#" data-bs-toggle="dropdown" role="button" aria-expanded="false"><i class="fa-solid fa-plus"></i></a>
+            <div class="dropdown-menu">
+              <a href="#modal_add_branch_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal"> Add top-level node</a>
+              <a href="#modal_add_child_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal"> Add subnode</a>
+            </div>
+          </div>
         </div>
         <div class="dropdown node-tree-dropdown">
           <%= link_to "#node-tree", data: { bs_toggle: 'collapse', behavior: 'collapse-collection toggle-node-tree' } do %>

--- a/app/views/layouts/tylium/_nodes.html.erb
+++ b/app/views/layouts/tylium/_nodes.html.erb
@@ -9,7 +9,9 @@
             <a href="#" data-bs-toggle="dropdown" role="button" aria-expanded="false"><i class="fa-solid fa-plus"></i></a>
             <div class="dropdown-menu">
               <a href="#modal_add_branch_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal"> Add top-level node</a>
-              <a href="#modal_add_child_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal"> Add subnode</a>
+              <% if @node.present? %>
+                <a href="#modal_add_child_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal"> Add subnode</a>
+              <% end %>
             </div>
           </div>
         </div>

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -18,6 +18,32 @@ describe 'node pages' do
     end
 
     describe "clicking the '+' button in the 'Nodes' sidebar", js: true do
+      context 'when no node is selected' do
+        before do
+          visit project_path(current_project)
+          find('.add-node-toggle').click
+        end
+
+        it 'contains a link to create a top-level node only' do
+          expect(page).to have_link 'Add top-level node'
+          expect(page).not_to have_link 'Add subnode'
+        end
+      end
+
+      context 'when a node is selected' do
+        before do
+          visit project_node_path(node.project, node)
+          find('.add-node-toggle').click
+        end
+
+        let(:node) { create(:node, project: current_project) }
+
+        it 'contains links to create a top-level node and a subnode' do
+          expect(page).to have_link 'Add top-level node'
+          expect(page).to have_link 'Add subnode'
+        end
+      end
+
       context 'when Add top-level node is clicked' do
         before do
           visit project_path(current_project)

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -20,7 +20,8 @@ describe 'node pages' do
     describe "clicking the '+' button in the 'Nodes' sidebar", js: true do
       before do
         visit project_path(current_project)
-        find('.add-node > a').click
+        find('.add-node-toggle').click
+        click_link 'Add top-level node'
       end
 
       let(:submit_form) { click_button 'Add' }


### PR DESCRIPTION
### Summary

#### Before:
To add single or multiple sub-nodes to an existing node users would have to:

1. navigate to the existing node
2. click the `...` menu icon
3. click add sub-node
4. fill out and submit the form

#### After:
Users can now click on the `+` icon next to `Nodes` in the sidebar to create single or multiple sub-nodes.

1. navigate to the existing node
2. click the `+` icon next to `Nodes` in the sidebar
3. click on `Add sub-node`
4. fill out and submit the form


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
