### PR TITLE
Nodes: add more types and icons

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [v#.#.#] ([month] [YYYY])
+  - Nodes: add more types and icons
   - Wizard:
     - Add analytics sharing step
     - Mark as done after Kit step, without waiting for the background job.

--- a/Gemfile
+++ b/Gemfile
@@ -228,7 +228,7 @@ gem 'dradis-plugins', '~> 4.19.0'
 gem 'dradis-api', path: 'engines/dradis-api'
 
 # Import / export project data
-gem 'dradis-projects', '~> 4.19.0'
+gem 'dradis-projects', github: 'dradis/dradis-projects', branch: 'nodes/icons'
 
 plugins_file = 'Gemfile.plugins'
 if File.exist?(plugins_file)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/dradis/dradis-projects.git
+  revision: 726eec47158c518935ae638fedb82a304dd00237
+  branch: nodes/icons
+  specs:
+    dradis-projects (4.19.0)
+      dradis-plugins (>= 4.8.0)
+      rubyzip
+
 PATH
   remote: engines/dradis-api
   specs:
@@ -190,9 +199,6 @@ GEM
     dradis-pentera (4.19.0)
       dradis-plugins (~> 4.0)
     dradis-plugins (4.19.0)
-    dradis-projects (4.19.0)
-      dradis-plugins (>= 4.8.0)
-      rubyzip
     dradis-qualys (4.19.0)
       dradis-plugins (~> 4.0)
       nokogiri (~> 1.3)
@@ -617,7 +623,7 @@ DEPENDENCIES
   dradis-openvas (~> 4.19.0)
   dradis-pentera (~> 4.19.0)
   dradis-plugins (~> 4.19.0)
-  dradis-projects (~> 4.19.0)
+  dradis-projects!
   dradis-qualys (~> 4.19.0)
   dradis-saint (~> 4.19.0)
   dradis-veracode (~> 4.19.0)

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -18,7 +18,7 @@ module HeraHelper
     when Issue
       tag = model.tags.first
     when Node
-      css = ['fa-solid']
+      css = ['fa-fw fa-solid']
       css << model.icon
     end
 

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -71,6 +71,13 @@ module HeraHelper
     end
   end
 
+  def node_types_collection
+    Node::Types::LABELS.map.with_index do |type, index|
+      next if Node::Types::SYSTEM_TYPES.include?(index)
+      [ type.titleize, index ]
+    end.compact
+  end
+
   def page_title
     [content_for(:title), "Dradis #{defined?(Dradis::Pro) ? 'Professional' : 'Community' } Edition"].compact.join(' | ')
   end

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -72,7 +72,7 @@ module HeraHelper
   end
 
   def node_types_collection
-    Node::Types::LABELS.map.with_index do |type, index|
+    Node::Types::LABELS.filter_map.with_index do |type, index|
       next if Node::Types::SYSTEM_TYPES.include?(index)
       icon = Node::Types::ICONS[index]
       html_options = icon.present? ? { 'data-combobox-option-icon': "fa-solid #{icon}" } : {}
@@ -81,7 +81,7 @@ module HeraHelper
         index,
         html_options
       ]
-    end.compact
+    end
   end
 
   def page_title

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -10,7 +10,6 @@ module HeraHelper
     css << icon_class
     css << extra_class if extra_class
 
-    options = { class: css.join(' ') }
     tag = nil
 
     case model
@@ -18,11 +17,15 @@ module HeraHelper
       tag = model.issue.tags.first
     when Issue
       tag = model.tags.first
+    when Node
+      css = ['fa-regular']
+      css << model.icon
     end
 
+    options = { class: css.join(' ') }
     if tag
       options[:style] = "color: #{tag.color}"
-    else
+    elsif !model.is_a?(Node)
       options[:style] = 'color: #222'
     end
 

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -74,7 +74,13 @@ module HeraHelper
   def node_types_collection
     Node::Types::LABELS.map.with_index do |type, index|
       next if Node::Types::SYSTEM_TYPES.include?(index)
-      [ type.titleize, index ]
+      icon = Node::Types::ICONS[index]
+      html_options = icon.present? ? { 'data-combobox-option-icon': "fa-solid #{icon}" } : {}
+      [
+        type.titleize,
+        index,
+        html_options
+      ]
     end.compact
   end
 

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -18,7 +18,7 @@ module HeraHelper
     when Issue
       tag = model.tags.first
     when Node
-      css = ['fa-regular']
+      css = ['fa-solid']
       css << model.icon
     end
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -6,14 +6,7 @@
 # Attachment objects associated with them.
 class Node < ApplicationRecord
   include NodeProperties
