### PR TITLE
add clarity for users when attempting to import unpublished results

### DIFF
--- a/app/views/issues/import.html.erb
+++ b/app/views/issues/import.html.erb
@@ -101,7 +101,7 @@
                         </div>
                       </div>
                     <% else %>
-                      <div class="btn-group" title="Result must be published in the library before it can be imported into the project." data-bs-toggle="tooltip">
+                      <div class="btn-group" title="This result is still in a <%= issue.state.humanize.titleize %> state. Publish it in the library before importing to the project." data-bs-toggle="tooltip">
                         <a href="javascript:void(0)" class="btn btn-primary disabled" disabled="disabled">
                           <i class="fa-solid fa-plus"></i> Add Issue (Published)
                         </a>

--- a/app/views/issues/import.html.erb
+++ b/app/views/issues/import.html.erb
@@ -101,9 +101,17 @@
                         </div>
                       </div>
                     <% else %>
-                    <div class="hover-only text-center">
-                      <span class="badge badge-outline-info">Result not Published</span>
-                    </div>
+                      <div class="btn-group" title="Result must be published in the library before it can be imported into the project." data-bs-toggle="tooltip">
+                        <a href="javascript:void(0)" class="btn btn-primary disabled" disabled="disabled">
+                          <i class="fa-solid fa-plus"></i> Add Issue (Published)
+                        </a>
+                        <a
+                          href="javascript:void(0)"
+                          class="btn btn-primary dropdown-toggle dropdown-toggle-split disabled"
+                          disabled="disabled"
+                          role="presentation"
+                        ></a>
+                      </div>
                     <% end %>
                   </td>
                 </tr>


### PR DESCRIPTION
### Summary

This PR improves the UX for users attempting to import unpublished results:

Before:
<img width="720" height="198" alt="image" src="https://github.com/user-attachments/assets/e0b40e31-14a8-4f0e-8379-827e283fba85" />

After:
<img width="261" height="194" alt="Screenshot 2025-12-19 at 10 27 38 AM" src="https://github.com/user-attachments/assets/5d150958-a339-4d10-bb0e-129699bfb73d" />

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
