### PR TITLE
Touch evidence, children and notes on node merge & add affected_ids to issues#index table cache

### DIFF
--- a/app/services/nodes/merger.rb
+++ b/app/services/nodes/merger.rb
@@ -31,66 +31,70 @@ class Nodes::Merger
 
   private
 
-    attr_accessor :target_node, :source_node, :copied_attachments
+  attr_accessor :target_node, :source_node, :copied_attachments
 
-    DESCENDENT_RELATIONSHIPS = {
-      activities: :trackable_id,
-      children: :parent_id,
-      evidence: :node_id,
-      notes: :node_id
-    }.freeze
+  DESCENDENT_RELATIONSHIPS = {
+    activities: :trackable_id,
+    children: :parent_id,
+    evidence: :node_id,
+    notes: :node_id
+  }.freeze
 
-    def move_descendents
-      DESCENDENT_RELATIONSHIPS.each do |relation, column|
-        source_node.send(relation).update_all(column => target_node.id)
-      end
+  def move_descendents
+    DESCENDENT_RELATIONSHIPS.each do |relation, column|
+      # update_all doesn't update timestamps so we need to do it manually
+      source_node.send(relation).update_all(
+        column => target_node.id,
+        :updated_at => Time.current
+      )
     end
+  end
 
-    def reset_counter_caches
-      Node.reset_counters target_node.id, :children_count
-    end
+  def reset_counter_caches
+    Node.reset_counters target_node.id, :children_count
+  end
 
-    def update_properties
-      source_node.properties.each do |key, value|
-        case key.to_sym
-        when :services
-          value.each do |service|
-            data = service.merge(source: :merge)
+  def update_properties
+    source_node.properties.each do |key, value|
+      case key.to_sym
+      when :services
+        value.each do |service|
+          data = service.merge(source: :merge)
+          target_node.set_service data
+        end
+      when :services_extras
+        value.each do |protocol_port, extras|
+          protocol, port = protocol_port.split('/')
+
+          extras.each do |extra|
+            data = {
+              extra[:id] => extra[:output],
+              source: extra[:source],
+              port: port.to_i,
+              protocol: protocol
+            }
+
             target_node.set_service data
           end
-        when :services_extras
-          value.each do |protocol_port, extras|
-            protocol, port = protocol_port.split('/')
-
-            extras.each do |extra|
-              data = {
-                extra[:id] => extra[:output],
-                source: extra[:source],
-                port: port.to_i,
-                protocol: protocol
-              }
-
-              target_node.set_service data
-            end
-          end
-        else
-          target_node.set_property key, value
         end
-      end
-
-      target_node.save
-    end
-
-    def copy_attachments
-      self.copied_attachments = []
-
-      source_node.attachments.each do |attachment|
-        copied_attachments << attachment.copy_to(target_node)
+      else
+        target_node.set_property key, value
       end
     end
 
-    def undo_attachments_copy
-      return unless copied_attachments&.any?
-      copied_attachments.each(&:delete)
+    target_node.save
+  end
+
+  def copy_attachments
+    self.copied_attachments = []
+
+    source_node.attachments.each do |attachment|
+      copied_attachments << attachment.copy_to(target_node)
     end
+  end
+
+  def undo_attachments_copy
+    return unless copied_attachments&.any?
+    copied_attachments.each(&:delete)
+  end
 end

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -1,4 +1,4 @@
-<% cache ['issues-table', @all_columns, issues.map(&:id), @issues.map(&:updated_at).map(&:to_i).sort.last, @tags] do %>
+<% cache ['issues-table', @all_columns, @issues.map(&:affected_ids), issues.map(&:id), @issues.map(&:updated_at).map(&:to_i).sort.last, @tags] do %>
   <% table_attributes = {
     behavior: 'dradis-datatable',
     'default-columns': @default_columns.to_json,
@@ -21,7 +21,7 @@
     </thead>
     <tbody>
       <% issues.each do |issue| %>
-        <% cache [issue, @all_columns, issue.try(:affected_count), issue.try(:state), 'issues-table', @tags] do %>
+        <% cache [issue, @all_columns, issue.try(:affected_count), issue.affected_ids, issue.try(:state), 'issues-table', @tags] do %>
           <tr id="issue-<%= issue.id %>" data-tag-url="<%= project_issue_path(current_project, issue) %>">
             <td class="select-checkbox" data-behavior="select-checkbox"></td>
             <% @all_columns.each do |column| %>


### PR DESCRIPTION
### Summary

After merging nodes, 
- The issues#index table cache doesn't update because we are not including `:affected` in the cache keys. This leads to broken nodes#show links in the affected column
- The issues/evidence#index table cache doesn't bust because the evidence `updated_at` does not get updated on node merge since we are using `update_all`. This leads to broken #edit links (since they point to the old node)

This PR adds `:affected_ids` to the issues#index table cache key and adds `updated_at: Time.current` to the list of columns to update in [merger.rb](https://github.com/dradis/dradis-ce/blob/e6539a7b2f69feb36b09b728fdef05aa7b901387/app/services/nodes/merger.rb#L43)'s `move_descendents` method


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
