### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To try Dradis Community, you can deploy your own instance (you will need account
   * [SAINT](https://dradis.com/integrations/saint.html)
   * [Zed Attack Proxy](https://dradis.com/integrations/zap.html)
   * ...
-  * [Full list](http://dradis.org/integrations/)
+  * [Full list](https://dradis.com/integrations/)
 
 
 ## Editions


### PR DESCRIPTION
We migrated our website to dradis.com in 2023, but Google doesn’t seem to have figured out that dradis.com is our new domain, and we’re losing a lot of traffic as a result.

We’re trying to update links to our previous domains, so they link directly to the new domain. I'd really appreciate it if you'd be able to update this link for me.

Thank you


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.


