### PR TITLE
Fix quote selector not scrolling automatically to the comment box in Safari

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@
       - Render Calculator links in tools menu
     - Liquid: 
       - Don't present dropdown options when creating new issue/evidence from template if the options contain Liquid filters
+    - Quote Selector:
+      - Scroll to comment box in Safari after selecting quote content
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/app/assets/javascripts/hera/modules/quote_selector.js
+++ b/app/assets/javascripts/hera/modules/quote_selector.js
@@ -130,6 +130,8 @@ class QuoteSelector {
       affix = editor.affixesLibrary('quote', selectionText);
       editor.injectSyntax(affix);
 
+      editor.$target[0].scrollIntoView({ behavior: 'smooth' });
+
       that.clear();
     });
   }


### PR DESCRIPTION
### Summary

This PR ensures the comment box is scrolled into view in all browsers after the Quote Selector is used to inject a quote with content into a comment.

### Check List

- [x] Added a CHANGELOG entry
