### PR TITLE
Fix digest footer links always redirecting to tester login

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -57,14 +57,14 @@
       <% if defined?(Dradis::Pro) %>
         <tr align="center">
           <td>
-            <%= link_to 'Manage your Dradis email preferences', edit_user_preferences_notifications_url, style: "color: #{css_color};" %>
+            <%= link_to 'Manage your Dradis email preferences', edit_user_preferences_notifications_url(contributors: @user.role?(:contributor) ? true : nil), style: "color: #{css_color};" %>
           </td>
         </tr>
       <% end %>
 
       <tr align="center">
         <td>
-          <a href="https://dradis.com/privacy.html" style="color: #{css_color};">Privacy</a> | <%= link_to 'Login to Dradis', login_url, style: "color: #{css_color};" %>
+          <a href="https://dradis.com/privacy.html" style="color: #{css_color};">Privacy</a> | <%= link_to 'Login to Dradis', @user.role?(:contributor) ? contributors_login_url : login_url, style: "color: #{css_color};" %>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
### Summary

Right now the footer in digests is the same for testers and contributors so contributors gett links like:
"Manage your Dradis email preferences":https://dradisframework.dev/pro/preferences/notifications
"Login to Dradis":https://dradisframework.dev/pro/login

If a contributor clicks one of the links within the notifications (links to projects, issues, etc) and is not yet signed in, they get redirected to the tester login page (/login) rather than the contributor login page (/contributors/login). 

#### Proposed Solution
Fix the login link and 'manage email preferences' links by checking contributor role

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
