### PR TITLE
SessionsController should inherit from SetupRequired

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 # This controller handles the login/logout function of the site.
-class SessionsController < ApplicationController
+class SessionsController < SetupRequiredController
   skip_before_action :verify_authenticity_token, only: :failure
 
   def create

--- a/app/controllers/setup_required_controller.rb
+++ b/app/controllers/setup_required_controller.rb
@@ -10,7 +10,7 @@ class SetupRequiredController < ApplicationController
   def setup_required_ce
     if (::Configuration.shared_password == 'improvable_dradis')
       redirect_to new_setup_password_path
-    elsif  ::Configuration.where(name: 'admin:usage_sharing').empty?
+    elsif ::Configuration.where(name: 'admin:usage_sharing').empty?
       redirect_to new_setup_analytics_path
     elsif Node.count.zero?
       # We're using this as a proxy for whether the instance has been configured

--- a/app/controllers/setup_required_controller.rb
+++ b/app/controllers/setup_required_controller.rb
@@ -10,6 +10,8 @@ class SetupRequiredController < ApplicationController
   def setup_required_ce
     if (::Configuration.shared_password == 'improvable_dradis')
       redirect_to new_setup_password_path
+    elsif  ::Configuration.where(name: 'admin:usage_sharing').empty?
+      redirect_to new_setup_analytics_path
     elsif Node.count.zero?
       # We're using this as a proxy for whether the instance has been configured
       # when we visit a project, the methodology_ and issue_library nodes are

--- a/app/views/setup/_progress.html.erb
+++ b/app/views/setup/_progress.html.erb
@@ -1,5 +1,8 @@
 <div class="setup-progress">
+  <% if defined?(Dradis::Pro) %>
+  <% else %>
   <div class="setup-progress-indicator <%= 'active' if (request.path == root_path) || request.path.include?('/password') %>"></div>
   <div class="setup-progress-indicator <%= 'active' if request.path.include?('/analytics') %>"></div>
+  <% end %>
   <div class="setup-progress-indicator <%= 'active' if request.path.include?('/kit') %>"></div>
 </div>

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -37,7 +37,7 @@ describe 'Sessions' do
   end
 
   context 'when using an incorrect password' do
-    let(:password) { 'wrong_pass'}
+    let(:password) { 'wrong_pass' }
 
     it 'redirect to login with a message' do
       login

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe 'Sessions' do
   subject { page }
 
-  # This matches fixtures/configurations.yml value.
   let(:password) { 'rspec_pass' }
   let(:user) do
     create(
@@ -13,13 +12,16 @@ describe 'Sessions' do
     )
   end
 
+  # this is needed to bypass the Setup steps
+  before do
+    create(:configuration, name: 'admin:password', value: ::BCrypt::Password.create('rspec_pass'))
+    create(:configuration, name: 'admin:usage_sharing', value: '1')
+    create(:project).issue_library
+  end
+
   # This needs to be a helper and not a let() block, because let is memoized
   # and reused.
   def login
-    # This gets us past Setup: Step 2
-    project = create(:project)
-    project.issue_library
-
     visit login_path
     fill_in 'login', with: user.email
     fill_in 'password', with: password

--- a/spec/features/setup/kits_spec.rb
+++ b/spec/features/setup/kits_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
-describe 'Setup::Kits' do
-
-  # This Setup step is CE only
-  break if defined?(Dradis::Pro)
+describe 'Setup::Kits', skip_setup_mock: true do
 
   context "when shared password is already set" do
     it "enqueues a KitImport job if a valid kit is passed" do

--- a/spec/features/setup/kits_spec.rb
+++ b/spec/features/setup/kits_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe 'Setup::Kits', skip_setup_mock: true do
 
-  context "when shared password is already set" do
-    it "enqueues a KitImport job if a valid kit is passed" do
+  context 'when shared password is already set' do
+    it 'enqueues a KitImport job if a valid kit is passed' do
 
       ActiveJob::Base.queue_adapter = :test
       ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
@@ -17,7 +17,7 @@ describe 'Setup::Kits', skip_setup_mock: true do
       end.to have_enqueued_job(KitImportJob)
     end
 
-    it "doesn't enque a KitImport if :none is passed" do
+    it 'doesn\'t enque a KitImport if :none is passed' do
       visit new_setup_kit_path
       expect do
         # We'd need JS to be able to click in the link and send a POST
@@ -25,7 +25,7 @@ describe 'Setup::Kits', skip_setup_mock: true do
       end.to_not have_enqueued_job(KitImportJob)
     end
 
-    it "doesn't enque a KitImport if invalid kit is passed" do
+    it 'doesn\'t enque a KitImport if invalid kit is passed' do
       visit new_setup_kit_path
       expect do
         # We'd need JS to be able to click in the link and send a POST

--- a/spec/features/user_searches_spec.rb
+++ b/spec/features/user_searches_spec.rb
@@ -10,7 +10,7 @@ describe 'User searches', type: :feature do
 
   before do
     login_to_project_as_user
-    visit root_path
+    visit project_path(current_project)
   end
 
   it 'can access search on main navigation' do

