### PR TITLE
Skip rubocop if no `.rb` files were changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ apt-get install --no-install-recommends -y curl git libjemalloc2 libvips && \
 apt-get install --no-install-recommends -y redis-server sqlite3 && \
 rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Set production environment
-ARG BUNDLE_GEMFILE="Gemfile.lock"
+# This can be overriden to build the Sandbox image
+ARG BUNDLE_GEMFILE="Gemfile"
 
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \

--- a/bin/rubocop-ci
+++ b/bin/rubocop-ci
@@ -9,7 +9,15 @@ else
   target="origin/$1"
 fi
 
-result_info="bundle exec rubocop --force-exclusion --format simple $(git diff-tree -r --no-commit-id --name-only $target..HEAD)"
+changed_ruby_files=$(git diff-tree -r --no-commit-id --name-only $target..HEAD | grep '\.rb$' || :)
+
+if [ -z "$changed_ruby_files" ]
+then
+  echo "✅ No Ruby files changed compared to $target. Skipping rubocop."
+  exit 0
+fi
+
+result_info="bundle exec rubocop --force-exclusion --format simple $changed_ruby_files"
 files_inspected=`$result_info | grep "files inspected\|file inspected" | cut -d " " -f1`
 warning_count=`$result_info | grep "offenses detected\|offense detected" | cut -d " " -f4`
 


### PR DESCRIPTION
### Summary

If no ruby files are changed, rubocop checks all files. If no .rb files were changed we want to skip instead


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
