### PR TITLE
Bump version to 4.17.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,9 @@
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
 
+v4.17.1 (July 2025)
+  - No changes
+
 v4.17.0 (July 2025)
   - Authentication: store current location before redirect
   - Calculators: Add MITRE ATT&CK

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: engines/dradis-api
   specs:
-    dradis-api (4.17.0)
+    dradis-api (4.17.1)
       jbuilder
 
 GEM

--- a/lib/dradis/ce/version.rb
+++ b/lib/dradis/ce/version.rb
@@ -3,7 +3,7 @@ module Dradis
     module VERSION #:nodoc:
       MAJOR = 4
       MINOR = 17
-      TINY  = 0
+      TINY  = 1
       PRE = nil
 
       STRING = [[MAJOR, MINOR, TINY].join('.'), PRE].compact.join('-')


### PR DESCRIPTION
### Summary

Pro version is 4.17.1 and we need to bump CE for consistency


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
