### PR TITLE
Setup::Kits#create - always mark_as_done

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 [v#.#.#] ([month] [YYYY])
-  - Wizard: add analytics sharing step
+  - Wizard:
+    - Add analytics sharing step
+    - Mark as done after Kit step, without waiting for the background job.
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:

--- a/app/controllers/setup/kits_controller.rb
+++ b/app/controllers/setup/kits_controller.rb
@@ -8,7 +8,7 @@ module Setup
     def create
       case @kit
       when :none
-        mark_as_done
+        ;
       when :welcome
         kit_folder = Rails.root.join('lib', 'tasks', 'templates', 'welcome').to_s
         logger = Log.new.info('Loading Welcome kit...')
@@ -17,6 +17,7 @@ module Setup
         KitImportJob.perform_later(kit_folder, logger: logger)
       end
 
+      mark_as_done
       flash[:notice] = 'All done. May the findings for this project be plentiful!'
       redirect_to login_path
     end


### PR DESCRIPTION
Before this change, if the user chose to upload a Kit, we'd enqueue the job and assume it'd populate the DB, which would be detected by the Setup Wizard. Then we'd redirect to /login

However, often, the /login page would detect the pristine DB (because the background worker hadn't kicked in yet), and send the user back to Setup::Kit#new.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
