### PR TITLE
[Backport] List enabled integrations in issues table 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
     - Add Thruster gem to handle https
     - Manage server processes with a Procfile and boot script
   - Font: Improve language support
+  - Integrations: List enabled integrations in issues table to show/hide integration-specific table actions
   - Rails: Upgrade Rails version to 8.0.2.1
   - Ruby: Upgrade Ruby version to 3.4.4
   - Upgraded gems: thor

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -22,6 +22,7 @@ class IssuesController < AuthenticatedController
   before_action :set_tags, except: [:destroy]
 
   def index
+    @enabled_integrations = Dradis::Plugins::with_feature(:addon).map(&:plugin_name).map(&:to_s)
   end
 
   def show

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -6,7 +6,8 @@
   'new-tag-path': new_project_tag_path(current_project),
   'can-publish': can?(:publish, current_project),
   'state-icons': local_assigns[:qa_state_icons] ? local_assigns[:qa_state_icons] : state_icons,
-  'tags-path': project_tags_path(current_project)
+  'tags-path': project_tags_path(current_project),
+  'enabled-integrations': @enabled_integrations
 }%>
 <% table_attributes.merge!(tags: @tags.map { |t| [t.display_name, t.color, t.name] }.to_json) if local_assigns[:tags] %>
 <%= tag.table class: 'table table-striped mb-0', data: table_attributes do %>


### PR DESCRIPTION
### Summary

When integrations are enabled/disabled we want to conditionally show/hide datatable table actions. In order to do this, we will keep an up-to-date list of enabled integrations in the issues#index table 


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
