### PR TITLE
catch case where PREV_SHA isn't found on first push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IS_MERGE: ${{ github.base_ref == '' }}
-      PREV_SHA: ${{ github.event.before }}
+      # SHA is set to all 0s on the first push to a new branch. We set it to
+      # an empty string to ensure our fallback chain works as expected.
+      PREV_SHA: ${{ github.event.before != '0000000000000000000000000000000000000000' && github.event.before || '' }}
       TARGET_BRANCH: ${{ github.base_ref }}
       FALLBACK_BRANCH: 'origin/develop'
     steps:


### PR DESCRIPTION
### Summary

Since we are no longer using the pull_request trigger, the push trigger sets the prev_sha to all 0s rather than null like pull_request used to. This catches that case and sets the prev_sha to empty so our fallback chain continues to work as expected.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
