### PR TITLE
fix nav render outside projects

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -16,6 +16,7 @@ class AuthenticatedController < SetupRequiredController
   before_action :set_paper_trail_whodunnit
   # before_action :render_onboarding_tour
 
+  helper :hera
   layout 'hera'
 
   # This is a central location where we can manage authorization errors (e.g.

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,4 @@
 class StaticPagesController < AuthenticatedController
-  include ProjectScoped
-
   before_action :set_entries, only: [:issuelib_index, :issuelib_import]
   before_action :set_tickets, only: [:remediationtracker_index]
 

--- a/app/helpers/hera_helper.rb
+++ b/app/helpers/hera_helper.rb
@@ -61,7 +61,8 @@ module HeraHelper
 
   def navbar_brand
     if !defined?(Dradis::Pro)
-      link_to main_app.project_path(current_project), class: 'navbar-brand' do
+      project = defined?(current_project) ? current_project : Project.new
+      link_to main_app.project_path(project), class: 'navbar-brand' do
         image_tag 'logo_small.png', alt: 'Dradis CE logo', class: 'p-lg-0'
       end
     else

--- a/app/views/layouts/hera.html.erb
+++ b/app/views/layouts/hera.html.erb
@@ -48,12 +48,8 @@
     ) do %>
 
     <header class="sticky-top">
-      <% if controller_path == 'styles' %>
-        <%= render partial: 'styles/header' %>
-      <% else %>
-        <%= render 'layouts/hera/navbar/main_nav' %>
-        <%= yield(:sub_nav) if content_for?(:sub_nav) %>
-      <% end %>
+      <%= render 'layouts/hera/navbar/main_nav' %>
+      <%= yield(:sub_nav) if content_for?(:sub_nav) %>
     </header>
 
     <div class="content-grid">

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -1,22 +1,24 @@
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/theme_menu' %>
 
-<% cache(['navbar-trash', current_project]) do %>
-  <li class="nav-item">
-    <%= link_to main_app.project_trash_path(current_project), class: 'nav-link' do %>
-      <i class="fa-solid fa-trash-can fa-fw d-none d-lg-inline" title="Trash"></i>
-      <span class="d-inline d-lg-none">Trash</span>
-    <% end %>
-  </li>
-<% end %>
-
-<% cache(['navbar-config', current_project]) do %>
-  <%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' do %>
-    <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
+<% if defined?(current_project) %>
+  <% cache(['navbar-trash', current_project]) do %>
+    <li class="nav-item">
+      <%= link_to main_app.project_trash_path(current_project), class: 'nav-link' do %>
+        <i class="fa-solid fa-trash-can fa-fw d-none d-lg-inline" title="Trash"></i>
+        <span class="d-inline d-lg-none">Trash</span>
+      <% end %>
+    </li>
   <% end %>
-<% end %>
 
-<% cache(['navbar-notifications', current_project]) do %>
-  <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications' %>
+  <% cache(['navbar-config', current_project]) do %>
+    <%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' do %>
+      <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
+    <% end %>
+  <% end %>
+
+  <% cache(['navbar-notifications', current_project]) do %>
+    <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications' %>
+  <% end %>
 <% end %>
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>

--- a/app/views/styles/_header.html.erb
+++ b/app/views/styles/_header.html.erb
@@ -1,7 +1,0 @@
-<div class="navbar-placeholder">
-  <%= image_tag 'logo_small.png', class: 'img-fluid logo' %>
-  
-  <a href="/">
-    <i class="fa-solid fa-arrow-left"></i> Back to the ship
-  </a>
-</div>


### PR DESCRIPTION
### Summary

The navbar called \`current_project\` in several places (brand link, trash, config, notifications). \`current_project\` was only exposed as a helper via \`ProjectScoped\`, so non-project views like \`StylesController\` and \`StaticPagesController\` had to \`include ProjectScoped\` just to keep the navbar from raising a \`NameError\`, even though they have no actual need for project-scoped behaviour.

The fix removes the \`ProjectScoped\` dependency from those controllers and guards the project-specific utility nav items with \`defined?(current_project)\` — the same pattern already used in the \`Mentioned\` and \`MultipleDestroy\` concerns. Adding \`helper :hera\` to \`AuthenticatedController\` (already present in Pro) ensures \`HeraHelper\` is available to all Hera layout views without needing \`ProjectScoped\`.

For \`navbar_brand\`, where CE always needs a link target, the \`Project.new\` fallback is applied locally within the method. \`Project.new\` always has \`id: 1\` by design — it is a plain Ruby value object, not an ActiveRecord model — so the fallback generates a valid URL on non-project pages.

This mirrors how Pro guards project-specific nav items with \`content_for?(:project_utility_nav)\`, keeping the sync clean with no \`defined?(Dradis::Pro)\` checks needed.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.