### PR TITLE
Catch previous sha == zeroes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IS_MERGE: ${{ github.base_ref == '' }}
-      PREV_SHA: ${{ github.event.before }}
+      PREV_SHA: ${{ github.event.before != '0000000000000000000000000000000000000000' && github.event.before || null }}
       TARGET_BRANCH: ${{ github.base_ref }}
       FALLBACK_BRANCH: 'origin/develop'
     steps:


### PR DESCRIPTION
### Summary

There's been a change to github workflows and now it sets the previous commit as `null` (or `0000000000000000000000000000000000000000`) if it is the first commit of the branch.

**Proposed solution**
Catch the zeroes when returned as the previous sha. If zeroes are returned, treat is as nil.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Commit message has a detailed description of what changed and why.
