### PR TITLE
Resolve db seeds conflict

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,6 @@ unless defined?(Dradis::Pro)
   end
 end
 
-# Seed Pro-specific engines if available
 if defined?(Dradis::Pro)
   # Load engine seeds
   Dradis::Pro::BI::Engine.load_seed

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,13 @@
-# Create a few default tags.
-Tag::DEFAULT_TAGS.each do |name|
-  Tag.create!(name: name)
+unless defined?(Dradis::Pro)
+  # Create a few default tags.
+  Tag::DEFAULT_TAGS.each do |name|
+    Tag.find_or_create_by(name: name)
+  end
+end
+
+# Seed Pro-specific engines if available
+if defined?(Dradis::Pro)
+  # Load engine seeds
+  Dradis::Pro::BI::Engine.load_seed
+  Dradis::Pro::Rules::Engine.load_seed
 end


### PR DESCRIPTION
### Summary

This PR resolves a sync conflict between CE and Pro by using find_or_create_by for default tags to prevent crashes and adding a conditional block to load engine-specific seeds for Pro.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~~- [ ] Added a CHANGELOG entry~~
- [x] Commit message has a detailed description of what changed and why.
