### PR TITLE
add caching to navbar to improve layout rendering

### DIFF
--- a/app/views/layouts/hera/navbar/_main_nav.html.erb
+++ b/app/views/layouts/hera/navbar/_main_nav.html.erb
@@ -1,4 +1,4 @@
-<% cache(['navbar', Dradis::Plugins.with_feature(:addon), current_user.notifications.unread.count]) do %>
+<% cache(['navbar', Dradis::Plugins.with_feature(:addon), current_user.notifications.unread.size]) do %>
   <nav class="navbar navbar-expand-lg main-nav">
     <div class="container-fluid">
       <%= navbar_brand %>

--- a/app/views/layouts/hera/navbar/_main_nav.html.erb
+++ b/app/views/layouts/hera/navbar/_main_nav.html.erb
@@ -1,4 +1,4 @@
-<% cache(['navbar', Dradis::Plugins.with_feature(:addon), current_user.notifications.unread.size]) do %>
+<% cache('navbar') do %>
   <nav class="navbar navbar-expand-lg main-nav">
     <div class="container-fluid">
       <%= navbar_brand %>

--- a/app/views/layouts/hera/navbar/_main_nav.html.erb
+++ b/app/views/layouts/hera/navbar/_main_nav.html.erb
@@ -1,17 +1,19 @@
+<% cache(['navbar', Dradis::Plugins.with_feature(:addon), current_user.notifications.unread.count]) do %>
   <nav class="navbar navbar-expand-lg main-nav">
-  <div class="container-fluid">
-    <%= navbar_brand %>
+    <div class="container-fluid">
+      <%= navbar_brand %>
 
-    <button class="navbar-toggler" type="button" data-behavior="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".dual-nav" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-      <i class="fa-solid fa-bars"></i>
-    </button>
+      <button class="navbar-toggler" type="button" data-behavior="navbar-toggler" data-bs-toggle="collapse" data-bs-target=".dual-nav" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <i class="fa-solid fa-bars"></i>
+      </button>
 
-    <div class="collapse navbar-collapse justify-content-end dual-nav" data-behavior="navbar-collapse">
-      <ul class="navbar-nav navbar-nav-scroll me-auto pb-0">
-        <%= render "layouts/hera/navbar/main_nav/#{Dradis.edition}" %>
-      </ul>
+      <div class="collapse navbar-collapse justify-content-end dual-nav" data-behavior="navbar-collapse">
+        <ul class="navbar-nav navbar-nav-scroll me-auto pb-0">
+          <%= render "layouts/hera/navbar/main_nav/#{Dradis.edition}" %>
+        </ul>
 
-      <%= render 'layouts/hera/navbar/main_nav/utility_nav' %>
+        <%= render 'layouts/hera/navbar/main_nav/utility_nav' %>
+      </div>
     </div>
-  </div>
-</nav>
+  </nav>
+<% end %>

--- a/app/views/layouts/hera/navbar/main_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/_ce.html.erb
@@ -6,4 +6,7 @@
     <span>Projects</span>
   <% end %>
 </li>
-<%= render 'layouts/hera/navbar/main_nav/tools_menu' %>
+
+<% cache(['navbar-tools', Dradis::Plugins.with_feature(:addon)]) do %>
+  <%= render 'layouts/hera/navbar/main_nav/tools_menu' %>
+<% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -7,23 +7,26 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<li class="nav-item notifications dropdown">
-  <%= link_to main_app.project_notifications_path(current_project), 
-    class: 'nav-link dropdown-toggle no-caret', 
-    data: { 
-      id: 'notifications',
-      bs_toggle: 'dropdown',
-      behavior: 'notifications-dropdown close-collapse',
-      project_id: current_project.id 
-    }, 
-    role: 'button', 
-    'aria-expanded': 'false' do %>
-    <i class="notifications-bell fa-solid fa-bell d-none d-lg-inline" title="Notifications"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
-    <span class="d-inline d-lg-none">Notifications</span>
-  <% end %>
-  <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>" aria-labelledby="notifications">
-  </div>
-</li>
+<% cache(['navbar-notifications', current_user.notifications.unread.count]) do %>
+  <li class="nav-item notifications dropdown">
+    <%= link_to main_app.project_notifications_path(current_project),
+      class: 'nav-link dropdown-toggle no-caret',
+      data: {
+        id: 'notifications',
+        bs_toggle: 'dropdown',
+        behavior: 'notifications-dropdown close-collapse',
+        project_id: current_project.id
+      },
+      role: 'button',
+      'aria-expanded': 'false' do %>
+      <i class="notifications-bell fa-solid fa-bell d-none d-lg-inline" title="Notifications"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
+      <span class="d-inline d-lg-none">Notifications</span>
+    <% end %>
+    <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>" aria-labelledby="notifications">
+    </div>
+  </li>
+<% end %>
+
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>
 
 <li class="nav-item dropdown me-0 mb-3 mb-lg-0">

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -7,7 +7,7 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<% cache(['navbar-notifications', current_user.notifications.unread.size]) do %>
+<% cache(['navbar-notifications', current_user.notifications.unread]) do %>
   <li class="nav-item notifications dropdown">
     <%= link_to main_app.project_notifications_path(current_project),
       class: 'nav-link dropdown-toggle no-caret',

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -7,7 +7,7 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<% cache(['navbar-notifications', current_user.notifications.unread.count]) do %>
+<% cache(['navbar-notifications', current_user.notifications.unread.size]) do %>
   <li class="nav-item notifications dropdown">
     <%= link_to main_app.project_notifications_path(current_project),
       class: 'nav-link dropdown-toggle no-caret',


### PR DESCRIPTION
### Summary

The navbar contains mostly static content but is rerendered on each page load from a number of partials. This PR implements caching to avoid rerendering static content from multiple partials.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
