### PR TITLE
Use ActiveJob UID for log initialization

### DIFF
--- a/app/jobs/upload_job.rb
+++ b/app/jobs/upload_job.rb
@@ -3,10 +3,10 @@ class UploadJob < ApplicationJob
 
   queue_as :dradis_upload
 
-  def perform(default_user_id:, file:, plugin_name:, project_id:, state:, uid:)
-    logger = Log.new(uid: uid)
+  def perform(default_user_id:, file:, plugin_name:, project_id:, state:)
+    logger = Log.new(uid: job_id)
 
-    logger.write { "Job id is #{uid}." }
+    logger.write { "Job id is #{job_id}." }
     logger.write { 'Running Ruby version %s' % RUBY_VERSION }
     logger.write { 'Worker process starting background task.' }
 
@@ -24,6 +24,7 @@ class UploadJob < ApplicationJob
 
     logger.write { 'Worker process completed.' }
 
+    self
   rescue => exception
     logger.write { "There was an error with the upload: #{exception.message}" }
     if Rails.env.development?

--- a/app/views/upload/create.js.erb
+++ b/app/views/upload/create.js.erb
@@ -1,23 +1,24 @@
 <% if @success -%>
-  ConsoleUpdater.jobId = '<%= @item_id %>'
-  $('#result').data('id', ConsoleUpdater.jobId)
-  $('#result').show()
-  $('#item_id').val(ConsoleUpdater.jobId)
-
-  $('#filesize').text('<%=j number_to_human_size( File.size(@attachment.fullpath) ) %>');
-  $('#spinner').hide();
-  ConsoleUpdater.parsing = true;
-  url = $('#new_upload').data('parse-url');
   data = {
     file: '<%= @attachment.filename %>',
-    item_id: '<%= @item_id %>',
     uploader: '<%= params[:uploader] %>'
   };
   <% if @state %>
     data.state = '<%= @state %>';
   <% end %>
 
-  $.post(url, data, null, 'script');
+  url = $('#new_upload').data('parse-url');
+  $.post(url, data, function(response) {
+    ConsoleUpdater.jobId = response['job_id']
+
+    $('#result').data('id', ConsoleUpdater.jobId)
+    $('#result').show()
+    $('#item_id').val(ConsoleUpdater.jobId)
+
+    $('#filesize').text('<%=j number_to_human_size( File.size(@attachment.fullpath) ) %>');
+    $('#spinner').hide();
+    ConsoleUpdater.parsing = true;
+  }, 'json');
 
   $('#attachment').val('<%= @attachment.filename %>');
   setTimeout(ConsoleUpdater.updateConsole, 1000);


### PR DESCRIPTION
### Summary

Refactor the job handling to use the ActiveJob UID instead. This requires the following changes:
- the controller will need to return the job ID
- create.js.erb will need to startup the ConsoleUpdater after receiving the job ID from the controller (callback)
- the job will not need the uid argument anymore
- In the upload controller, the inline call will need to be updated to call job.perform_now instead of calling the importer directly


### Check List

- [ ] Added a CHANGELOG entry
