### PR TITLE
Remove unnecessary data attribute

### DIFF
--- a/app/views/layouts/hera/navbar/projects/_utility_nav.html.erb
+++ b/app/views/layouts/hera/navbar/projects/_utility_nav.html.erb
@@ -3,7 +3,7 @@
     <%= render "layouts/hera/navbar/projects/search" %>
   </li>
   <li class="nav-item">
-    <%= link_to main_app.project_trash_path(current_project), class: 'nav-link', data: { behavior: 'nav-link' } do %>
+    <%= link_to main_app.project_trash_path(current_project), class: 'nav-link' do %>
       <i class="fa-solid fa-trash-can fa-fw me-1 me-lg-0" title="Trash"></i>
       <span class="d-inline d-lg-none">Trash</span>
     <% end %>

--- a/app/views/projects/_sub_nav_content.html.erb
+++ b/app/views/projects/_sub_nav_content.html.erb
@@ -1,18 +1,18 @@
 <ul class="navbar-nav">
   <%= content_tag :li, class: class_names('nav-item', active: controller_path == 'projects') do %>
-    <% link_to main_app.project_path(current_project), class: 'nav-link', data: { behavior: 'nav-link' } do %>
+    <% link_to main_app.project_path(current_project), class: 'nav-link' do %>
       <i class="fa-regular fa-folder-open me-1" title="Overview"></i>
       <span>Overview</span>
     <% end %>
   <% end %>
   <%= content_tag :li, class: class_names('nav-item', active: controller_path == 'issues') do %>
-    <%= link_to main_app.project_issues_path(current_project), class: 'nav-link', data: { behavior: 'nav-link' } do %>
+    <%= link_to main_app.project_issues_path(current_project), class: 'nav-link' do %>
       <i class="fa-solid fa-bug me-1" title="Issues"></i>
       <span>Issues</span>
     <% end %>
   <% end %>
   <%= content_tag :li, class: class_names('nav-item', active: ['boards', 'cards'].include?(controller_path)) do %>
-    <%= link_to main_app.project_boards_path(current_project), class: 'nav-link', data: { behavior: 'nav-link' } do %>
+    <%= link_to main_app.project_boards_path(current_project), class: 'nav-link' do %>
       <i class="fa-brands fa-trello me-1" title="Methodologies"></i>
       <span >Methodologies</span>
     <% end %>


### PR DESCRIPTION
### Summary

This PR removes the unnecessary 'nav-link' data attribute that was added to some navigation links during the navigation re-design.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
