### PR TITLE
Redirect to the next item when clicking on the QA widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 [v#.#.#] ([month] [YYYY])
   - Hera: Add new layout with redesigned navigation
-  - QA: Add View History link when viewing Issues/Content blocks
+  - QA:
+    - Add View History link when viewing Issues/Content blocks
+    - Redirect to the next item after reviewing
   - Upgraded gems:
     - [gem]
   - Bugs fixes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
   - Hera: Add new layout with redesigned navigation
   - QA:
     - Add View History link when viewing Issues/Content blocks
-    - Redirect to the next item after reviewing
+    - Automatically go to the next record after reviewing
   - Upgraded gems:
     - [gem]
   - Bugs fixes:

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -64,10 +64,11 @@ class QA::IssuesController < AuthenticatedController
   end
 
   def redirect_to_next_issue_or_index
-    notice = 'State updated successfully.'
+    notice = "State successfully updated for #{@issue.title}."
     next_issue = current_project.issues.ready_for_review.first
 
     if next_issue
+      notice << ' You are now viewing the next issue ready for review.'
       redirect_to project_qa_issue_path(current_project, next_issue), notice: notice
     else
       redirect_to project_qa_issues_path(current_project), notice: notice

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -23,7 +23,8 @@ class QA::IssuesController < AuthenticatedController
   def update
     if @issue.update(state: @state, updated_at: Time.now)
       track_state_change(@issue)
-      redirect_to project_qa_issues_path(current_project), notice: 'State updated successfully.'
+
+      redirect_to_next_issue_or_index
     else
       render :show, alert: @issue.errors.full_messages.join('; ')
     end
@@ -60,6 +61,17 @@ class QA::IssuesController < AuthenticatedController
 
   def liquid_resource_assigns
     { 'issue' => IssueDrop.new(@issue) }
+  end
+
+  def redirect_to_next_issue_or_index
+    notice = 'State updated successfully.'
+    next_issue = current_project.issues.ready_for_review.first
+
+    if next_issue
+      redirect_to project_qa_issue_path(current_project, next_issue), notice: notice
+    else
+      redirect_to project_qa_issues_path(current_project), notice: notice
+    end
   end
 
   def set_issue

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -24,7 +24,7 @@ class QA::IssuesController < AuthenticatedController
     if @issue.update(state: @state, updated_at: Time.now)
       track_state_change(@issue)
 
-      redirect_to_next_issue_or_index
+      redirect_to *next_issue_or_index_path
     else
       render :show, alert: @issue.errors.full_messages.join('; ')
     end
@@ -63,15 +63,15 @@ class QA::IssuesController < AuthenticatedController
     { 'issue' => IssueDrop.new(@issue) }
   end
 
-  def redirect_to_next_issue_or_index
+  def next_issue_or_index_path
     notice = "State successfully updated for #{@issue.title}."
     next_issue = current_project.issues.ready_for_review.first
 
     if next_issue
       notice << ' You are now viewing the next issue ready for review.'
-      redirect_to project_qa_issue_path(current_project, next_issue), notice: notice
+      [project_qa_issue_path(current_project, next_issue), notice: notice]
     else
-      redirect_to project_qa_issues_path(current_project), notice: notice
+      [project_qa_issues_path(current_project), notice: notice]
     end
   end
 

--- a/spec/support/qa_shared_examples.rb
+++ b/spec/support/qa_shared_examples.rb
@@ -96,7 +96,7 @@ shared_examples 'qa pages' do |item_type|
 
         expect { click_button state }.to have_enqueued_job(ActivityTrackingJob).with(job_params(record))
 
-        expect(page).to have_selector('.alert-success', text: 'State updated successfully.')
+        expect(page).to have_selector('.alert-success', text: 'State successfully updated')
         expect(record.reload.state).to eq state.downcase.gsub(' ', '_')
 
         next_item = model.where(state: 'ready_for_review').first

--- a/spec/support/qa_shared_examples.rb
+++ b/spec/support/qa_shared_examples.rb
@@ -96,9 +96,16 @@ shared_examples 'qa pages' do |item_type|
 
         expect { click_button state }.to have_enqueued_job(ActivityTrackingJob).with(job_params(record))
 
-        expect(current_path).to eq polymorphic_path([current_project, :qa, item_type.to_s.pluralize.to_sym])
         expect(page).to have_selector('.alert-success', text: 'State updated successfully.')
         expect(record.reload.state).to eq state.downcase.gsub(' ', '_')
+
+        next_item = model.where(state: 'ready_for_review').first
+
+        if next_item
+          expect(current_path).to eq polymorphic_path([current_project, :qa, next_item])
+        else
+          expect(current_path).to eq polymorphic_path([current_project, :qa, item_type.to_s.pluralize.to_sym])
+        end
       end
     end
   end


### PR DESCRIPTION
### Spec
Going through the list of items that are ready for review requires a lot of clicks since clicking on the widget redirects the users to the QA#index page. We can make it easier for users by redirecting the users to the next ready for review item instead.

**Proposed solution**
Update the redirect_to path on the QA#update controller

### Check List

- [x] Added a CHANGELOG entry