### PR TITLE
Add View History link in QA

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [v#.#.#] ([month] [YYYY])
   - Hera: Add new layout with redesigned navigation
+  - QA: Add View History link when viewing Issues/Content blocks
   - Upgraded gems:
     - [gem]
   - Bugs fixes:

--- a/app/assets/stylesheets/hera/modules.scss
+++ b/app/assets/stylesheets/hera/modules.scss
@@ -192,7 +192,7 @@
       }
 
       &:last-of-type {
-        margin: 0 0.75rem;
+        margin-left: 0.25rem;
       }
     }
   }

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -7,14 +7,14 @@ class RevisionsController < AuthenticatedController
   before_action :load_record, except: [ :trash, :recover ]
 
   def index
-    redirect_to action: :show, id: @record.versions.last.try(:id) || 0, return_to: params[:return_to]
+    redirect_to action: :show, id: @record.versions.last.try(:id) || 0, qa: params[:qa] == 'true'
   end
 
   def show
     # Use `reorder`, not `order`, to override Paper Trail's default scope
     @revisions = @record.versions.includes(:item).reorder('created_at DESC')
     @revision  = @revisions.find(params[:id])
-    @return_to_qa = params[:return_to] == 'qa'
+    @qa = params[:qa] == 'true'
 
     if @revision.event == 'update'
       @diffed_revision = DiffedRevision.new(@revision, @record)

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -7,13 +7,14 @@ class RevisionsController < AuthenticatedController
   before_action :load_record, except: [ :trash, :recover ]
 
   def index
-    redirect_to action: :show, id: @record.versions.last.try(:id) || 0
+    redirect_to action: :show, id: @record.versions.last.try(:id) || 0, return_to: params[:return_to]
   end
 
   def show
     # Use `reorder`, not `order`, to override Paper Trail's default scope
     @revisions = @record.versions.includes(:item).reorder('created_at DESC')
     @revision  = @revisions.find(params[:id])
+    @return_to_qa = params[:return_to] == 'qa'
 
     if @revision.event == 'update'
       @diffed_revision = DiffedRevision.new(@revision, @record)

--- a/app/helpers/revisions_helper.rb
+++ b/app/helpers/revisions_helper.rb
@@ -28,7 +28,7 @@ module RevisionsHelper
     when Card
       project_board_list_card_revision_path(current_project, @board, @list, record, revision)
     when Issue
-      project_issue_revision_path(current_project, record, revision)
+      project_issue_revision_path(current_project, record, revision, params)
     when Note
       project_node_note_revision_path(current_project, record.node, record, revision)
     when Evidence

--- a/app/helpers/revisions_helper.rb
+++ b/app/helpers/revisions_helper.rb
@@ -28,7 +28,7 @@ module RevisionsHelper
     when Card
       project_board_list_card_revision_path(current_project, @board, @list, record, revision)
     when Issue
-      project_issue_revision_path(current_project, record, revision, params)
+      project_issue_revision_path(current_project, record, revision, qa: params[:qa])
     when Note
       project_node_note_revision_path(current_project, record.node, record, revision)
     when Evidence

--- a/app/views/qa/issues/show.html.erb
+++ b/app/views/qa/issues/show.html.erb
@@ -29,7 +29,7 @@
                 <% end %>
               </span>
               <span class="action">
-                <%= link_to project_issue_revisions_path(current_project, @issue, return_to: :qa) do %>
+                <%= link_to project_issue_revisions_path(current_project, @issue, qa: true) do %>
                   <i class="fa-solid fa-history fa-fw"></i> View History
                 <% end %>
               </span>

--- a/app/views/qa/issues/show.html.erb
+++ b/app/views/qa/issues/show.html.erb
@@ -27,6 +27,8 @@
                 <%= link_to edit_project_qa_issue_path(current_project, @issue) do %>
                   <i class="fa-solid fa-pencil fa-fw"></i> Edit
                 <% end %>
+              </span>
+              <span class="action">
                 <%= link_to project_issue_revisions_path(current_project, @issue, return_to: :qa) do %>
                   <i class="fa-solid fa-history fa-fw"></i> View History
                 <% end %>

--- a/app/views/qa/issues/show.html.erb
+++ b/app/views/qa/issues/show.html.erb
@@ -27,6 +27,9 @@
                 <%= link_to edit_project_qa_issue_path(current_project, @issue) do %>
                   <i class="fa-solid fa-pencil fa-fw"></i> Edit
                 <% end %>
+                <%= link_to project_issue_revisions_path(current_project, @issue) do %>
+                  <i class="fa-solid fa-history fa-fw"></i> View History
+                <% end %>
               </span>
             </span>
           </h4>

--- a/app/views/qa/issues/show.html.erb
+++ b/app/views/qa/issues/show.html.erb
@@ -27,7 +27,7 @@
                 <%= link_to edit_project_qa_issue_path(current_project, @issue) do %>
                   <i class="fa-solid fa-pencil fa-fw"></i> Edit
                 <% end %>
