### PR TITLE
Disable reloading in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,10 +3,11 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded any time
+  # In the development environment your application's code can be reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  # Set enable_reloading to true to turn on this setting
+  config.enable_reloading = false
 
   # Do not eager load code on boot.
   config.eager_load = false


### PR DESCRIPTION
### Summary
When working in development, Psych throws a `Tried to dump unspecified class: UserPreferences` (or `FieldList`) error when the code is auto reloaded after changes are made.

We're setting `yaml_column_permitted_classes` in an after_initialize block and these are not being preserved/set correctly on reloads

### Proposed Solution
Disable reloading of code in development environment by setting `config.enable_reloading = false`


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
