### PR TITLE
Subscribe to issue events via namespace and create activities using published events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 [v#.#.#] ([month] [YYYY])
-  - Activities: Subscribe to events via namespace and create activities using published events
+  - Activities: Subscribe to issue CRUD events via namespace and create activities using published events
   - Docker:
     - Update default attachments & templates locations to storage/
     - Include assets for all integrations regardless of enabled/disabled status

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [v#.#.#] ([month] [YYYY])
+  - Activities: Subscribe to events via namespace and create activities using published events
   - Docker:
     - Update default attachments & templates locations to storage/
     - Include assets for all integrations regardless of enabled/disabled status

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -117,7 +117,7 @@ class Issue < Note
     end
   end
 
-   # Returns a hash that will be used as part of event notification workflows.
+  # Returns a hash that will be used as part of event notification workflows.
   def local_event_payload
     {
       author: author,

--- a/config/initializers/activity_tracking.rb
+++ b/config/initializers/activity_tracking.rb
@@ -1,0 +1,5 @@
+Rails.application.reloader.to_prepare do
+  ::ActivityService.configure do |activity_service|
+    activity_service.subscribe_namespace 'issue'
+  end
+end


### PR DESCRIPTION
### Summary

Use EventPublisher to publish issue events that ActivityService is subscribed to, removing the need for `ActivityTracking`

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
