### PR TITLE
move timer to accomodate populated pro navbar

### DIFF
--- a/engines/dradis-sandbox/app/assets/stylesheets/dradis/sandbox/timer.scss
+++ b/engines/dradis-sandbox/app/assets/stylesheets/dradis/sandbox/timer.scss
@@ -4,8 +4,16 @@
   align-items: center;
   gap: 0.25rem;
   position: fixed;
+  right: 12rem;
   top: 0.6rem;
-  left: 50%;
-  transform: translateX(-50%);
   z-index: 1050;
+
+  @media (max-width: 1024px) {
+    right: 10.75rem;
+  }
+
+  @media (max-width: 991px) {
+    right: 50%;
+    transform: translateX(50%);
+  }
 }


### PR DESCRIPTION
### Summary

This PR moves the sandbox timer closer to the utility menu for desktop sized viewports

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
