### PR TITLE
Evaluate Liquid in issue/evidence fields before rendering in the #index tables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 [v#.#.#] ([month] [YYYY])
+  - Liquid: evaluate Liquid content before rendering all issues/evidence tables
   - Wizard: add analytics sharing step
-  - [entity]:
-    - [future tense verb] [feature]
   - Upgraded gems:
     - [gem]
   - Bugs fixes:

--- a/app/helpers/markup_helper.rb
+++ b/app/helpers/markup_helper.rb
@@ -10,4 +10,12 @@ module MarkupHelper
       source_url: main_app.source_fields_path
     }
   end
+
+  def liquified_field(field, record)
+    LiquidParser.new(
+      field: field,
+      project: current_project, 
+      record: record
+    ).parse
+  end
 end

--- a/app/services/liquid_parser.rb
+++ b/app/services/liquid_parser.rb
@@ -1,0 +1,39 @@
+class LiquidParser
+  attr_accessor :field, :project, :record
+
+  def initialize(field: nil, project:, record:)
+    @field = field
+    @project = project
+    @record = record
+  end
+
+  def parse
+    @output ||= HTML::Pipeline::Dradis::LiquidFilter.call(
+      value,
+      liquid_assigns: liquid_assigns
+    ).strip
+  end
+
+  private
+
+  def value
+    if field
+      record.fields[field]
+    else
+      record.content
+    end
+  end
+
+  def liquid_assigns
+    project_assigns = LiquidCachedAssigns.new(project: project)
+
+    project_assigns.merge(record_assigns)
+  end
+
+  def record_assigns
+    record_class = record.class.to_s
+    drop_class = "#{record_class}Drop".constantize
+
+    { record_class.underscore => drop_class.new(record) }
+  end
+end

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -50,7 +50,8 @@
                 when 'Updated'
                   [issue.updated_at.to_i, local_time_ago(issue.updated_at)]
                 else
-                  [issue.fields.fetch(column, ''), markup(issue.fields.fetch(column, ''))]
+                  text = liquified_field(column, issue)
+                  [text, markup(text)]
                 end
               %>
               <%= content_tag :td,

--- a/app/views/issues/evidence/_table.html.erb
+++ b/app/views/issues/evidence/_table.html.erb
@@ -31,7 +31,8 @@
               when 'Updated'
                 [evidence.updated_at.to_i, local_time_ago(evidence.updated_at)]
               else
-                [evidence.fields.fetch(column, ''), markup(evidence.fields.fetch(column, ''))]
+                text = liquified_field(column, evidence)
+                [text, markup(text)]
               end
             %>
             <td data-sort="<%= sort %>"><%= display %></td>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -47,7 +47,8 @@
               when 'Updated'
                 [item.updated_at.to_i, local_time_ago(item.updated_at)]
               else
-                [item.fields.fetch(column, ''), markup(item.fields.fetch(column, ''))]
+                text = liquified_field(column, item)
+                [text, markup(text)]
               end
               %>
               <td data-sort="<%= sort %>"><%= display %></td>


### PR DESCRIPTION
### Summary

Currently, even though Liquid works as expected in Word filters and other contexts, it cannot be displayed properly in the Issues/Evidence tables.

Add a view helper that uses LiquidParser on the given field so that the text shows up with evaluated Liquid in the tables

We also need to add `LiquidParser` 

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
