### PR TITLE
Configure DO deployment to use existing Docker image

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -2,6 +2,9 @@ spec:
   name: dradis-ce
   services:
   - name: web
+    health_check:
+      http_path: /up
+    http_port: 80
     image:
       registry_type: DOCKER_HUB
       registry: dradis


### PR DESCRIPTION
### Summary

Instead of building an image from the Dockerfile use an existing image from Docker Hub.

### Check List

- ~~[ ] Added a CHANGELOG entry~~
- ~~[ ] Commit message has a detailed description of what changed and why.~~
