### PR TITLE
[Backport] Remove default_scope in routes and set relative root at Rack-level

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,8 +2,13 @@
 
 require_relative 'config/environment'
 
-run Rails.application
 Rails.application.load_server
+
+# Prepends routes with '/pro' in production.
+# config.relative_url_root is set automatically by Rails when we set ENV['RAILS_RELATIVE_URL_ROOT'] in the puma config
+map Rails.application.config.relative_url_root || '/' do
+  run Rails.application
+end
 
 # Mount the Resque web interface in development. In production is already
 # available through the CIC.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,3 @@
-if ENV['RAILS_RELATIVE_URL_ROOT']
-  Rails.application.routes.default_scope = ENV['RAILS_RELATIVE_URL_ROOT']
-end
-
 Rails.application.routes.draw do
   get 'up', to: ->(env) { [204, {}, ['']] }
 


### PR DESCRIPTION
### Summary

> Map relative_url_root at middleware level instead of using a default scope in our routes.rb file. A change was introduced in Rails 7.1 that allows engines to use relative_url_root so to avoid having /pro double appended, we should do this at the middleware level

This PR Backports this change from Pro

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
