### PR TITLE
Implement pre-auth #store_location

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,9 @@
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
 
+v4.17.0 (Xxx 2025)
+  - Authentication: store current location before redirect
+
 v4.16.0 (May 2025)
   - Forms: Add a combobox for selecting, filtering, and creating options
   - Hera: Add new layout with redesigned navigation

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -7,6 +7,7 @@ module Authentication
   end
 
   def access_denied
+    store_location
     throw :warden, message: 'Please sign in first. Access denied.'
   end
 
@@ -52,6 +53,13 @@ module Authentication
   def redirect_to_target_or_default(default, *args)
     redirect_to(session[:return_to] || default, *args)
     session[:return_to] = nil
+  end
+
+  # Save the current location in session so we can go back after a successful
+  # authentication. Use #redirect_back_or_default to return to the stored
+  # location.
+  def store_location
+    session[:return_to] = request.fullpath
   end
 
   # The main accessor for the warden proxy instance


### PR DESCRIPTION
To allow us to return to the URL that caused the auth filter to kick in. Interestingly, the app already made use of the :return_to param w/ ever storing it first.


### Check List

- [x] Added a CHANGELOG entry
