### PR TITLE
Add subnodes using the Nodes '+' icon

### DIFF
--- a/app/views/layouts/tylium/_nodes.html.erb
+++ b/app/views/layouts/tylium/_nodes.html.erb
@@ -11,6 +11,10 @@
             <% end %>
             <div class='dropdown-menu'>
               <a href='#modal_add_branch_node' class='dropdown-item' tabindex='-1' data-bs-toggle='modal'>Add top-level node</a>
+              <% if @node %>
+                <div class='divider'></div>
+                <a href='#modal_add_child_node' class='dropdown-item' tabindex='-1' data-bs-toggle='modal'>Add subnode</a>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/layouts/tylium/_nodes.html.erb
+++ b/app/views/layouts/tylium/_nodes.html.erb
@@ -5,7 +5,14 @@
       <span class="sidebar-link-label">Nodes</span>
       <div class="d-flex align-items-center gap-1">
         <div class="add-node">
-          <a href="#modal_add_branch_node" data-bs-toggle="modal" tabindex="-1"><i class="fa-solid fa-plus" data-behavior="add-node"></i><span class="visually-hidden">Add node</span></a>
+          <div class="dropdown">
+            <%= link_to 'javascript:void(0)', class: 'dropdown-toggle add-node-toggle', data: { bs_toggle: 'dropdown' } do %>
+              <i class="fa-solid fa-plus"></i>
+            <% end %>
+            <div class='dropdown-menu'>
+              <a href='#modal_add_branch_node' class='dropdown-item' tabindex='-1' data-bs-toggle='modal'>Add top-level node</a>
+            </div>
+          </div>
         </div>
         <div class="dropdown node-tree-dropdown">
           <%= link_to "#node-tree", data: { bs_toggle: 'collapse', behavior: 'collapse-collection toggle-node-tree' } do %>

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -18,86 +18,95 @@ describe 'node pages' do
     end
 
     describe "clicking the '+' button in the 'Nodes' sidebar", js: true do
-      before do
+      it 'shows a link to create a top-level node' do
         visit project_path(current_project)
-        find('.add-node > a').click
+        find('.add-node-toggle').click
+        expect(page).to have_link 'Add top-level node'
       end
 
-      let(:submit_form) { click_button 'Add' }
-
-      it 'shows a modal for adding a top-level node' do
-        expect(page).to have_field :branch_node_label
-      end
-
-      describe "submitting the 'new top-level node' form" do
-        it 'creates and shows the new node' do
-          fill_in :branch_node_label, with: 'My awesome node'
-          expect { submit_form }.to change { Node.count }.by(1)
-          expect(page).to have_content 'Successfully created node.'
-          new_node = Node.last
-          expect(current_path).to eq project_node_path(new_node.project, new_node)
+      context 'when "Add top-level node" is clicked' do
+        before do
+          visit project_path(current_project)
+          find('.add-node-toggle').click
+          click_link 'Add top-level node'
         end
-      end
 
-      include_examples 'creates an Activity', :create, Node
+        let(:submit_form) { click_button 'Add' }
 
-      example 'adding multiple root nodes' do
-        choose 'Add multiple'
-        expect(page).to have_no_field :branch_node_label
-        expect(page).to have_field :branch_nodes_list
+        it 'shows a modal for adding a top-level node' do
+          expect(page).to have_field :branch_node_label
+        end
 
-        # Include a blank line to make sure that no node gets created:
-        fill_in :branch_nodes_list, with: <<-LIST.strip_heredoc
-            node 1
+        describe "submitting the 'new top-level node' form" do
+          it 'creates and shows the new node' do
+            fill_in :branch_node_label, with: 'My awesome node'
+            expect { submit_form }.to change { Node.count }.by(1)
+            expect(page).to have_content 'Successfully created node.'
+            new_node = Node.last
+            expect(current_path).to eq project_node_path(new_node.project, new_node)
+          end
+        end
 
-            node_2
-                 node with trailing whitespace
-          LIST
+        include_examples 'creates an Activity', :create, Node
 
-        expect do
-          click_button 'Add'
-        end.to change { current_project.nodes.in_tree.count }.by(3) \
-          .and change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(3)
+        example 'adding multiple root nodes' do
+          choose 'Add multiple'
+          expect(page).to have_no_field :branch_node_label
+          expect(page).to have_field :branch_nodes_list
 
