### PR TITLE
Fix dropdown options breaking when options involve a pipe character

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,7 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
-    - [entity]:
-      - [future tense verb] [bug fix]
+    - Liquid: Allow Liquid to be used in dropdown options when creating new issue/evidence from template
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -2,7 +2,12 @@ class FieldsController < AuthenticatedController
   # Returns the form view given a source text
   def form
     @form_data = FieldParser.source_to_fields_array(params[:source])
-    @allow_dropdown = params[:allow_dropdown] == 'true'
+    @allow_dropdown = if params[:source].match?(/{{.*?}}|{%.*?%}/)
+      false
+    else
+      params[:allow_dropdown] == 'true'
+    end
+
     render layout: false
   end
 


### PR DESCRIPTION
### Summary
When creating new issue/evidence/card from a note template or from the default template (RTP), if you have Liquid content that contains filters Ex. {{ issue.fields['CVSSv3.BaseScore'] | times: 10 }}, it is split into different dropdown options at the `|` character. 

#### Proposed Solution

Set `@allow_dropdown` to false if the text contains Liquid syntax


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
