### PR TITLE
API add Node properties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,8 +22,8 @@
     - [report type]:
       - [future tense verb] [reporting enhancement]
   - REST/JSON API enhancements:
-    - [API entity]:
-      - [future tense verb] [API enhancement]
+    - Nodes endpoint:
+      - include Node Properties in Node API requests
   - Security Fixes:
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,7 +22,7 @@
     - [report type]:
       - [future tense verb] [reporting enhancement]
   - REST/JSON API enhancements:
-    - Nodes endpoint:
+    - Nodes:
       - include Node Properties in Node API requests
   - Security Fixes:
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,7 +23,7 @@
       - [future tense verb] [reporting enhancement]
   - REST/JSON API enhancements:
     - Nodes:
-      - include Node Properties in Node API requests
+      - include Node properties
   - Security Fixes:
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v3/nodes_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v3/nodes_controller.rb
@@ -44,7 +44,7 @@ module Dradis::CE::API
       protected
 
       def node_params
-        params.require(:node).permit(:label, :type_id, :parent_id, :position)
+        params.require(:node).permit(:label, :type_id, :parent_id, :position, properties: {})
       end
     end
   end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v3/nodes_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v3/nodes_controller.rb
@@ -44,7 +44,7 @@ module Dradis::CE::API
       protected
 
       def node_params
-        params.require(:node).permit(:label, :type_id, :parent_id, :position, properties: {})
+        params.require(:node).permit(:label, :type_id, :parent_id, :position, :raw_properties)
       end
     end
   end

--- a/engines/dradis-api/app/views/dradis/ce/api/v3/nodes/_node.json.jbuilder
+++ b/engines/dradis-api/app/views/dradis/ce/api/v3/nodes/_node.json.jbuilder
@@ -1,4 +1,4 @@
-json.(node, :id, :label, :type_id, :parent_id, :position, :created_at, :updated_at)
+json.(node, :id, :label, :properties, :type_id, :parent_id, :position, :created_at, :updated_at)
 
 json.evidence node.evidence do |evidence|
   json.partial! evidence

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/nodes_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/nodes_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe 'Nodes API' do
-
   include_context 'project scoped API'
   include_context 'https'
 
@@ -66,6 +65,7 @@ describe 'Nodes API' do
 
         retrieved_node = JSON.parse(response.body)
         expect(retrieved_node['label']).to eq node.label
+        expect(retrieved_node['properties']).to eq node.properties
       end
     end
 
@@ -80,6 +80,9 @@ describe 'Nodes API' do
             label:     'New Node',
             type_id:   Node::Types::HOST,
             parent_id: parent_node_id,
+            properties: {
+              'ip' => '1.1.1.1'
+            },
             position:  3
           }
         }
@@ -130,13 +133,19 @@ describe 'Nodes API' do
     end
 
     describe 'PUT /api/nodes/:id' do
-
       let(:node) { create(:node, label: 'Existing Node', project: current_project) }
 
       let(:valid_put) do
         put "/api/nodes/#{ node.id }", params: valid_params.to_json, env: @env.merge('CONTENT_TYPE' => 'application/json')
       end
-      let(:valid_params) { { node: { label: 'Updated Node' } } }
+      let(:valid_params) do
+        {
+          node: {
+            label: 'Updated Node',
+            properties: { 'ip' => '1.0.0.1' }
+          }
+        }
+      end
 
       it 'updates a node' do
         valid_put
@@ -144,6 +153,7 @@ describe 'Nodes API' do
         expect(current_project.nodes.find(node.id).label).to eq valid_params[:node][:label]
         retrieved_node = JSON.parse(response.body)
         expect(retrieved_node['label']).to eq valid_params[:node][:label]
+        expect(retrieved_node['properties']).to eq valid_params[:node][:properties]
       end
 
       let(:submit_form) { valid_put }
@@ -185,7 +195,6 @@ describe 'Nodes API' do
     end
 
     describe 'DELETE /api/nodes/:id' do
-
       let(:node) { create(:node, label: 'Existing Node', project: current_project) }
       let(:delete_node) { delete "/api/nodes/#{ node.id }", env: @env }
 
@@ -201,5 +210,4 @@ describe 'Nodes API' do
       include_examples 'creates an Activity', :destroy
     end
   end
-
 end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/nodes_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/nodes_spec.rb
@@ -80,9 +80,9 @@ describe 'Nodes API' do
             label:     'New Node',
             type_id:   Node::Types::HOST,
             parent_id: parent_node_id,
-            properties: {
+            raw_properties: {
               'ip' => '1.1.1.1'
-            },
+            }.to_json,
             position:  3
           }
         }
@@ -97,7 +97,11 @@ describe 'Nodes API' do
         expect(response.location).to eq(dradis_api.node_url(retrieved_node['id']))
 
         valid_params[:node].each do |attr, value|
-          expect(retrieved_node[attr.to_s]).to eq value
+          if attr == :raw_properties
+            expect(retrieved_node['properties']).to eq(JSON.parse(value))
+          else
+            expect(retrieved_node[attr.to_s]).to eq value
+          end
         end
       end
 
@@ -142,7 +146,7 @@ describe 'Nodes API' do
         {
           node: {
             label: 'Updated Node',
-            properties: { 'ip' => '1.0.0.1' }
+            raw_properties: { 'ip' => '1.0.0.1' }.to_json
           }
         }
       end
@@ -153,7 +157,7 @@ describe 'Nodes API' do
         expect(current_project.nodes.find(node.id).label).to eq valid_params[:node][:label]
         retrieved_node = JSON.parse(response.body)
         expect(retrieved_node['label']).to eq valid_params[:node][:label]
-        expect(retrieved_node['properties']).to eq valid_params[:node][:properties]
+        expect(retrieved_node['properties']).to eq JSON.parse(valid_params[:node][:raw_properties])
       end
 
       let(:submit_form) { valid_put }


### PR DESCRIPTION
### Summary

This change allows users to view Node Properties as part of API Node requests.


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [X] Added a CHANGELOG entry
