### PR TITLE
Bump dradis-plugins to 4.12.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -213,7 +213,7 @@ end
 #
 
 # Base framework classes required by other plugins
-gem 'dradis-plugins', '~> 4.12.0'
+gem 'dradis-plugins', '~> 4.12.1'
 
 gem 'dradis-api', path: 'engines/dradis-api'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       dradis-plugins (~> 4.0)
     dradis-openvas (4.12.0)
       dradis-plugins (~> 4.0)
-    dradis-plugins (4.12.0)
+    dradis-plugins (4.12.1)
     dradis-projects (4.12.0)
       dradis-plugins (>= 4.8.0)
       rubyzip
@@ -544,7 +544,7 @@ DEPENDENCIES
   dradis-nmap (~> 4.12.0)
   dradis-ntospider (~> 4.12.0)
   dradis-openvas (~> 4.12.0)
-  dradis-plugins (~> 4.12.0)
+  dradis-plugins (~> 4.12.1)
   dradis-projects (~> 4.12.0)
   dradis-qualys (~> 4.12.0)
   dradis-saint (~> 4.12.0)


### PR DESCRIPTION
### Summary

Bump dradis-plugins to 4.12.1 to include update to template migration


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
