### PR TITLE
Fix Deploy to DigitalOcean button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -12,4 +12,6 @@ spec:
     git:
       branch: develop
       repo_clone_url: https://github.com/dradis/dradis-ce.git
+    health_check:
+      http_path: /up
     name: web

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,7 +1,6 @@
 spec:
   name: dradis-ce
   services:
-  - environment_slug: ruby-on-rails
     envs:
     - key: RAILS_ENV
       value: production

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -9,8 +9,8 @@ spec:
     - key: RAILS_SERVE_STATIC_FILES
       value: enabled
       scope: RUN_TIME
+    dockerfile_path: Dockerfile
     git:
       branch: develop
       repo_clone_url: https://github.com/dradis/dradis-ce.git
     name: web
-    run_command: ./bin/setup

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,7 +1,7 @@
 spec:
   name: dradis-ce
   services:
-    dockerfile_path: Dockerfile
+  - dockerfile_path: Dockerfile
     git:
       branch: develop
       repo_clone_url: https://github.com/dradis/dradis-ce.git

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,17 +1,11 @@
 spec:
   name: dradis-ce
   services:
-  - envs:
-    - key: RAILS_ENV
-      value: production
-      scope: RUN_TIME
-    - key: RAILS_SERVE_STATIC_FILES
-      value: enabled
-      scope: RUN_TIME
     dockerfile_path: Dockerfile
     git:
       branch: develop
       repo_clone_url: https://github.com/dradis/dradis-ce.git
     health_check:
       http_path: /up
+    http_port: 80
     name: web

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,7 +1,7 @@
 spec:
   name: dradis-ce
   services:
-    envs:
+  - envs:
     - key: RAILS_ENV
       value: production
       scope: RUN_TIME


### PR DESCRIPTION
### Summary

We can stop using buildpacks and use the Dockerfile for our app deployment.

ENV variables and ports now come form the Dockerfile.

### Check List

- ~~[ ] Added a CHANGELOG entry~~
- ~~[ ] Commit message has a detailed description of what changed and why.~~
