### PR TITLE
fix disabled prompts not being selected for single-selects

### DIFF
--- a/app/assets/javascripts/hera/modules/combobox.js
+++ b/app/assets/javascripts/hera/modules/combobox.js
@@ -478,7 +478,13 @@ class ComboBox {
       `[data-value="${this.$target.val()}"]`
     );
 
-    $initialOption = $initialOption.length ? $initialOption : [];
+    if (!$initialOption.length) {
+      if (this.isMultiSelect) {
+        $initialOption = [];
+      } else {
+        $initialOption = this.$comboboxOptions.first();
+      }
+    }
 
     this.selectOptions($initialOption);
     this.$combobox.toggleClass(


### PR DESCRIPTION
### Summary

https://github.com/dradis/dradis-ce/pull/1400 introduced a bug where single-selects with a disabled prompt option don't have the prompt selected on page load, instead selecting the first non-disabled option.

This PR fixes this bug by checking if the select is a multiselect element first and only applies the fix from https://github.com/dradis/dradis-ce/pull/1400 to multiselects.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