-        expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h|
-            h[:job]
-          }.last(3)
-        ).to include *Array.new(3, ActivityTrackingJob)
-        expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
-            h1[:args].map { |h2| h2['action'] }
-          }.flatten.last(3)
-        ).to include *Array.new(3, 'create')
-        expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
-            h1[:args].map { |h2| h2['trackable_type'] }
-          }.flatten.last(3)
-        ).to include *Array.new(3, 'Node')
+          # Include a blank line to make sure that no node gets created:
+          fill_in :branch_nodes_list, with: <<-LIST.strip_heredoc
+              node 1
 
-        expect(current_project.nodes.last(3).map(&:label)).to match_array([
-          'node 1',
-          'node_2',
-          'node with trailing whitespace',
-        ])
+              node_2
+                  node with trailing whitespace
+            LIST
 
-        # redirects to project root:
-        expect(page).to have_selector 'h3', text: /PROJECT SUMMARY/i
-      end
+          expect do
+            click_button 'Add'
+          end.to change { current_project.nodes.in_tree.count }.by(3) \
+            .and change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(3)
 
-      example 'adding multiple root host nodes' do
-        choose 'Add multiple'
+          expect(
+            ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h|
+              h[:job]
+            }.last(3)
+          ).to include *Array.new(3, ActivityTrackingJob)
+          expect(
+            ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+              h1[:args].map { |h2| h2['action'] }
+            }.flatten.last(3)
+          ).to include *Array.new(3, 'create')
+          expect(
+            ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+              h1[:args].map { |h2| h2['trackable_type'] }
+            }.flatten.last(3)
+          ).to include *Array.new(3, 'Node')
 
-        fill_in :branch_nodes_list, with: "foo\nbar"
-        select 'Host', from: :branch_nodes_icon
+          expect(current_project.nodes.last(3).map(&:label)).to match_array([
+            'node 1',
+            'node_2',
+            'node with trailing whitespace',
+          ])
 
-        expect do
-          click_button 'Add'
-        end.to change { current_project.nodes.in_tree.count }.by(2)
+          # redirects to project root:
+          expect(page).to have_selector 'h3', text: /PROJECT SUMMARY/i
+        end
 
-        expect(
-          current_project.nodes.in_tree.last(2).all? { |n| n.type_id == Node::Types::HOST }
-        ).to be true
+        example 'adding multiple root host nodes' do
+          choose 'Add multiple'
+
+          fill_in :branch_nodes_list, with: "foo\nbar"
+          select 'Host', from: :branch_nodes_icon
+
+          expect do
+            click_button 'Add'
+          end.to change { current_project.nodes.in_tree.count }.by(2)
+
+          expect(
+            current_project.nodes.in_tree.last(2).all? { |n| n.type_id == Node::Types::HOST }
+          ).to be true
+        end
       end
     end
 


### PR DESCRIPTION
### Summary
Until now, users have had to navigate through multiple steps to add
sub-nodes to an existing node. This has been time-consuming and
somewhat cumbersome, especially when multiple sub-nodes need to be
created.

This PR introduces a seamless solution that simplifies this process
significantly. Now, users can effortlessly add single or multiple
sub-nodes directly from the navigation sidebar. By clicking the `+`
icon next to the Nodes header in the navigation sidebar, the user can
access a dropdown with the following options:
* Add top-level node
* Add subnode

![Nodes + dropdown](https://github.com/dradis/dradis-ce/assets/102092/743502c6-47d9-43a8-84a9-b78e7fed4141)

When clicking the **'Add top-level node'** link, the user will see a modal
with the form to add a new top-level node — existing functionality so
far. When clicking the **'Add subnode'** link, the user will see a modal
with the form to add a new subnode.

This means the user can create top-level node(s) or subnode(s) right
from the navigation bar, all within a single modal.

### Testing

**Create a top-level node:**
1. Click the '+' icon next to the Nodes header in the navigation
sidebar
3. Click on 'Add top-level node'
4. Select 'Add one' or 'Add multiple'
5. Enter the name(s) of the subnode(s)
6. Select the icon — No icon or Host
7. Submit the form
8. See the new top-level node in the Nodes sections

**Create a subnode:**
1. **[IMPORTANT]** Make sure a node is selected in the Nodes section. It
can be any top-level node or any subnode 
3. Click the '+' icon next to the Nodes header in the navigation
sidebar
4. Click on 'Add subnode'
5. Select 'Add one' or 'Add multiple'
6. Enter the name(s) of the subnode(s)
7. Select the icon — No icon or Host
8. Submit the form
9. See the new top-level node in the Nodes sections

[CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List
- [ ] Added a CHANGELOG entry
