### PR TITLE
[Backport] Fix ActionCable routing after removing default scope in routes

### DIFF
--- a/app/views/layouts/hera.html.erb
+++ b/app/views/layouts/hera.html.erb
@@ -22,6 +22,7 @@
       read: image_path('favicon.ico') 
     } %>
 
+    <%= action_cable_meta_tag %>
     <%= stylesheet_link_tag 'hera', media: 'all', 'data-turbo-track' => true %>
     <%= javascript_include_tag 'hera', 'data-turbo-track' => true %>
     <%= csrf_meta_tag %>

--- a/config.ru
+++ b/config.ru
@@ -4,8 +4,16 @@ require_relative 'config/environment'
 
 Rails.application.load_server
 
-# Prepends routes with '/pro' in production.
+# map block prepends routes with '/pro' in production.
 # config.relative_url_root is set automatically by Rails when we set ENV['RAILS_RELATIVE_URL_ROOT'] in the puma config
+# or by config.relative_url_root in production.rb
+#
+# Currently, we have specific references to '/pro' in the following places:
+# - production.rb -> config.relative_url_root & action_cable.mount_path
+# - nginx.conf -> locations: /pro, /pro/cable, /pro/assets
+# - smtp.yml.template
+#
+# These will need to be updated when we update our configurations for Docker deployment
 map Rails.application.config.relative_url_root || '/' do
   run Rails.application
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,9 +3,6 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # mount all routes under /pro subdirectory
-  config.relative_url_root = '/pro'
-
   # The production environment is meant for finished, "live" apps.
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,9 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # mount all routes under /pro subdirectory
+  config.relative_url_root = '/pro'
+
   # The production environment is meant for finished, "live" apps.
   # Code is not reloaded between requests.
   config.cache_classes = true
@@ -46,7 +49,7 @@ Rails.application.configure do
   config.active_storage.draw_routes = false
 
   # Mount Action Cable outside main process or domain.
-  # config.action_cable.mount_path = nil
+  config.action_cable.mount_path = "#{config.relative_url_root}/cable"
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 


### PR DESCRIPTION
### Summary

In pro, since updating our routes.rb to no longer use a default_scope (and using env['RAILS_RELATIVE_URL_ROOT'] in config.ru instead) we need to update our ActionCable route otherwise the websocket connection fails with "Connection to wss://<ip>/cable failed". We need to point it to /pro/cable instead.

This PR backports the relevant changes for ce/pro parity


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
