### PR TITLE
Add MITRE ATT&CK Calculator 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 [v#.#.#] ([month] [YYYY])
-  - [entity]:
-    - [future tense verb] [feature]
+  - Calculators: Add MITRE ATT&CK
   - Hera: Update brand colors
   - Upgraded gems:
     - [gem]

--- a/Gemfile
+++ b/Gemfile
@@ -235,6 +235,7 @@ end
 
 gem 'dradis-calculator_cvss', '~> 4.16.0'
 gem 'dradis-calculator_dread', '~> 4.16.0'
+gem 'dradis-calculator_mitre', github: 'dradis/dradis-calculator_mitre'
 
 # ---------------------------------------------------------------------- Export
 gem 'dradis-csv_export', '~> 4.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/dradis/dradis-calculator_mitre.git
+  revision: a6d84665d102695f383bda49e0058ebf2140f880
+  specs:
+    dradis-calculator_mitre (1.0.0)
+      dradis-plugins (~> 4.0)
+
+GIT
   remote: https://github.com/dradis/dradis-plugins.git
   revision: e554147b15d18aef404905c0815a05a3261a12f4
   branch: fix/missing-constant
@@ -336,7 +343,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.8-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -513,7 +520,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
+    sqlite3 (2.7.0)
+      mini_portile2 (~> 2.8.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -581,6 +589,7 @@ DEPENDENCIES
   dradis-burp (~> 4.16.0)
   dradis-calculator_cvss (~> 4.16.0)
   dradis-calculator_dread (~> 4.16.0)
+  dradis-calculator_mitre!
   dradis-coreimpact (~> 4.16.0)
   dradis-csv (~> 4.16.1)
   dradis-csv_export (~> 4.16.0)


### PR DESCRIPTION
### Summary

This PR adds the MITRE ATT&CK Calculator as a default calculator to accompany CVSS and DREAD

### Check List

- [x] Added a CHANGELOG entry
