### PR TITLE
make clipboard js init a shared behavior

### DIFF
--- a/app/assets/javascripts/shared/behaviors.js
+++ b/app/assets/javascripts/shared/behaviors.js
@@ -93,6 +93,47 @@
           urlWithTab
         );
       });
+
+    // Initialize clipboard.js
+    const clipboard = new Clipboard('[data-clipboard-text]');
+
+    clipboard.on('success', function (e) {
+      const $copyBtn = $(e.trigger);
+      e.clearSelection();
+      $copyBtn.tooltip({
+        placement: 'bottom',
+        title: 'Copied to clipboard!',
+        trigger: 'manual',
+      });
+      $copyBtn.tooltip('show');
+      setTimeout(function () {
+        $copyBtn.tooltip('hide');
+      }, 1000);
+    });
+
+    clipboard.on('error', function (e) {
+      const actionKey = e.action === 'cut' ? 'X' : 'C',
+        $copyBtn = $(e.trigger);
+      let actionMsg;
+
+      if (/Mac/i.test(navigator.userAgent)) {
+        actionMsg = 'Press ⌘-' + actionKey + ' to ' + e.action;
+      } else {
+        actionMsg = 'Press Ctrl-' + actionKey + ' to ' + e.action;
+      }
+
+      $copyBtn.tooltip({
+        placement: 'bottom',
+        title: actionMsg,
+        trigger: 'manual',
+      });
+      $copyBtn.tooltip('show');
+      setTimeout(function () {
+        $copyBtn.tooltip('hide');
+      }, 1000);
+    });
+
+    window.initBehaviors = initBehaviors;
   }
 
   document.addEventListener('turbolinks:load', function () {

--- a/app/assets/javascripts/tylium/behaviors.js.coffee
+++ b/app/assets/javascripts/tylium/behaviors.js.coffee
@@ -10,40 +10,6 @@ document.addEventListener "turbolinks:load", ->
 
   # --------------------------------------------------- Standard jQuery plugins
 
-  # Initialize clipboard.js:
-  clipboard = new Clipboard('.js-attachment-url-copy')
-
-  clipboard.on 'success', (e) ->
-    $btn = $(e.trigger)
-    e.clearSelection()
-    $btn.tooltip
-      placement: 'bottom'
-      title:     'Copied attachment URL to clipboard!',
-      trigger:   'manual'
-    $btn.tooltip('show')
-
-
-  clipboard.on 'error', (e) ->
-    actionKey = if e.action == 'cut' then 'X' else 'C'
-    if /Mac/i.test(navigator.userAgent)
-      actionMsg = 'Press ⌘-' + actionKey + ' to '+ e.action
-    else
-      actionMsg = 'Press Ctrl-' + actionKey + ' to ' + e.action
-
-    $btn = $(e.trigger)
-
-    $btn.tooltip
-      placement: 'bottom'
-      title:     actionMsg
-      trigger:   'manual'
-    $btn.tooltip('show')
-
-
-  $(".attachments-box").on "mouseleave", ".js-attachment-url-copy", ->
-    $this = $(this)
-    $this.tooltip('hide')
-
-
   # -------------------------------------------------------- Our jQuery plugins
 
   # Activate jQuery.breadCrumbs

--- a/app/assets/javascripts/tylium/modules/fileupload.js
+++ b/app/assets/javascripts/tylium/modules/fileupload.js
@@ -1,43 +1,62 @@
 // jQuery.fileUpload  - handles attachment uploads (gem: jquery-fileupload-rails)
 
 function fileUploadInit() {
-  $('[data-behavior~=jquery-upload]').fileupload({
-     autoUpload: true,
-     dropZone: function(){ return $('[data-behavior~=drop-zone]') },
-     pasteZone: function(){ return $('[data-behavior~=drop-zone]') },
-     singleFileUploads: true,
-     destroy: function(e, data) {
-       if (confirm('Are you sure?\n\nProceeding will delete this attachment from the associated node.')) {
-         $.blueimp.fileupload.prototype.options.destroy.call(this, e, data);
-       }
-     }
-  }).on('fileuploadadd', function (e, data) {
-    // data.$textarea is added to the input field owned by the editor and is
-    // only present when the image button is clicked. Copying, or dragging does
-    // not append the attribute.
-    var $textarea = (e.originalEvent !== undefined) ? $(e.originalEvent.target) : data.$textarea;
+  $('[data-behavior~=jquery-upload]')
+    .fileupload({
+      autoUpload: true,
+      dropZone: function () {
+        return $('[data-behavior~=drop-zone]');
+      },
+      pasteZone: function () {
+        return $('[data-behavior~=drop-zone]');
+      },
+      singleFileUploads: true,
+      destroy: function (e, data) {
+        if (
+          confirm(
+            'Are you sure?\n\nProceeding will delete this attachment from the associated node.'
+          )
+        ) {
+          $.blueimp.fileupload.prototype.options.destroy.call(this, e, data);
+        }
+      },
+    })
+    .on('fileuploadadd', function (e, data) {
+      // data.$textarea is added to the input field owned by the editor and is
+      // only present when the image button is clicked. Copying, or dragging does
+      // not append the attribute.
+      var $textarea =
+        e.originalEvent !== undefined
+          ? $(e.originalEvent.target)
+          : data.$textarea;
 
-    if ($textarea.is($('[data-behavior~=rich-toolbar]'))) {
-      var editorToolbar = $textarea.data('editorToolbar');
-      data.replaceImagePlaceholder = editorToolbar.replaceImagePlaceholder.bind(editorToolbar);
+      if ($textarea.is($('[data-behavior~=rich-toolbar]'))) {
+        var editorToolbar = $textarea.data('editorToolbar');
+        data.replaceImagePlaceholder =
+          editorToolbar.replaceImagePlaceholder.bind(editorToolbar);
 
-      $.each(data.files, editorToolbar.insertImagePlaceholder.bind(editorToolbar));
-    }
-  }).on('fileuploaddone', function (e, data) {
-    if (data.replaceImagePlaceholder !== undefined) {
-      $.each(data.files, data.replaceImagePlaceholder.bind(null, data));
-    }
-  });
+        $.each(
+          data.files,
+          editorToolbar.insertImagePlaceholder.bind(editorToolbar)
+        );
+      }
+    })
+    .on('fileuploaddone', function (e, data) {
+      if (data.replaceImagePlaceholder !== undefined) {
+        $.each(data.files, data.replaceImagePlaceholder.bind(null, data));
+      }
+      window.initBehaviors($('[data-behavior~=jquery-upload]'));
+    });
 }
 
-document.addEventListener("turbolinks:load", function() {
+document.addEventListener('turbolinks:load', function () {
   // Bind fileUpload on page load.
   fileUploadInit();
 });
 
 // Un-bind fileUpload on page unload.
-document.addEventListener('turbolinks:before-cache', function() {
-  $('[data-behavior~=jquery-upload]').each(function() {
+document.addEventListener('turbolinks:before-cache', function () {
+  $('[data-behavior~=jquery-upload]').each(function () {
     $(this).fileupload('destroy');
   });
 });

--- a/app/views/attachments/_attachment_box.html.erb
+++ b/app/views/attachments/_attachment_box.html.erb
@@ -55,7 +55,7 @@
                     </td>
                     <td rowspan="2" align="right" class="copy-link">
                       <button
-                        class="btn btn-copy btn-transparent js-attachment-url-copy"
+                        class="btn btn-copy btn-transparent"
                         data-clipboard-text="!<%= main_app.project_node_attachment_path(node.project, node, '') + attachment.url_encoded_filename %>!"
                       >
                         <i class="fa-solid fa-link"></i>
@@ -151,7 +151,7 @@
                 </td>
                 <td rowspan="2" align="right" class="copy-link">
                   <button
-                    class="btn btn-copy btn-transparent js-attachment-url-copy"
+                    class="btn btn-copy btn-transparent"
                     data-clipboard-text="!{%= file.url %}!"
                   >
                     <i class="fa-solid fa-link"></i>


### PR DESCRIPTION
### Summary

This PR moves the clipboard.js init into `shared/behaviors` for use outside of tylium.

### Check List

~- [ ] Added a CHANGELOG entry~
