### PR TITLE
Add service_properties constant to node properties

### DIFF
--- a/app/models/concerns/node_properties.rb
+++ b/app/models/concerns/node_properties.rb
@@ -19,12 +19,13 @@ module NodeProperties
   end
 
   SERVICE_KEYS = %i[protocol port state product reason name version]
+  SERVICE_PROPERTIES = %i[services services_extras]
 
   # -------------------------------------------- Individual property management
   # Sets a property, storing value as Array when needed
   # and taking care of duplications
   def set_property(key, value)
-    if [:services, :services_extras].include?(key.to_sym) # let's get defensive
+    if SERVICE_PROPERTIES.include?(key.to_sym) # let's get defensive
       raise ArgumentError, 'don\'t use set_property for :services or '\
                            ':services_extras, use set_service instead'
     end
@@ -100,7 +101,6 @@ module NodeProperties
       end
     end
   end
-
 
   # -------------------------------------- :raw_properties accessors for the UI
   def raw_properties


### PR DESCRIPTION
### Summary

Add service_properties constant to node properties so that we can reuse it across the application

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [] Added a CHANGELOG entry
