### PR TITLE
Bump nokogiri to 1.18.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'bcrypt', '3.1.12'
 gem 'json', '2.3.0'
 
 # XML manipulation
-gem 'nokogiri', '>= 1.18.5'
+gem 'nokogiri', '>= 1.18.8'
 
 # MySQL backend
 # gem 'mysql2', '~> 0.5.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,14 +348,14 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.18.5)
+    nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.5-arm64-darwin)
+    nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-darwin)
+    nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-linux-gnu)
+    nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -645,7 +645,7 @@ DEPENDENCIES
   net-imap (>= 0.5.6)
   net-pop
   net-smtp
-  nokogiri (>= 1.18.5)
+  nokogiri (>= 1.18.8)
   paper_trail (~> 15.2.0)
   parslet (~> 1.6.0)
   pg


### PR DESCRIPTION
### Summary

Bump nokogiri to 1.18.8 re: CVE-2025-32414 and CVE-2025-32415


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
