### PR TITLE
prevent multiple workflow runs on the same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     branches: ['**']
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   audits:
     name: Security Audits

--- a/Gemfile
+++ b/Gemfile
@@ -239,7 +239,6 @@ end
 # effective.
 
 # ----------------------------------------------------------------- Calculators
-
 gem 'dradis-calculator_cvss', '~> 4.19.0'
 gem 'dradis-calculator_dread', '~> 4.19.0'
 gem 'dradis-calculator_mitre', '~> 4.19.0'


### PR DESCRIPTION
### Summary

This PR prevents multiple concurrent CI workflow runs and only keeps the most current (latest) one. 

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
