### PR TITLE
Add config/shared back to .gitignore and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,7 @@
 /attachments/
 /avatars/
 /config/credentials/*
+/config/shared/*
 /templates/*
 
 # Ignore development and test files

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 # Ignore app-specific folders
 /backup/
 /config/credentials/
+/config/shared/
 /sample_files/
 /Gemfile.plugins
 


### PR DESCRIPTION
### Summary

`config/shared` was removed from `.gitignore` and `.dockerignore` when we moved their paths to `config/credentials`. This can cause the existing credentials stored in the old path to be included when committing code. This PR adds them back as a safety measure


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
