### PR TITLE
Don't run migrate templates to mappings if the mappings table doesn't exist

### DIFF
--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -11,9 +11,11 @@ Rails.application.reloader.to_prepare do
     # ---------------------------------------------------------------- 3.1 Upload
     template_dir = Configuration.paths_templates_plugins
 
-    Dradis::Plugins::with_feature(:upload).each do |integration|
-      integration.copy_samples(to: template_dir)
-      integration.migrate_templates_to_mappings(from: template_dir)
+    if Mapping.table_exists?
+      Dradis::Plugins::with_feature(:upload).each do |integration|
+        integration.copy_samples(to: template_dir)
+        integration.migrate_templates_to_mappings(from: template_dir)
+      end
     end
 
     # ---------------------------------------------------------------- 3.2 Export

--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -14,7 +14,7 @@ Rails.application.reloader.to_prepare do
     if Mapping.table_exists?
       Dradis::Plugins::with_feature(:upload).each do |integration|
         integration.copy_samples(to: template_dir)
-        integration.migrate_templates_to_mappings(from: template_dir)
+        integration.migrate_templates_to_mappings(from: template_dir) if !Rails.env.test?
       end
     end
 

--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -10,7 +10,7 @@ Rails.application.reloader.to_prepare do
   if (ActiveRecord::Base.connection rescue false) && Configuration.table_exists? && Configuration.paths_templates.exist?
     # ---------------------------------------------------------------- 3.1 Upload
     template_dir = Configuration.paths_templates_plugins
-
+    # mappings table may not exist when migrating from an old OVA to a new one so we need this guard
     if Mapping.table_exists?
       Dradis::Plugins::with_feature(:upload).each do |integration|
         integration.copy_samples(to: template_dir)

--- a/config/initializers/z_11_plugin_templates.rb
+++ b/config/initializers/z_11_plugin_templates.rb
@@ -7,15 +7,16 @@
 # Unless the DB is already migrated, do nothing
 
 Rails.application.reloader.to_prepare do
-  if (ActiveRecord::Base.connection rescue false) && Configuration.table_exists? && Configuration.paths_templates.exist?
+  if (ActiveRecord::Base.connection rescue false) &&
+    Configuration.table_exists? &&
+    Configuration.paths_templates.exist? &&
+    Mapping.table_exists?
     # ---------------------------------------------------------------- 3.1 Upload
     template_dir = Configuration.paths_templates_plugins
     # mappings table may not exist when migrating from an old OVA to a new one so we need this guard
-    if Mapping.table_exists?
-      Dradis::Plugins::with_feature(:upload).each do |integration|
-        integration.copy_samples(to: template_dir)
-        integration.migrate_templates_to_mappings(from: template_dir) if !Rails.env.test?
-      end
+    Dradis::Plugins::with_feature(:upload).each do |integration|
+      integration.copy_samples(to: template_dir)
+      integration.migrate_templates_to_mappings(from: template_dir) if !Rails.env.test?
     end
 
     # ---------------------------------------------------------------- 3.2 Export


### PR DESCRIPTION
### Summary
Don't call migrate_templates_to_mappings if the mappings table doesn't exist yet.

This causes an issue when migrating from an older OVA to a new OVA when the mappings table has not yet been created and the initializer tries to run this method before db:migrate

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

