### PR TITLE
Sandbox/cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 WORKDIR /dradis
 
 # Install dependencies for Ruby build and gems
+#   if using image_processing for ActiveStorage, add libvips
 RUN apt-get update -qq && \
-apt-get install --no-install-recommends -y curl git libjemalloc2 libvips && \
-apt-get install --no-install-recommends -y redis-server sqlite3 && \
+apt-get install --no-install-recommends -y libjemalloc2 redis-server sqlite3 && \
 rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'stimulus-rails'
 gem 'jbuilder', '~> 2.13'
 
 # Use Active Storage variant
+# add libvips to Dockerfile if enabling
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,3 +58,5 @@ module Dradis
     config.exceptions_app = self.routes
   end
 end
+
+require 'dradis/ce'

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,5 +58,3 @@ module Dradis
     config.exceptions_app = self.routes
   end
 end
-
-require 'dradis/ce'

--- a/lib/dradis.rb
+++ b/lib/dradis.rb
@@ -18,4 +18,3 @@ module Dradis
     end
   end
 end
-

--- a/lib/dradis.rb
+++ b/lib/dradis.rb
@@ -2,15 +2,21 @@ module Dradis
   class << self
     SANDBOX_FILE_PATH = 'tmp/sandbox.txt'
 
-    def sandbox?
-      return @sandbox if defined?(@sandbox)
-      @sandbox = !!(((ENV['SANDBOX'] || File.exist?(File.expand_path(SANDBOX_FILE_PATH, __dir__))) && ENV['SANDBOX'] != 'false'))
-    end
-
     def configure_bundle
       if sandbox?
         ENV['BUNDLE_GEMFILE'] = 'Gemfile.sandbox'
       end
     end
+
+    def edition
+      :ce
+    end
+
+    def sandbox?
+      return @sandbox if defined?(@sandbox)
+      @sandbox = !!(((ENV['SANDBOX'] || File.exist?(File.expand_path(SANDBOX_FILE_PATH, __dir__))) && ENV['SANDBOX'] != 'false'))
+    end
   end
 end
+
+require 'dradis/ce'

--- a/lib/dradis.rb
+++ b/lib/dradis.rb
@@ -19,4 +19,3 @@ module Dradis
   end
 end
 
-require 'dradis/ce'

--- a/lib/dradis/ce.rb
+++ b/lib/dradis/ce.rb
@@ -6,10 +6,6 @@ module Dradis
       VERSION::STRING
     end
   end
-
-  def self.edition
-    :ce
-  end
 end
 
 require 'html/ignore_liquid_in_textile_block_codes'


### PR DESCRIPTION
### Summary

Through the work in https://github.com/dradis/dradis-ce/pull/1498 a couple of changes came up:

1. lib/dradis contains the ::Dradis module definition, which in the past also existed in lib/dradis/ce we can consolidate that.
2. It seems the Docker image contained a few extra packages we can remove to slim it down

### Check List

- ~~[ ] Added a CHANGELOG entry~~
- [x] Commit message has a detailed description of what changed and why.
