### PR TITLE
Consistent sorting icons (fixes sorting in Pro)

### DIFF
--- a/app/assets/javascripts/hera/behaviors.js
+++ b/app/assets/javascripts/hera/behaviors.js
@@ -189,7 +189,7 @@ document.addEventListener('turbo:load', function () {
       axis: 'y',
       containment: 'parent',
       cursor: 'grabbing',
-      handle: '.fa-grip-vertical',
+      handle: '.fa-reorder',
       update: function () {
         $.post(
           $(this).data('sort-url'),

--- a/app/assets/stylesheets/hera/modules/_icons.scss
+++ b/app/assets/stylesheets/hera/modules/_icons.scss
@@ -2,7 +2,7 @@
   color: $green;
 }
 
-.fa-grip-vertical {
+.fa-reorder {
   cursor: grab;
 
   &:active {

--- a/app/views/tags/_table.html.erb
+++ b/app/views/tags/_table.html.erb
@@ -23,7 +23,7 @@
                content =
               case column
               when 'Sort'
-                  content_tag(:i, nil, class: 'fa-solid fa-grip-vertical w-100') + content_tag(:span, 'Change sort order', class: 'visually-hidden')
+                  content_tag(:i, nil, class: 'fa-solid fa-reorder w-100') + content_tag(:span, 'Change sort order', class: 'visually-hidden')
               when 'Name'
                   content_tag(:span, class: 'tag', style: "color: #{tag.color}") do
                     content_tag(:i, nil, class: 'fa-solid fa-tag fa-fw me-1') + tag.display_name

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -48,7 +48,7 @@ describe 'Tag pages:' do
 
     describe 'sorting tags', js: true do
       it 'updates tag priority values' do
-        tag3_element = find("#tag-#{tag3.id}").find('.fa-grip-vertical')
+        tag3_element = find("#tag-#{tag3.id}").find('.fa-reorder')
         tag1_element = find("#tag-#{tag.id}")
 
         tag3_element.drag_to(tag1_element)


### PR DESCRIPTION
### Summary

This PR uses consistent sorting icons and updates the sort element trigger. Acts as a pre-req for fixing sorting in RT. 

### Check List

~- [ ] Added a CHANGELOG entry~
