### PR TITLE
removed method File.exists?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -221,7 +221,7 @@ gem 'dradis-api', path: 'engines/dradis-api'
 gem 'dradis-projects', '~> 4.13.0'
 
 plugins_file = 'Gemfile.plugins'
-if File.exists?(plugins_file)
+if File.exist?(plugins_file)
   eval(IO.read(plugins_file), binding)
 end
 


### PR DESCRIPTION
### Summary

File.exists? alias was removed in 3.2.0 see https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/ and https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2 so use File.exist? instead for compatibility with 3.2+

### Other Information

There is not much to add.

### Copyright assignment

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### CHANGELOG

I'm not sure you want to add that to the changelog since it's just chore

- [ ] Added a CHANGELOG entry
