### PR TITLE
Improve tools menu access based on user roles, and Dradis version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
+    - Calculators:
+      - Render Calculator links in tools menu
     - Liquid: 
       - Don't present dropdown options when creating new issue/evidence from template if the options contain Liquid filters
     - Bug tracker items:

--- a/app/views/layouts/hera/navbar/main_nav/tools_menu/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/tools_menu/_ce.html.erb
@@ -1,1 +1,1 @@
-<%= render_view_hooks('tools_menu') %>
+<%= render_view_hooks('ce_tools_menu') %>


### PR DESCRIPTION
### Summary

With the previous guard for contributors, CE users could not access the calculators from the Tools menu. This PR fixes this issue, as it comprises a CE-specific tools menu partial allowing users to properly access calculator links.


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