-
-  module Types
-    DEFAULT = 0
-    HOST = 1
-    METHODOLOGY = 2
-    ISSUELIB = 3
-    USER_TYPES = [DEFAULT, HOST]
-  end
+  include Types
 
   acts_as_tree counter_cache: true, order: :label
 
@@ -58,7 +51,6 @@ class Node < ApplicationRecord
   # -- Callbacks ------------------------------------------------------------
   before_destroy :destroy_attachments
   before_save do |record|
-    record.type_id = Types::DEFAULT unless record.type_id
     record.position = 0 unless record.position
   end
 
@@ -71,10 +63,6 @@ class Node < ApplicationRecord
     user_nodes.roots
   }
 
-  scope :user_nodes, -> {
-    where('type_id IN (?)', Types::USER_TYPES)
-  }
-
   # -- Class Methods --------------------------------------------------------
 
   # -- Instance Methods -----------------------------------------------------
@@ -85,10 +73,6 @@ class Node < ApplicationRecord
   # Return all the Attachment objects associated with this Node.
   def attachments
     Attachment.find(:all, conditions: { node_id: self.id })
-  end
-
-  def user_node?
-    Types::USER_TYPES.include?(self.type_id)
   end
 
   # SEE: https://github.com/amerine/acts_as_tree/issues/63

--- a/app/models/node/types.rb
+++ b/app/models/node/types.rb
@@ -5,16 +5,17 @@ module Node::Types
   HOST = 1
   METHODOLOGY = 2
   ISSUELIB = 3
