### PR TITLE
Move tag-input to top for QA entries

### DIFF
--- a/app/assets/stylesheets/hera/views/issues/_issues.scss
+++ b/app/assets/stylesheets/hera/views/issues/_issues.scss
@@ -1,5 +1,6 @@
 body.issues.edit,
-body.issues.new {
+body.issues.new,
+body.qa-issues.edit {
   .tag-input {
     display: flex;
     align-items: center;
@@ -27,13 +28,6 @@ body.issues.edit {
       background-color: $primary;
       color: $white;
     }
-  }
-}
-
-body.qa-issues.edit {
-  .tag-input {
-    display: flex;
-    align-items: center;
   }
 }
 


### PR DESCRIPTION
### Summary

After updating the Editor UI, the tag-input element in QA::Entry#edit, was still placed after the content of the entry, something that caused an inconsistency between QA::Entry#edit and Issue#edit. This PR makes the necessary CSS changes to assert consistency between the two.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
