### PR TITLE
Add AttachmentsCopier concern

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [v#.#.#] ([month] [YYYY])
+  - Attachments: Copy attachments when moving an evidence/note
   - Liquid: Make project-level collections available for Liquid syntax
   - Upgraded gems: nokogiri, rails, rexml
   - Bugs fixes:

--- a/app/controllers/concerns/attachments_copier.rb
+++ b/app/controllers/concerns/attachments_copier.rb
@@ -7,7 +7,7 @@ module AttachmentsCopier
 
       if attachment
         new_attachment = attachment.copy_to(record.node)
-        new_filename = ERB::Util.url_encode(new_attachment.filename)
+        new_filename = new_attachment.url_encoded_filename
         new_path = full_screenshot_path.gsub(
           /nodes\/[0-9]+\/attachments\/.+/,
           "nodes/#{new_attachment.node_id}/attachments/#{new_filename}"

--- a/app/controllers/concerns/attachments_copier.rb
+++ b/app/controllers/concerns/attachments_copier.rb
@@ -1,0 +1,19 @@
+module AttachmentsCopier
+  def copy_attachments(record)
+    record.content.scan(Attachment::SCREENSHOT_REGEX).each do |screenshot_url|
+      _, _, _, _, project_id, node_id, filename, _ = screenshot_url
+
+      attachment = Attachment.find_by(filename: filename, node_id: record.node_id_was)
+
+      if attachment
+        new_attachment = attachment.copy_to(record.node)
+        new_url = screenshot_url[0].gsub(
+          /nodes\/[0-9]+\/attachments/,
+          "nodes/#{new_attachment.node_id}/attachments"
+        )
+
+        record.content = record.content.gsub(screenshot_url[0], new_url)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/attachments_copier.rb
+++ b/app/controllers/concerns/attachments_copier.rb
@@ -1,18 +1,19 @@
 module AttachmentsCopier
   def copy_attachments(record)
-    record.content.scan(Attachment::SCREENSHOT_REGEX).each do |screenshot_url|
-      _, _, _, _, project_id, node_id, filename, _ = screenshot_url
+    record.content.scan(Attachment::SCREENSHOT_REGEX).each do |screenshot_path|
+      full_screenshot_path, _, _, _, project_id, node_id, filename, _ = screenshot_path
 
-      attachment = Attachment.find_by(filename: filename, node_id: record.node_id_was)
+      attachment = Attachment.find_by(filename: CGI::unescape(filename), node_id: record.node_id_was)
 
       if attachment
         new_attachment = attachment.copy_to(record.node)
-        new_url = screenshot_url[0].gsub(
-          /nodes\/[0-9]+\/attachments/,
-          "nodes/#{new_attachment.node_id}/attachments"
+        new_filename = ERB::Util.url_encode(new_attachment.filename)
+        new_path = full_screenshot_path.gsub(
+          /nodes\/[0-9]+\/attachments\/.+/,
+          "nodes/#{new_attachment.node_id}/attachments/#{new_filename}"
         )
 
-        record.content = record.content.gsub(screenshot_url[0], new_url)
+        record.content = record.content.gsub(full_screenshot_path, new_path)
       end
     end
   end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -1,4 +1,5 @@
 class EvidenceController < NestedNodeResourceController
+  include AttachmentsCopier
   include ConflictResolver
   include EvidenceHelper
   include LiquidEnabledResource
@@ -54,6 +55,8 @@ class EvidenceController < NestedNodeResourceController
 
       @evidence.assign_attributes(evidence_params)
       autogenerate_issue if evidence_params[:issue_id].blank?
+
+      copy_attachments(@evidence) if @evidence.node_changed?
 
       if @evidence.save
         track_updated(@evidence)

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,7 @@
 # This controller exposes the REST operations required to manage the Note
 # resource.
 class NotesController < NestedNodeResourceController
+  include AttachmentsCopier
   include ConflictResolver
   include LiquidEnabledResource
   include Mentioned
@@ -44,7 +45,11 @@ class NotesController < NestedNodeResourceController
   # Update the attributes of a Note
   def update
     updated_at_before_save = @note.updated_at.to_i
-    if @note.update(note_params)
+
+    @note.assign_attributes(note_params)
+    copy_attachments(@note) if @note.node_changed?
+
+    if @note.save
       track_updated(@note)
       check_for_edit_conflicts(@note, updated_at_before_save)
       # if the note has just been moved to another node, we must reload

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -14,7 +14,6 @@
 **
 =end
 
-
 # ==Description
 # This class in an abstraction layer to the <tt>attachments/</tt> folder. It allows
 # access to the folder content in a way that mimics the working of ActiveRecord
@@ -83,7 +82,7 @@ class Attachment < File
   end
 
   def self.find_by(filename:, node_id:)
-    find(filename, conditions: { node_id: node_id } )
+    find(filename, conditions: { node_id: node_id })
   rescue StandardError
   end
 
@@ -93,17 +92,17 @@ class Attachment < File
     dir = Dir.new(pwd)
 
     # makes the find request and stores it to resources
-    return_value = case args.first
+    case args.first
     when :all, :first, :last
       attachments = []
       if options[:conditions] && options[:conditions][:node_id]
         node_id = options[:conditions][:node_id].to_s
         raise "Node with ID=#{node_id} does not exist" unless Node.exists?(node_id)
-        if (File.exist?( File.join(pwd, node_id)))
+        if (File.exist?(File.join(pwd, node_id)))
           node_dir = Dir.new(pwd.join(node_id)).sort
           node_dir.each do |attachment|
             next unless (attachment =~ /^(.+)$/) == 0 && !File.directory?(pwd.join(node_id, attachment))
-            attachments << Attachment.new(:filename => $1, :node_id => node_id.to_i)
+            attachments << Attachment.new(filename: $1, node_id: node_id.to_i)
           end
         end
       else
@@ -112,7 +111,7 @@ class Attachment < File
           node_dir = Dir.new(pwd.join(node)).sort
           node_dir.each do |attachment|
             next unless (attachment =~ /^(.+)$/) == 0 && !File.directory?(pwd.join(node, attachment))
-            attachments << Attachment.new(:filename => $1, :node_id => node.to_i)
+            attachments << Attachment.new(filename: $1, node_id: node.to_i)
           end
         end
         attachments.sort_by!(&:filename)
@@ -131,18 +130,17 @@ class Attachment < File
       # in this routine we find the attachment by file name and node id
       filename = args.first
       attachments = []
-      raise "You need to supply a node id in the condition parameter" unless options[:conditions] && options[:conditions][:node_id]
+      raise 'You need to supply a node id in the condition parameter' unless options[:conditions] && options[:conditions][:node_id]
       node_id = options[:conditions][:node_id].to_s
       raise "Node with ID=#{node_id} does not exist" unless Node.exists?(node_id)
       node_dir = Dir.new(pwd.join(node_id)).sort
       node_dir.each do |attachment|
         next unless ((attachment =~ /^(.+)$/) == 0 && $1 == filename)
-        attachments << Attachment.new(:filename => $1, :node_id => node_id.to_i)
+        attachments << Attachment.new(filename: $1, node_id: node_id.to_i)
       end
       raise "Could not find Attachment with filename #{filename}" if attachments.empty?
       attachments.first
     end
-    return return_value
   end
 
   def self.model_name

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -66,6 +66,8 @@ class Attachment < File
   AttachmentPwd = Rails.env.test? ? Rails.root.join('tmp', 'attachments') : Rails.root.join('attachments')
   FileUtils.mkdir_p(AttachmentPwd) unless File.exists?(AttachmentPwd)
 
+  SCREENSHOT_REGEX = /\!((https?:\/\/.+)|((\/pro)?\/projects\/(\d+)\/nodes\/(\d+)\/attachments\/(.+?)(\(.*\))?))\!/i
+
   # -- Class Methods  ---------------------------------------------------------
 
   def self.all(*args)

--- a/spec/features/evidence_moving_spec.rb
+++ b/spec/features/evidence_moving_spec.rb
@@ -29,9 +29,13 @@ describe 'moving an evidence', js: true do
     click_move_evidence
   end
 
-  let(:current_evidence) { @evidence = create(:evidence, node: @node_5) }
+  let(:content) { "#[Description]#\nTest Evidence\n" }
+  let(:current_evidence) { @evidence = create(:evidence, content: content, node: @node_5) }
 
   describe 'moving an evidence to a different node' do
+    let(:attachment) { create(:attachment, node: @node_5) }
+    let(:content) { "#[Description]#\n!/projects/#{current_project.id}/nodes/#{@node_5.id}/attachments/#{attachment.filename}!\n" }
+
     before do
       within('#modal_move_evidence') do
         click_link @node_1.label
@@ -45,6 +49,10 @@ describe 'moving an evidence', js: true do
 
     it 'should redirect to evidence show path' do
       expect(current_path).to eq(project_node_evidence_path(current_project, @node_1, current_evidence))
+    end
+
+    it 'should update the attachment reference to the new node' do
+      expect(current_evidence.reload.content).to include("nodes/#{@node_1.id}")
     end
   end
 

--- a/spec/features/evidence_moving_spec.rb
+++ b/spec/features/evidence_moving_spec.rb
@@ -33,10 +33,13 @@ describe 'moving an evidence', js: true do
   let(:current_evidence) { @evidence = create(:evidence, content: content, node: @node_5) }
 
   describe 'moving an evidence to a different node' do
-    let(:attachment) { create(:attachment, node: @node_5) }
+    let(:attachment) { create(:attachment, filename: 'name with spaces.png', node: @node_5) }
     let(:content) { "#[Description]#\n!/projects/#{current_project.id}/nodes/#{@node_5.id}/attachments/#{attachment.filename}!\n" }
 
     before do
+      # Ensure this works with duplicated attachment
+      create(:attachment, filename: 'name with spaces.png', node: @node_1)
+
       within('#modal_move_evidence') do
         click_link @node_1.label
         click_submit

--- a/spec/features/note_moving_spec.rb
+++ b/spec/features/note_moving_spec.rb
@@ -30,9 +30,13 @@ describe 'moving a note', js: true do
     click_move_note
   end
 
-  let(:current_note) { @note = create(:note, node: @node_5) }
+  let(:text) { "#[Description]#\nTest Note\n" }
+  let(:current_note) { @note = create(:note, text: text, node: @node_5) }
 
   describe 'moving a note to a different node' do
+    let(:attachment) { create(:attachment, node: @node_5) }
+    let(:text) { "#[Description]#\n!/projects/#{current_project.id}/nodes/#{@node_5.id}/attachments/#{attachment.filename}!\n" }
+
     before do
       within('#modal_move_note') do
         click_link @node_1.label
@@ -46,6 +50,10 @@ describe 'moving a note', js: true do
 
     it 'should redirect to note show path' do
       expect(current_path).to eq(project_node_note_path(current_project, @node_1, current_note))
+    end
+
+    it 'should update the attachment reference to the new node' do
+      expect(current_note.reload.content).to include("nodes/#{@node_1.id}")
     end
   end
 

--- a/spec/features/note_moving_spec.rb
+++ b/spec/features/note_moving_spec.rb
@@ -34,10 +34,13 @@ describe 'moving a note', js: true do
   let(:current_note) { @note = create(:note, text: text, node: @node_5) }
 
   describe 'moving a note to a different node' do
-    let(:attachment) { create(:attachment, node: @node_5) }
+    let(:attachment) { create(:attachment, filename: 'name with spaces.png', node: @node_5) }
     let(:text) { "#[Description]#\n!/projects/#{current_project.id}/nodes/#{@node_5.id}/attachments/#{attachment.filename}!\n" }
 
     before do
+      # Ensure this works with duplicated attachment
+      create(:attachment, filename: 'name with spaces.png', node: @node_1)
+
       within('#modal_move_note') do
         click_link @node_1.label
         click_submit


### PR DESCRIPTION
### Spec
When moving an instance of evidence to another node the attachments are not moved. This means that if we delete the original node, the attachments are destroyed and the attachment can no longer be referenced in the evidence.

**Proposed solution**
Copy the attachment to the new node when an evidence or note are moved
- In the controller's update action, check if the node_id is being changed
- If yes, check whether the text includes any attachment syntax (!/projects/1/nodes/1/attachments/img.jpeg!)
- If yes, find the attachment by file name and node_id and copy the attachment to the new node 
- Update the evidence/note text with the reference to the new node's attachment.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
