### PR TITLE
Update CI triggers to run on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: CI
 
 on:
-  pull_request:
-    branches: ['*']
   push:
-    branches: [develop, main]
-  workflow_dispatch:
+    branches: ['**']
 
 jobs:
   audits:


### PR DESCRIPTION
### Summary

The PR changes the ci workflow triggers to only run on push. Some changes have happened on GH's side that allow us to remove our manual workflow trigger workaround for dependent branches. 

When commits are pushed to a branch before a PR is opened, workflows are now triggered so we no longer need to use the pull_request trigger to run the workflow on the commits pushed before the PR is opened. 

Similarly, we no longer need to use the pull_request trigger to run the workflow on merges to main or develop because merges now trigger a push (pushing the merge commit) and a duplicate trigger on pull_request (because the pull_request was closed). 

This leaves us with only needing a push trigger on all branches.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
