### PR TITLE
Ensure proper contrast-ratio in notifications' dropdown

### DIFF
--- a/app/assets/stylesheets/hera/modules/_notifications.scss
+++ b/app/assets/stylesheets/hera/modules/_notifications.scss
@@ -11,7 +11,7 @@
     z-index: 2;
 
     .time {
-      color: $text-muted;
+      color: $grey-800;
     }
   }
 


### PR DESCRIPTION
### Summary

This PR fixes the contrast-ratio for read notifications' time copy in the navbar.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
