### PR TITLE
Fix incorrect parsing of field values that contain Liquid when creating new records

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,6 @@
     - rexml
   - Bugs fixes:
     - Editor: Fix incorrect parsing of field value options that contain Liquid
-      - [future tense verb] [bug fix]
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
   - Upgraded gems:
     - rexml
   - Bugs fixes:
-    - [entity]:
+    - Editor: Fix incorrect parsing of field value options that contain Liquid
       - [future tense verb] [bug fix]
     - Bug tracker items:
       - [item]

--- a/app/helpers/fields_helper.rb
+++ b/app/helpers/fields_helper.rb
@@ -1,0 +1,11 @@
+module FieldsHelper
+  FIELD_VALUES_REGEX = /(\{\{[^}]+\}\})|\|?([^|]+)/
+
+  def parse_field_value_options(values)
+    values.scan(FIELD_VALUES_REGEX)
+      .flatten
+      .compact
+      .map(&:strip)
+      .reject(&:empty?)
+  end
+end

--- a/app/views/fields/_field.html.erb
+++ b/app/views/fields/_field.html.erb
@@ -1,5 +1,5 @@
 <% field_name = local_assigns[:field] ? field[0]  : '' %>
-<% value = local_assigns[:field] ? field[1] : '' %>
+<% values = local_assigns[:field] ? field[1] : '' %>
 
 <div class="textile-form-field" data-behavior="textile-form-field">
   <div class="d-inline-flex justify-content-between w-100">
@@ -21,12 +21,12 @@
   </div>
   <div class="inline-editable">
     <div class="edit-hover">
-      <% options = value.split(' | ') %>
+      <% options = parse_field_value_options(values) %>
       <% if @allow_dropdown && options.count > 1 %>
         <%= select :item_form, "field_value_#{index}", options, {}, { class: 'form-control', data: { behavior: 'preview-enabled' }, tabindex: index + 1 } %>
       <% else %>
         <%= label_tag "item_form[field_value_#{index}]", 'Field Value', class: 'visually-hidden' %>
-        <%= text_area_tag "item_form[field_value_#{index}]", value, rows: 1,
+        <%= text_area_tag "item_form[field_value_#{index}]", values, rows: 1,
           class: 'form-control',
           data: {
             behavior: 'preview-enabled rich-toolbar drop-zone',


### PR DESCRIPTION
### Summary

When creating new issue/evidence from a note template or from the default template (RTP), if you have Liquid content that contains filters Ex. `{{ issue.fields['CVSSv3.BaseScore'] | times: 10 }}`, it will be split into different options in the dropdown
```
["{{ issue.fields['CVSSv3.BaseScore']", "times: 10 }}"]
```

#### Solution
Use regex to scan the string and split it into the correct options


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
