### PR TITLE
Fix browser native back button behavior

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,7 @@
   - Liquid: Make project-level collections available for Liquid syntax
   - Upgraded gems: nokogiri, rails, rexml
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - Navigation: Restore functionality of native browser back/forward buttons
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/assets/javascripts/shared/behaviors.js
+++ b/app/assets/javascripts/shared/behaviors.js
@@ -81,11 +81,13 @@
     }
 
     // Update address bar with current tab param
-    $('[data-bs-toggle~=tab]').on('shown.bs.tab', function (e) {
-      let currentTab = $(e.target).attr('href').substring(1);
-      searchParams.set('tab', currentTab);
-      history.pushState(null, null, `?${searchParams.toString()}`);
-    });
+    $('[data-bs-toggle~=tab]')
+      .unbind()
+      .on('shown.bs.tab', function (e) {
+        let currentTab = $(e.target).attr('href').substring(1);
+        searchParams.set('tab', currentTab);
+        history.pushState(null, null, `?${searchParams.toString()}`);
+      });
   }
 
   document.addEventListener('turbolinks:load', function () {

--- a/app/assets/javascripts/shared/behaviors.js
+++ b/app/assets/javascripts/shared/behaviors.js
@@ -88,6 +88,14 @@
         searchParams.set('tab', currentTab);
         history.pushState(null, null, `?${searchParams.toString()}`);
       });
+
+    // Allows users to navigate using the native browser back/forward buttons
+    // even when we manipulate the browser history with pushState()
+    $(window)
+      .unbind()
+      .on('popstate', function () {
+        location.reload();
+      });
   }
 
   document.addEventListener('turbolinks:load', function () {


### PR DESCRIPTION
### Summary

This PR restores the functionality of native browser back/forward buttons. Previously, this was broken after clicking on tabs in any view.

### Check List

- [x] Added a CHANGELOG entry
