### PR TITLE
Add sub nodes from add node modal

### DIFF
--- a/app/assets/javascripts/tylium/pages/nodes/new_form.js
+++ b/app/assets/javascripts/tylium/pages/nodes/new_form.js
@@ -15,6 +15,23 @@
       }
     }
 
+    var $checkbox = $('[data-behavior=node-type-toggle] .form-check-input');
+    var $parentNodeSelect = $('[data-behavior=parent-node-select]');
+
+    if (!$checkbox.prop('checked')) {
+      $parentNodeSelect.css('display', 'none');
+    } else {
+      $parentNodeSelect.css('display', 'block');
+    }
+
+    $checkbox.change(function() {
+      if (!$checkbox.prop('checked')) {
+        $parentNodeSelect.css('display', 'none');
+      } else {
+        $parentNodeSelect.css('display', 'block');
+      }
+    });
+
     if ($('[data-behavior~=copy-node-label]').length) {
       $('[data-behavior~=copy-node-label]').click(function() {
         var $modal = $(this).parents('[data-behavior~=add-node]'),

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -61,13 +61,18 @@
           url: main_app.project_nodes_path(current_project),
           html: { class: 'add_one_node_form form-horizontal', id: "new_#{type}_node_form" }
         ) do |f| %>
-          <%= f.hidden_field :parent_id, id: "#{type}_parent_id" %>
           <%= f.input :label, input_html: { id: "#{type}_node_label", data: { behavior: 'node-label' } } %>
           <%= f.input :type_id,
             collection: [["No icon", Node::Types::DEFAULT], ["Host", Node::Types::HOST]],
             include_blank: false,
             label: 'Icon',
             input_html: { class: 'form-select', id: "#{type}_node_icon", data: { behavior: 'node-icon' } }
+          %>
+          <%= f.input :parent_id,
+            collection: @nodes.map { |n| [n.label, n.id] },
+            include_blank: true,
+            label: 'Parent node',
+            input_html: { class: 'form-select', id: "parent_node_select", data: { behavior: 'node-parent' } }
           %>
         <% end %>
 

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -68,12 +68,14 @@
             label: 'Icon',
             input_html: { class: 'form-select', id: "#{type}_node_icon", data: { behavior: 'node-icon' } }
           %>
-          <%= f.input :parent_id,
-            collection: @nodes.map { |n| [n.label, n.id] },
-            include_blank: true,
-            label: 'Parent node',
-            input_html: { class: 'form-select', id: "parent_node_select", data: { behavior: 'node-parent' } }
-          %>
+          <div data-behavior='parent-node-select'>
+            <%= f.input :parent_id,
+              collection: @nodes.map { |n| [n.label, n.id] },
+              include_blank: true,
+              label: 'Parent node',
+              input_html: { class: 'form-select', id: "parent_node_select", data: { behavior: 'node-parent' } }
+            %>
+          </div>
         <% end %>
 
         <%# We can't use 'form_for' because 'list' isn't an attribute that exists

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -26,6 +26,7 @@
                 'node_type',
                 :child,
                 type == :child,
+                id: 'node_type_child',
                 class: "node_type_toggle form-check-input") %>
           <%= label_tag "node_type_child", "Sub-node", class: 'form-check-label' %>
         </div>

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -88,7 +88,6 @@
             Please add at least one node
           </div>
 
-          <%= hidden_field_tag "nodes[parent_id]", @node.id if type == :child %>
           <%= label_tag "#{type}_nodes_list", 'To create multiple nodes, add one node name per line:', class: 'form-label' %>
           <%= text_area_tag "nodes[list]", "", rows: 3, class: 'mb-3 nodes_list form-control', id: "#{type}_nodes_list", data: { behavior: 'nodes-list' } %>
           <%= label_tag "#{type}_nodes_icon", 'Icon', class: 'form-label' %>
@@ -102,6 +101,17 @@
             id: "#{type}_nodes_icon",
             data: { behavior: 'nodes-icon' })
           %>
+          <div data-behavior='parent-node-select'>
+            <%= label_tag "nodes[parent_id]", 'Parent node', class: 'form-label' %>
+            <%= select_tag(
+              "nodes[parent_id]",
+              options_from_collection_for_select(current_project.nodes.user_nodes.order(:label), 'id', 'label'),
+              include_blank: true,
+              class: 'form-select',
+              id: "parent_node_select",
+              data: { behavior: 'node-parent' }
+            ) %>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -21,6 +21,17 @@
       </div>
 
       <div class="modal-body">
+        <div class='form-check' data-behavior='node-type-toggle'>
+          <%= check_box_tag(
+                'node_type',
+                :child,
+                type == :child,
+                class: "node_type_toggle form-check-input") %>
+          <%= label_tag "node_type_child", "Sub-node", class: 'form-check-label' %>
+        </div>
+
+        <hr>
+
         <%# we need to scope the names of the radio buttons to this specific modal
           # so that clicking a radio in the 'add child' modal won't deselect the
           # radios in the 'add branch' modal %>

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -70,7 +70,7 @@
           %>
           <div data-behavior='parent-node-select'>
             <%= f.input :parent_id,
-              collection: @nodes.map { |n| [n.label, n.id] },
+              collection: current_project.nodes.user_nodes.order(:label).map { |n| [n.label, n.id] },
               include_blank: true,
               label: 'Parent node',
               input_html: { class: 'form-select', id: "parent_node_select", data: { behavior: 'node-parent' } }


### PR DESCRIPTION
### Summary

Before:
To add single or multiple sub-nodes to an existing node users would have to:
1. navigate to the existing node
2. click the `...` menu icon
3. click `add sub-node`
4. fill out and submit the form

After:
Users can now click on the + icon next to Nodes in the sidebar to create single or multiple sub-nodes.
1. click the `+` icon next to Nodes in the sidebar (from any route)
2. click `Sub-node` checkbox
3. select parent node from dropdown
4. fill out and submit the form

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry