### PR TITLE
Fix focus state in vertical nav-tabs

### DIFF
--- a/app/assets/stylesheets/hera/modules.scss
+++ b/app/assets/stylesheets/hera/modules.scss
@@ -286,7 +286,6 @@
           }
         }
 
-        &:focus,
         &:hover {
           background-color: $light;
         }


### PR DESCRIPTION
### Summary

This PR asserts that :focus-visible in vertical nav-tabs does not get overwritten by custom :focus properties.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
