### PR TITLE
Bump selenium-webdriver to 4.29

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@
     - Add View History link when viewing Issues/Content blocks
     - Automatically go to the next record after reviewing
   - Upgraded gems:
-    - capybara, net-imap, nokogiri, paper_trail, rack, rails, rails-html-sanitizer, rexml, rspec-rails
+    - capybara, net-imap, nokogiri, paper_trail, rack, rails, rails-html-sanitizer, rexml, rspec-rails, selenium-webdriver
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile
+++ b/Gemfile
@@ -193,7 +193,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'capybara', '~> 3.40'
   gem 'guard-rspec', require: false
-  gem 'selenium-webdriver', '~> 4.17'
+  gem 'selenium-webdriver', '~> 4.29'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'timecop'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,8 +505,9 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.3.1)
-    selenium-webdriver (4.18.1)
+    selenium-webdriver (4.29.1)
       base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -556,7 +557,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     webrick (1.8.2)
-    websocket (1.2.10)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -656,7 +657,7 @@ DEPENDENCIES
   rubyzip (>= 1.2.2)
   sanitize (= 6.0.2)
   sass-rails (~> 6.0)
-  selenium-webdriver (~> 4.17)
+  selenium-webdriver (~> 4.29)
   shoulda-matchers (~> 3.1)
   simple_form
   sinatra (~> 2.2.3)


### PR DESCRIPTION
### Summary

Backport from Pro - bumping selenium-webdriver as part of dealing with a CI error

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