-                <%= link_to project_issue_revisions_path(current_project, @issue) do %>
+                <%= link_to project_issue_revisions_path(current_project, @issue, return_to: :qa) do %>
                   <i class="fa-solid fa-history fa-fw"></i> View History
                 <% end %>
               </span>

--- a/app/views/revisions/_breadcrumbs.html.erb
+++ b/app/views/revisions/_breadcrumbs.html.erb
@@ -13,8 +13,13 @@
       <li class="breadcrumb-item"><%= link_to @record.node.label, project_node_path(current_project, @record.node, tab: 'evidence-tab') %></li>
       <li class="breadcrumb-item"><%= link_to @record.title, project_node_evidence_path(current_project, @record.node, @record) %></li>
     <% when Issue %>
-      <li class="breadcrumb-item"><%= link_to 'All issues', project_issues_path(current_project) %></li>
-      <li class="breadcrumb-item"><%= link_to @record.title, project_issue_path(current_project, @record) %></li>
+      <% if return_to_qa %>
+        <li class="breadcrumb-item"><%= link_to 'QA', project_qa_issues_path(current_project) %></li>
+        <li class="breadcrumb-item"><%= link_to @record.title, project_qa_issue_path(current_project, @record) %></li>
+      <% else %>
+        <li class="breadcrumb-item"><%= link_to 'All issues', project_issues_path(current_project) %></li>
+        <li class="breadcrumb-item"><%= link_to @record.title, project_issue_path(current_project, @record) %></li>
+      <% end %>
     <% when Note %>
       <li class="breadcrumb-item"><a href="javascript:void(0)" data-behavior="sidebar-toggle">Nodes</a></li>
       <li class="breadcrumb-item"><%= link_to @record.node.label, project_node_path(current_project, @record.node, tab: 'notes-tab') %></li>

--- a/app/views/revisions/_breadcrumbs.html.erb
+++ b/app/views/revisions/_breadcrumbs.html.erb
@@ -13,7 +13,7 @@
       <li class="breadcrumb-item"><%= link_to @record.node.label, project_node_path(current_project, @record.node, tab: 'evidence-tab') %></li>
       <li class="breadcrumb-item"><%= link_to @record.title, project_node_evidence_path(current_project, @record.node, @record) %></li>
     <% when Issue %>
-      <% if return_to_qa %>
+      <% if qa %>
         <li class="breadcrumb-item"><%= link_to 'QA', project_qa_issues_path(current_project) %></li>
         <li class="breadcrumb-item"><%= link_to @record.title, project_qa_issue_path(current_project, @record) %></li>
       <% else %>

--- a/app/views/revisions/show.html.erb
+++ b/app/views/revisions/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "#{@record.class.model_name} ##{@record.id} - comparing revisions" %>
 
 <% content_for :breadcrumbs do %>
-  <%= render partial: 'breadcrumbs' %>
+  <%= render partial: 'breadcrumbs', locals: { return_to_qa: @return_to_qa } %>
 <% end %>
 
 <% if @node %>

--- a/app/views/revisions/show.html.erb
+++ b/app/views/revisions/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "#{@record.class.model_name} ##{@record.id} - comparing revisions" %>
 
 <% content_for :breadcrumbs do %>
-  <%= render partial: 'breadcrumbs', locals: { return_to_qa: @return_to_qa } %>
+  <%= render partial: 'breadcrumbs', locals: { qa: @qa } %>
 <% end %>
 
 <% if @node %>
@@ -43,7 +43,7 @@
                     <% if revision == @revision %>
                       Currently Viewing
                     <% elsif revision.event == "update" %>
-                      <%= link_to "View Changes", record_revision_path(@record, revision, return_to: @return_to_qa ? :qa : nil) %>
+                      <%= link_to "View Changes", record_revision_path(@record, revision, qa: @qa) %>
                     <% end %>
                   <% end %>
                 </td>

--- a/app/views/revisions/show.html.erb
+++ b/app/views/revisions/show.html.erb
@@ -43,7 +43,7 @@
                     <% if revision == @revision %>
                       Currently Viewing
                     <% elsif revision.event == "update" %>
-                      <%= link_to "View Changes", record_revision_path(@record, revision) %>
+                      <%= link_to "View Changes", record_revision_path(@record, revision, return_to: @return_to_qa ? :qa : nil) %>
                     <% end %>
                   <% end %>
                 </td>


### PR DESCRIPTION
### Spec

If a user doing QA on an issue/content block wants to see the history, they will have to navigate out of the QA page, find the relevant record and click on it. Only then will they have access to the revisions history of the record. This takes a lot of clicks when we can just add a link to the revision history in the QA#show.

**Proposed solution**

- Add View history button to the QA Issues and Content blocks show pages
- Dynamically render the revisions breadcrumbs depending on where the user is coming from
  - If the user is from the QA page, render breadcrumbs that link to QA pages
  - Otherwise, render the breadcrumbs that link to the non-QA page

### Check List

- [x] Added a CHANGELOG entry