--- a/spec/fixtures/configurations.yml
+++ b/spec/fixtures/configurations.yml
@@ -1,4 +1,0 @@
-# ::BCrypt::Password.create('rspec_pass')
-password:
-  name: 'admin:password'
-  value: $2a$10$KXgHWzfmtCULbUFYg8XRLOqQLitq6CL6xbXO2gszKbPwRUoRhy6CC

--- a/spec/fixtures/configurations.yml
+++ b/spec/fixtures/configurations.yml
@@ -1,6 +1,3 @@
-analytics:
-  name: 'admin:usage_sharing'
-  value: 1
 # ::BCrypt::Password.create('rspec_pass')
 password:
   name: 'admin:password'

--- a/spec/fixtures/nodes.yml
+++ b/spec/fixtures/nodes.yml
@@ -1,3 +1,0 @@
-root:
-  label: 'Wizard Bypass'
-  type_id: Node::Types::ISSUELIB

--- a/spec/fixtures/nodes.yml
+++ b/spec/fixtures/nodes.yml
@@ -1,0 +1,3 @@
+root:
+  label: 'Wizard Bypass'
+  type_id: Node::Types::ISSUELIB

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,9 +82,9 @@ RSpec.configure do |config|
   config.include ControllerMacros, type: :feature
   config.include ControllerMacros, type: :request
   # config.include SelecterHelper,   type: :feature
-  config.include SupportHelper,    type: :controller
-  config.include SupportHelper,    type: :feature
-  config.include SupportHelper,    type: :request
+  config.include SupportHelper, type: :controller
+  config.include SupportHelper, type: :feature
+  config.include SupportHelper, type: :request
   config.include FactoryBot::Syntax::Methods
   config.include WaitForAjax, type: :feature
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,9 +82,9 @@ RSpec.configure do |config|
   config.include ControllerMacros, type: :feature
   config.include ControllerMacros, type: :request
   # config.include SelecterHelper,   type: :feature
-  # config.include SupportHelper,    type: :controller
-  # config.include SupportHelper,    type: :feature
-  # config.include SupportHelper,    type: :request
+  config.include SupportHelper,    type: :controller
+  config.include SupportHelper,    type: :feature
+  config.include SupportHelper,    type: :request
   config.include FactoryBot::Syntax::Methods
   config.include WaitForAjax, type: :feature
 

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,15 +1,6 @@
 module ControllerMacros
   extend ActiveSupport::Concern
 
-  included do
-    # Bypassing the setup Wizard
-    ## Shared Password
-    ## Analytics
-    fixtures :configurations
-    ## Kit
-    fixtures :nodes
-  end
-
   # Macro to emulate user login
   def login_as_user(user = create(:user))
     allow_any_instance_of(ApplicationController).to \

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,7 +1,14 @@
 module ControllerMacros
   extend ActiveSupport::Concern
 
-  included { fixtures :configurations }
+  included do
+    # Bypassing the setup Wizard
+    ## Shared Password
+    ## Analytics
+    fixtures :configurations
+    ## Kit
+    fixtures :nodes
+  end
 
   # Macro to emulate user login
   def login_as_user(user = create(:user))
@@ -16,12 +23,6 @@ module ControllerMacros
     login_as_user
 
     @project = Project.new
-
-    # Bypassing the setup Wizard
-    ## Password: via fixture file
-    ## Analytics: via fixture file
-    ## Kit: weaksauce alert: this creates a Node which flags the Setup as done.
-    @project.issue_library
   end
 
   def current_project

--- a/spec/support/support_helper.rb
+++ b/spec/support/support_helper.rb
@@ -1,0 +1,19 @@
+module SupportHelper
+  def self.included(base)
+    included_ce(base)
+    included_pro(base) if defined?(Dradis::Pro)
+  end
+
+  def self.included_ce(base)
+    base.before(:each) do |example|
+      # Disable the setup tour
+      unless example.metadata[:skip_setup_mock]
+        allow_any_instance_of(SetupRequiredController)
+          .to receive(:setup_required).and_return(true)
+      end
+    end
+  end
+
+  def self.included_pro(base)
+  end
+end

--- a/spec/support/support_helper.rb
+++ b/spec/support/support_helper.rb
@@ -1,7 +1,7 @@
 module SupportHelper
   def self.included(base)
     included_ce(base)
-    included_pro(base) if defined?(Dradis::Pro)
+    included_pro(base)
   end
 
   def self.included_ce(base)


### PR DESCRIPTION
### Summary

This is to ensure you're not attempting to log in without having run
through the Setup Wizard yet. It's a rare situation that can happen
either in Development or if in the Sandbox environment your DB gets
nuked while you were signed in. Then your session expires, and you're
sent to /login on a pristine DB, which before this PR the controller
wouldn't detect.

After this change, even in that scenario, /login redirects to /setup if
the DB becomes pristine.

The problem is that our Specs were relying on "login trickery" to bypass
the Setup Wizard rather than addressing the problem head on. This PR
also creates the necessary support to bypass the Setup Wizard steps
inside the specs (but continue to be able to test it.


### Check List

- ~~[ ] Added a CHANGELOG entry~~
- [x] Commit message has a detailed description of what changed and why.
