### PR TITLE
Ignore screenshots when diffing

### DIFF
--- a/app/services/diffed_content.rb
+++ b/app/services/diffed_content.rb
@@ -85,7 +85,11 @@ class DiffedContent
 
   def diff_by_word(source_content, target_content)
     Differ.format = :html
-    differ_result = Differ.diff_by_word(source_content, target_content)
+    differ_result =
+      Differ.diff_by_word(
+        source_content.gsub(/!.+?!/, ''),
+        target_content.gsub(/!.+?!/, '')
+      )
 
     output = highlighted_string(differ_result)
 

--- a/spec/services/diffed_content_spec.rb
+++ b/spec/services/diffed_content_spec.rb
@@ -13,6 +13,16 @@ describe DiffedContent do
         target: "#[Title]#\n<mark>Issue2</mark>\n"
       })
     end
+
+    it 'ignores attachments from the diff' do
+      issue1.update text: "#[Title]#\nIssue1\n!attachment1!"
+      issue2.update text: "#[Title]#\nIssue2\n!attachment2!"
+
+      expect(subject.content_diff).to eq({
+        source: "#[Title]#\n<mark>Issue1</mark>\n\n",
+        target: "#[Title]#\n<mark>Issue2</mark>\n\n"
+      })
+    end
   end
 
   describe '#changed?' do

--- a/spec/services/diffed_content_spec.rb
+++ b/spec/services/diffed_content_spec.rb
@@ -15,12 +15,12 @@ describe DiffedContent do
     end
 
     it 'ignores attachments from the diff' do
-      issue1.update text: "#[Title]#\nIssue1\n!attachment1!"
-      issue2.update text: "#[Title]#\nIssue2\n!attachment2!"
+      issue1.update text: "#[Title]#\nIssue1\n!attachment1!\n\n!attachment2!"
+      issue2.update text: "#[Title]#\nIssue2\n!attachment3!\n\n!attachment4!"
 
       expect(subject.content_diff).to eq({
-        source: "#[Title]#\n<mark>Issue1</mark>\n\n",
-        target: "#[Title]#\n<mark>Issue2</mark>\n\n"
+        source: "#[Title]#\n<mark>Issue1</mark>",
+        target: "#[Title]#\n<mark>Issue2</mark>"
       })
     end
   end


### PR DESCRIPTION
### Spec
When importing an entry to a project, the ActiveStorage::Blob is uploaded as an attachment. This converts the blob syntax:
```
!/addons/issuelib/images/<blob id>!
```
to the attachment syntax:
```
!/projects/<project id>/nodes/<node id>/attachments/<filename>!
```

This will immediately unsync the content between the issue and entry.

**Proposed solution**
Ignore the screenshots when comparing content

### Check List

~- [ ] Added a CHANGELOG entry~