### PR TITLE
Add dradis/ and html/ to ignore list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module Dradis
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks templates])
+    config.autoload_lib(ignore: %w[assets dradis html tasks templates])
 
     config.active_record.default_column_serializer = YAML
 


### PR DESCRIPTION
### Summary

Add dradis/ and html/ to lib autoload ignore list since they are using non-conventional capitalization in their files (HTML and VERSION)

(will be addressed properly in another PR)

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
