### PR TITLE
Assert access to notification-read icon

### DIFF
--- a/app/assets/stylesheets/hera/modules/_notifications.scss
+++ b/app/assets/stylesheets/hera/modules/_notifications.scss
@@ -48,6 +48,7 @@
     position: absolute;
     top: 30px;
     right: 15px;
+    z-index: 2;
   }
 
   &.unread {


### PR DESCRIPTION
### Summary

This PR increases the z-index of the notification-read icon in the notifications dropdown menu to assert it's clickable.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