-  FOLDER = 4
-  ATTACHMENT = 5
-  UPLOAD = 6
-  DESKTOP = 7
-  SERVER = 8
-  MOBILE = 9
-  TABLET = 10
-  USER = 11
-  NETWORK = 12
-  CREDENTIAL = 13
+  CONTENTLIB = 4
+  FOLDER = 5
+  ATTACHMENT = 6
+  UPLOAD = 7
+  DESKTOP = 8
+  SERVER = 9
+  MOBILE = 10
+  TABLET = 11
+  USER = 12
+  NETWORK = 13
+  CREDENTIAL = 14
 
   LABELS = %w[
     Default
@@ -48,7 +49,8 @@ module Node::Types
 
   SYSTEM_TYPES = [
     METHODOLOGY,
-    ISSUELIB
+    ISSUELIB,
+    CONTENTLIB
   ]
 
   included do

--- a/app/models/node/types.rb
+++ b/app/models/node/types.rb
@@ -1,0 +1,78 @@
+module Node::Types
+  extend ActiveSupport::Concern
+
+  DEFAULT = 0
+  HOST = 1
+  METHODOLOGY = 2
+  ISSUELIB = 3
+  FOLDER = 4
+  ATTACHMENT = 5
+  UPLOAD = 6
+  DESKTOP = 7
+  SERVER = 8
+  MOBILE = 9
+  TABLET = 10
+  USER = 11
+  NETWORK = 12
+  CREDENTIAL = 13
+
+  LABELS = %w[
+    Default
+    Host
+    Methodology
+    IssueLib
+    Folder
+    Attachment
+    Upload
+    Desktop
+    Server
+    Mobile
+    Tablet
+    User
+    Network
+    Credential
+  ].freeze
+
+  ICONS = [
+    '',
+    'fa-laptop',
+    '',
+    '',
+    'fa-folder',
+    'fa-paperclip',
+    'fa-cloud-arrow-up',
+    'fa-desktop',
+    'fa-server',
+    'fa-mobile-screen',
+    'fa-tablet-screen-button',
+    'fa-user',
+    'fa-sitemap',
+    'fa-key'
+  ].freeze
+
+  SYSTEM_TYPES = [
+    METHODOLOGY,
+    ISSUELIB
+  ]
+
+  included do
+    # -- Callbacks ------------------------------------------------------------
+    before_save do |record|
+      self[:type_id] ||= DEFAULT
+    end
+
+    # -- Scopes ---------------------------------------------------------------
+    scope :user_nodes, -> {
+      where.not('type_id IN (?)', SYSTEM_TYPES)
+    }
+  end
+
+  # -- Instance Methods -----------------------------------------------------
+  def icon
+    ICONS[self.type_id]
+  end
+
+  def user_node?
+    !SYSTEM_TYPES.include?(self.type_id)
+  end
+end

--- a/app/models/node/types.rb
+++ b/app/models/node/types.rb
@@ -20,6 +20,9 @@ module Node::Types
   LABELS = %w[
     Default
     Host
+    Methodology
+    IssueLib
+    ContentLib
     Folder
     Attachment
     Upload
@@ -35,6 +38,9 @@ module Node::Types
   ICONS = [
     '',
     'fa-laptop',
+    '',
+    '',
+    '',
     'fa-folder',
     'fa-paperclip',
     'fa-cloud-arrow-up',

--- a/app/models/node/types.rb
+++ b/app/models/node/types.rb
@@ -19,8 +19,6 @@ module Node::Types
   LABELS = %w[
     Default
     Host
-    Methodology
-    IssueLib
     Folder
     Attachment
     Upload
@@ -36,8 +34,6 @@ module Node::Types
   ICONS = [
     '',
     'fa-laptop',
-    '',
-    '',
     'fa-folder',
     'fa-paperclip',
     'fa-cloud-arrow-up',

--- a/app/views/layouts/hera/_node.html.erb
+++ b/app/views/layouts/hera/_node.html.erb
@@ -13,9 +13,7 @@
   <% end %>
 
   <%= link_to main_app.project_node_path(node.project, node), title: node.label, data: { behavior: 'sidebar-link sidebar-node-link' } do %>
-    <% if node.type_id == Node::Types::HOST %>
-      <i class="fa-solid fa-laptop"></i>
-    <% end %>
+    <%= colored_icon_for_model(node, nil) %>
     <%= node.label %>
   <% end %>
 

--- a/app/views/nodes/edit.html.erb
+++ b/app/views/nodes/edit.html.erb
@@ -15,7 +15,7 @@
 
         <%=
           f.input :type_id,
-            collection: Node::Types::LABELS.map.with_index { |type, index| [ type.titleize, index ] },
+            collection: node_types_collection,
             include_blank: false,
             label: 'Icon'
         %>

--- a/app/views/nodes/edit.html.erb
+++ b/app/views/nodes/edit.html.erb
@@ -13,7 +13,12 @@
       <%= simple_form_for [current_project, @node] do |f| %>
         <%= f.input :label, label: "New name" %>
 
-        <%= f.input :type_id, collection: [["No icon", Node::Types::DEFAULT], ["Host", Node::Types::HOST]], include_blank: false, label: 'Icon' %>
+        <%=
+          f.input :type_id,
+            collection: Node::Types::LABELS.map.with_index { |type, index| [ type.titleize, index ] },
+            include_blank: false,
+            label: 'Icon'
+        %>
 
         <%= f.input :raw_properties, as: :text, label: 'Properties', value: @node.raw_properties, input_html: { class: :json, rows: 20 } %>
 

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -77,7 +77,9 @@
           <%= select_tag(
             "nodes[type_id]",
             options_for_select(
-              [["No icon", Node::Types::DEFAULT], ["Host", Node::Types::HOST]]
+              node_types_collection.map do |label, value, html_options|
+                [label, value, html_options || {}]
+              end
             ),
             include_blank: false,
             class: 'form-select',

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -53,7 +53,7 @@
           <%= f.hidden_field :parent_id, id: "#{type}_parent_id" %>
           <%= f.input :label, input_html: { id: "#{type}_node_label", data: { behavior: 'node-label' } } %>
           <%= f.input :type_id,
-            collection: [["No icon", Node::Types::DEFAULT], ["Host", Node::Types::HOST]],
+            collection: Node::Types::LABELS.map.with_index { |type, index| [ type.titleize, index ] },
             include_blank: false,
             label: 'Icon',
             input_html: { class: 'form-select', id: "#{type}_node_icon", data: { behavior: 'node-icon' } }

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -76,11 +76,7 @@
           <%= label_tag "#{type}_nodes_icon", 'Icon', class: 'form-label' %>
           <%= select_tag(
             "nodes[type_id]",
-            options_for_select(
-              node_types_collection.map do |label, value, html_options|
-                [label, value, html_options || {}]
-              end
-            ),
+            options_for_select(node_types_collection),
             include_blank: false,
             class: 'form-select',
             id: "#{type}_nodes_icon",

--- a/app/views/nodes/modals/_add_node.html.erb
+++ b/app/views/nodes/modals/_add_node.html.erb
@@ -53,7 +53,7 @@
           <%= f.hidden_field :parent_id, id: "#{type}_parent_id" %>
           <%= f.input :label, input_html: { id: "#{type}_node_label", data: { behavior: 'node-label' } } %>
           <%= f.input :type_id,
-            collection: Node::Types::LABELS.map.with_index { |type, index| [ type.titleize, index ] },
+            collection: node_types_collection,
             include_blank: false,
             label: 'Icon',
             input_html: { class: 'form-select', id: "#{type}_node_icon", data: { behavior: 'node-icon' } }


### PR DESCRIPTION
### Summary

Widen the selection of icons available to use in your nodes to make it simpler to organise your project:

<img width="470" height="818" alt="Screenshot 2025-12-09 at 12 45 23" src="https://github.com/user-attachments/assets/86bd7808-088a-41c3-9ce0-6f1256172e64" />

To do so, we've extracted the Node::Types module into its own file to keep things contained, and reused the helper method that displayed Issue/Evidence icons.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
