### PR TITLE
Fix search bar in project-level sub-nav 

### DIFF
--- a/app/assets/stylesheets/hera/modules/navigation/_navigation.scss
+++ b/app/assets/stylesheets/hera/modules/navigation/_navigation.scss
@@ -328,6 +328,11 @@ header {
             }
 
             @media (min-width: 992px) {
+              padding-left: 0.7rem;
+              padding-right: 0.7rem;
+            }
+
+            @media (min-width: 1025px) {
               padding-left: 1rem;
               padding-right: 1rem;
             }
@@ -353,8 +358,8 @@ header {
 
               .nav-link {
                 color: $text-link;
-                padding-left: 1rem;
-                padding-right: 1rem;
+                padding-left: 0.7rem;
+                padding-right: 0.7rem;
               }
             }
 
@@ -364,6 +369,18 @@ header {
 
             &:last-child {
               margin-right: 0;
+            }
+          }
+
+          @media (min-width: 1025px) {
+            &.active,
+            &:active,
+            &:focus,
+            &:hover {
+              .nav-link {
+                padding-left: 1rem;
+                padding-right: 1rem;
+              }
             }
           }
         }

--- a/app/assets/stylesheets/hera/modules/navigation/_navigation.scss
+++ b/app/assets/stylesheets/hera/modules/navigation/_navigation.scss
@@ -117,6 +117,14 @@ header {
       @media (max-width: 991px) {
         padding: 0;
       }
+
+      @media (min-width: 992px) {
+        padding: 0 0.25rem;
+      }
+
+      @media (min-width: 1025px) {
+        padding: 0 1.5rem;
+      }
     }
 
     &.main-nav {
@@ -381,8 +389,6 @@ header {
       }
 
       @media (min-width: 992px) {
-        padding: 0 1rem;
-
         .navbar-nav.utility-nav {
           a,
           .nav-link {

--- a/app/views/layouts/hera/navbar/_sub_nav.html.erb
+++ b/app/views/layouts/hera/navbar/_sub_nav.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg sub-nav">
-  <div class="container-fluid p-lg-0">
+  <div class="container-fluid">
     <div class="collapse navbar-collapse dual-nav" data-behavior="navbar-collapse">
       <%= render partial: locals[:sub_nav_content] %>
     </div>


### PR DESCRIPTION
### Summary

In certain viewport widths (~992px) when the search bar is expanded, all elements positioned to its right side get thrown off the screen. This PR makes the necessary changes to the CSS to allow more horizontal space for the search bar to expand without causing any issues to the surrounding elements.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
