### PR TITLE
Ignore CVE-2025-58767: DoS vulnerability in REXML until Ruby upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Security audit dependencies
         run: bundle exec bundler-audit --update --ignore CVE-2024-21510 CVE-2025-61921
       - name: Security audit ruby
-        run: bundle exec ruby-audit update && bundle exec ruby-audit check --ignore CVE-2025-61594
+        # These ignores can be removed once the Ruby version is upgraded to >= 3.4.8
+        run: bundle exec ruby-audit update && bundle exec ruby-audit check --ignore CVE-2025-61594 CVE-2025-58767
       - name: Security audit application code
         run: bundle exec brakeman -q -w2
   rubocop:


### PR DESCRIPTION
### Summary

This PR ignores the [CVE-2025-58767: DoS vulnerability in REXML](https://www.ruby-lang.org/en/news/2025/09/18/dos-rexml-cve-2025-58767/) in CI. Since we are already locked in the latest safe `rexml` version, it is safe to ignore for now until we upgrade Ruby to >= 3.4.8.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~~- [ ] Added a CHANGELOG entry~~
- [x] Commit message has a detailed description of what changed and why.
