### PR TITLE
Wrap code setting yaml_column_permitted_classes in to_prepare

### DIFF
--- a/config/initializers/yaml_serializers.rb
+++ b/config/initializers/yaml_serializers.rb
@@ -1,4 +1,4 @@
-Rails.application.config.after_initialize do
+Rails.application.reloader.to_prepare do
   ActiveRecord.yaml_column_permitted_classes = [
     ActiveModel::Errors,
     ActiveSupport::TimeWithZone,


### PR DESCRIPTION
### Summary
When working in development, Psych throws a `Tried to dump unspecified class: UserPreferences` (or `FieldList`) error when the code is auto reloaded after changes are made.

We're setting `yaml_column_permitted_classes` in an after_initialize block and these are not being preserved/set correctly on reloads because the classes get assigned new object_ids and the permitted classes are pointing to the stale object_ids.

### Proposed Solution
Wrap ActiveRecord.yaml_column_permitted_classes= in a `to_prepare` block so it is reloaded in development


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
