### PR TITLE
add trigger to manually run CI on any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ['*']
   push:
     branches: [develop, main]
+  workflow_dispatch:
 
 jobs:
   audits:


### PR DESCRIPTION
### Summary

Add ability to trigger the GitHub `CI` Workflow manually on any branch from the [Actions](https://github.com/dradis/dradis-ce/actions) view.

### Check List

~- [ ] Added a CHANGELOG entry~
