### PR TITLE
Remove unneeded background-color definitions in `navigation.scss`

### DIFF
--- a/app/assets/stylesheets/hera/modules/navigation/_navigation.scss
+++ b/app/assets/stylesheets/hera/modules/navigation/_navigation.scss
@@ -158,8 +158,6 @@ header {
           &:active,
           &:focus,
           &:hover {
-            background-color: $main-nav-bg;
-
             .dropdown-item {
               background-color: lighten($main-nav-bg, 10%);
               color: $text-default;
@@ -193,7 +191,6 @@ header {
 
       .navbar-collapse {
         align-self: flex-start;
-        background-color: $main-nav-bg;
       }
 
       .navbar-nav:not(.utility-nav) {


### PR DESCRIPTION
### Summary

This PR backports the change from Pro that removes the unnecessary CSS.

### Check List

~- [ ] Added a CHANGELOG entry~
