### PR TITLE
Use assign_attributes and save when editing nodes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 [v#.#.#] ([month] [YYYY])
   - Forms: Add a combobox for selecting, filtering, and creating options
   - Hera: Add new layout with redesigned navigation
+  - Nodes: Catch invalid JSON errors when editing node properties
   - Revisions: Show state changes in the revisions view
   - Turbo: Remove turbolinks and add turbo-rails
   - QA:

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -65,7 +65,7 @@ class NodesController < NestedNodeResourceController
   # POST /nodes/sort
   def sort
     params[:nodes].each_with_index do |id, index|
-      current_project.nodes.update_all({position: index+1}, {id: id})
+      current_project.nodes.update_all({ position: index + 1 }, { id: id })
     end
     head :ok
   end
@@ -73,7 +73,9 @@ class NodesController < NestedNodeResourceController
   # PUT /node/<id>
   def update
     respond_to do |format|
-      if @node.update(node_params)
+      @node.assign_attributes(node_params)
+
+      if @node.save
         track_updated(@node)
         format.html { redirect_to project_node_path(current_project, @node), notice: 'Node updated.' }
         format.json { render json: { success: true }.to_json }


### PR DESCRIPTION
### Spec
When editing a node's properties and using invalid JSON, the node is not saved but no errors are displayed. This is confusing for users as they can't see what the issue is when editing nodes.

**Proposed solution**
Use `assign_attributes` and `save` to catch the node json errors

### Check List

- [x] Added a CHANGELOG entry
