### PR TITLE
Create issues from cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,9 @@
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
 
+  [v4.14.0] ([September] [2024])
+  - Issues: Card data can be used to template a new Issue creation
+
 v4.13.0 (July 2024)
   - Attachments: Copy attachments when moving an evidence/note
   - Liquid: Make project-level collections available for Liquid syntax

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -53,7 +53,9 @@
               <% end %>
 
               <div class="card-actions mt-4">
-                <%= link_to 'Create Issue', class: 'btn btn-primary' %>
+                <%= link_to 'Create Issue', new_project_issue_path(card_id: @card.id, issue: {
+                    text: "#{@card.name} #{@card.description}"
+                    }), class: 'btn btn-primary' %>
                 </div>
               </div>
 

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -28,7 +28,7 @@
                   <span class="text-truncate" title="<%= @card.name %>"><%= @card.name %></span>
                   <%= render partial: 'actions' %>
                 </h4>
-
+                
                 <div class="card-description">
                   <div class="content-textile" data-behavior="content-textile">
                     <%= markup(@card.description) %>
@@ -51,6 +51,11 @@
                   </div>
                 <% end %>
               <% end %>
+
+              <div class="card-actions mt-4">
+                <%= link_to 'Create Issue', class: 'btn btn-primary' %>
+                </div>
+              </div>
 
             </div>
           </div>

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -287,6 +287,20 @@ describe 'Card pages:' do
           }.to raise_error ActiveRecord::RecordNotFound
         end
       end
+
+      describe 'clicking Create Issue' do
+
+        it 'displays the Create Issue button' do
+          visit project_board_list_card_path(current_project, @board, @list, @card)
+          expect(page).to have_link('Create Issue')
+        end
+
+        it 'creates a new issue with the cards information' do
+        click_link 'Create Issue'
+        expect(page).to have_text(card.name)
+        expect(page).to have_text(card.description)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Creation of a new 'Create Issue' button within the Methodologies Cards. This allows data from the specific card to be carried over as a template when creating an issue, with the pre-existing functionality of editing Issue fields still remaining. 


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
