### PR TITLE
Simplify InlineThreadSelector to anchor against rendered content

### DIFF
--- a/app/assets/javascripts/hera/modules/inline_thread_highlighter.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_highlighter.js
@@ -116,29 +116,40 @@ class InlineThreadHighlighter {
   // Returns an array of { node, startOffset, endOffset } segments —
   // one per text node that overlaps the match. Each segment stays
   // within a single text node so surroundContents works safely.
+  //
+  // Uses innerText as the combined string because anchor.exact comes
+  // from getSelection().toString() which mirrors innerText behavior
+  // (inserting \n at block boundaries and <br> elements).
   findTextInNodes(textNodes, searchText) {
-    let combined = '';
-    const nodeMap = [];
-
-    for (let i = 0; i < textNodes.length; i++) {
-      const nodeText = textNodes[i].textContent;
-      const startIndex = combined.length;
-      combined += nodeText;
-      nodeMap.push({
-        node: textNodes[i],
-        startIndex: startIndex,
-        endIndex: combined.length
-      });
-    }
-
+    const combined = this.contentEl.innerText;
     const matchIndex = combined.indexOf(searchText);
     if (matchIndex === -1) return [];
 
     const matchEnd = matchIndex + searchText.length;
+
+    // Map each text node to its position within innerText
+    const nodeMap = [];
+    let searchFrom = 0;
+
+    for (var i = 0; i < textNodes.length; i++) {
+      var content = textNodes[i].textContent;
+      if (!content.trim()) continue;
+
+      var pos = combined.indexOf(content, searchFrom);
+      if (pos === -1) continue;
+
+      nodeMap.push({
+        node: textNodes[i],
+        startIndex: pos,
+        endIndex: pos + content.length
+      });
+      searchFrom = pos + content.length;
+    }
+
     const segments = [];
 
-    for (let j = 0; j < nodeMap.length; j++) {
-      const entry = nodeMap[j];
+    for (var j = 0; j < nodeMap.length; j++) {
+      var entry = nodeMap[j];
 
       // Skip nodes entirely before the match
       if (entry.endIndex <= matchIndex) continue;
@@ -146,8 +157,8 @@ class InlineThreadHighlighter {
       // Stop after nodes entirely after the match
       if (entry.startIndex >= matchEnd) break;
 
-      const segStart = Math.max(matchIndex, entry.startIndex) - entry.startIndex;
-      const segEnd = Math.min(matchEnd, entry.endIndex) - entry.startIndex;
+      var segStart = Math.max(matchIndex, entry.startIndex) - entry.startIndex;
+      var segEnd = Math.min(matchEnd, entry.endIndex) - entry.startIndex;
 
       segments.push({
         node: entry.node,

--- a/app/assets/javascripts/hera/modules/inline_thread_selector.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_selector.js
@@ -19,7 +19,7 @@ class InlineThreadSelector {
     this.$container = $(container);
     this.$content = this.$container.find('[data-behavior~=content-textile]');
     this.coordinator = coordinator;
-    this.renderedText = this.$content[0].textContent;
+    this.renderedText = this.$content[0].innerText;
     this.pendingSelection = null;
 
     // Prevent double-binding
@@ -45,7 +45,7 @@ class InlineThreadSelector {
     // Liquid async rendering replaces innerHTML of content-textile,
     // destroying our appended button. Re-read text and re-append.
     this.$content.on('dradis:liquid-rendered', () => {
-      this.renderedText = this.$content[0].textContent;
+      this.renderedText = this.$content[0].innerText;
       this.appendButton();
     });
   }
@@ -143,42 +143,19 @@ class InlineThreadSelector {
   }
 
   findFieldName(position) {
+    const text = this.renderedText;
     const headings = this.$content[0].querySelectorAll('h5');
     let currentField = null;
 
     for (let i = 0; i < headings.length; i++) {
-      const heading = headings[i];
-      const range = document.createRange();
-      range.selectNodeContents(heading);
+      const name = headings[i].textContent.trim();
+      const headingPos = text.indexOf(name);
+      if (headingPos === -1 || headingPos > position) break;
 
-      // Compare heading's position in the textContent to the selection position.
-      // Walk text nodes up to this heading to find its offset.
-      const headingOffset = this.textOffsetOf(heading);
-      if (headingOffset > position) break;
-
-      currentField = heading.textContent.trim();
+      currentField = name;
     }
 
     return currentField;
-  }
-
-  textOffsetOf(targetNode) {
-    const walker = document.createTreeWalker(
-      this.$content[0],
-      NodeFilter.SHOW_TEXT,
-      null,
-      false
-    );
-
-    let offset = 0;
-    let node;
-
-    while ((node = walker.nextNode())) {
-      if (targetNode.contains(node)) return offset;
-      offset += node.textContent.length;
-    }
-
-    return offset;
   }
 
   isValidSelection(selectionObj) {

--- a/app/assets/javascripts/hera/modules/inline_thread_selector.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_selector.js
@@ -19,10 +19,8 @@ class InlineThreadSelector {
     this.$container = $(container);
     this.$content = this.$container.find('[data-behavior~=content-textile]');
     this.coordinator = coordinator;
-    this.rawText = this.$content.data('content') || '';
+    this.renderedText = this.$content[0].textContent;
     this.pendingSelection = null;
-
-    this._buildFieldMap();
 
     // Prevent double-binding
     if (this.$container.data('inlineThreadSelector')) {
@@ -45,8 +43,9 @@ class InlineThreadSelector {
     this.bindEvents();
 
     // Liquid async rendering replaces innerHTML of content-textile,
-    // destroying our appended button. Re-append after render completes.
+    // destroying our appended button. Re-read text and re-append.
     this.$content.on('dradis:liquid-rendered', () => {
+      this.renderedText = this.$content[0].textContent;
       this.appendButton();
     });
   }
@@ -111,89 +110,24 @@ class InlineThreadSelector {
     });
   }
 
-  // Build a version of the raw text with #[Field]# markers replaced by just
-  // the field name, plus a position map from stripped→raw indices. This lets
-  // us find user selections (which see rendered text without markers) and
-  // map back to raw text positions for anchoring.
-  _buildFieldMap() {
-    const raw = this.rawText.replace(/\r\n/g, '\n');
-    this._normalizedRaw = raw;
-    this._strippedText = '';
-    this._strippedToRaw = [];
-
-    const fieldRegex = /#\[([^\]]*?)\]#/g;
-    let lastEnd = 0;
-    let match;
-
-    while ((match = fieldRegex.exec(raw)) !== null) {
-      // Copy characters before the marker as-is
-      for (let i = lastEnd; i < match.index; i++) {
-        this._strippedToRaw.push(i);
-        this._strippedText += raw.charAt(i);
-      }
-      // Copy just the field name (skip #[ and ]#)
-      const nameStart = match.index + 2;
-      const name = match[1];
-      for (let j = 0; j < name.length; j++) {
-        this._strippedToRaw.push(nameStart + j);
-        this._strippedText += name.charAt(j);
-      }
-      lastEnd = match.index + match[0].length;
-    }
-
-    // Copy remaining text after last marker
-    for (let k = lastEnd; k < raw.length; k++) {
-      this._strippedToRaw.push(k);
-      this._strippedText += raw.charAt(k);
-    }
-  }
-
   buildAnchor(selectedText) {
+    const text = this.renderedText;
     let selection = selectedText.replace(/\r\n/g, '\n');
-    const raw = this._normalizedRaw;
 
-    // Fast path: exact match in raw text (selection within a single field value)
-    let rawIndex = raw.indexOf(selection);
-    if (rawIndex === -1) {
-      rawIndex = raw.indexOf(selection.trim());
-      if (rawIndex !== -1) { selection = selection.trim(); }
+    let index = text.indexOf(selection);
+    if (index === -1) {
+      selection = selection.trim();
+      index = text.indexOf(selection);
     }
 
-    if (rawIndex !== -1) {
-      return this._buildResult(rawIndex, rawIndex + selection.length, selectedText);
-    }
+    if (index === -1) return null;
 
-    // Slow path: search in stripped text (handles selections spanning #[Field]#)
-    let strippedIndex = this._strippedText.indexOf(selection);
-    if (strippedIndex === -1) {
-      const trimmed = selection.trim();
-      strippedIndex = this._strippedText.indexOf(trimmed);
-      if (strippedIndex !== -1) { selection = trimmed; }
-    }
-
-    if (strippedIndex === -1) {
-      return null;
-    }
-
-    // Map stripped positions back to raw positions
-    const rawStart = this._strippedToRaw[strippedIndex];
-    const endMapIndex = strippedIndex + selection.length - 1;
-    if (endMapIndex >= this._strippedToRaw.length) {
-      return null;
-    }
-    const rawEnd = this._strippedToRaw[endMapIndex] + 1;
-
-    return this._buildResult(rawStart, rawEnd, selectedText);
-  }
-
-  _buildResult(rawStart, rawEnd, selectedText) {
-    const raw = this._normalizedRaw;
-
-    const prefixStart = Math.max(0, rawStart - 30);
-    const prefix = raw.substring(prefixStart, rawStart);
-    const suffixEnd = Math.min(raw.length, rawEnd + 30);
-    const suffix = raw.substring(rawEnd, suffixEnd);
-    const fieldName = this.findFieldName(rawStart);
+    const prefixStart = Math.max(0, index - 30);
+    const prefix = text.substring(prefixStart, index);
+    const endPos = index + selection.length;
+    const suffixEnd = Math.min(text.length, endPos + 30);
+    const suffix = text.substring(endPos, suffixEnd);
+    const fieldName = this.findFieldName(index);
 
     return {
       type: 'TextQuoteSelector',
@@ -201,27 +135,50 @@ class InlineThreadSelector {
       prefix: prefix,
       suffix: suffix,
       position: {
-        start: rawStart,
-        end: rawEnd
+        start: index,
+        end: endPos
       },
       field_name: fieldName
     };
   }
 
   findFieldName(position) {
-    const fieldRegex = /#\[(.+?)\]#/g;
-    let match;
+    const headings = this.$content[0].querySelectorAll('h5');
     let currentField = null;
-    const raw = this._normalizedRaw;
 
-    while ((match = fieldRegex.exec(raw)) !== null) {
-      if (match.index > position) {
-        break;
-      }
-      currentField = match[1];
+    for (let i = 0; i < headings.length; i++) {
+      const heading = headings[i];
+      const range = document.createRange();
+      range.selectNodeContents(heading);
+
+      // Compare heading's position in the textContent to the selection position.
+      // Walk text nodes up to this heading to find its offset.
+      const headingOffset = this.textOffsetOf(heading);
+      if (headingOffset > position) break;
+
+      currentField = heading.textContent.trim();
     }
 
     return currentField;
+  }
+
+  textOffsetOf(targetNode) {
+    const walker = document.createTreeWalker(
+      this.$content[0],
+      NodeFilter.SHOW_TEXT,
+      null,
+      false
+    );
+
+    let offset = 0;
+    let node;
+
+    while ((node = walker.nextNode())) {
+      if (targetNode.contains(node)) return offset;
+      offset += node.textContent.length;
+    }
+
+    return offset;
   }
 
   isValidSelection(selectionObj) {

--- a/app/assets/javascripts/hera/modules/inline_thread_selector.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_selector.js
@@ -112,19 +112,18 @@ class InlineThreadSelector {
 
   buildAnchor(selectedText) {
     const text = this.renderedText;
-    let selection = selectedText.replace(/\r\n/g, '\n');
 
-    let index = text.indexOf(selection);
+    let index = text.indexOf(selectedText);
     if (index === -1) {
-      selection = selection.trim();
-      index = text.indexOf(selection);
+      selectedText = selectedText.trim();
+      index = text.indexOf(selectedText);
     }
 
     if (index === -1) return null;
 
     const prefixStart = Math.max(0, index - 30);
     const prefix = text.substring(prefixStart, index);
-    const endPos = index + selection.length;
+    const endPos = index + selectedText.length;
     const suffixEnd = Math.min(text.length, endPos + 30);
     const suffix = text.substring(endPos, suffixEnd);
     const fieldName = this.findFieldName(index);

--- a/app/assets/stylesheets/hera/modules/_inline_threads.scss
+++ b/app/assets/stylesheets/hera/modules/_inline_threads.scss
@@ -69,4 +69,5 @@
 
 .thread-quoted-text {
   font-size: 0.9rem;
+  white-space: pre-line;
 }

--- a/app/views/inline_threads/_inline_thread.html.erb
+++ b/app/views/inline_threads/_inline_thread.html.erb
@@ -1,6 +1,6 @@
 <div class="inline-thread" id="inline_thread_<%= inline_thread.id %>" data-behavior="inline-thread" data-thread-id="<%= inline_thread.id %>">
   <%= render 'inline_threads/header', inline_thread: inline_thread %>
-  <blockquote class="thread-quoted-text border-start border-3 border-primary ps-3 text-muted fst-italic mt-4">
+  <blockquote class="thread-quoted-text border-start border-3 border-primary ps-3 text-muted fst-italic">
     <%= inline_thread.quoted_text %>
   </blockquote>
 

--- a/spec/features/inline_thread_selector_spec.rb
+++ b/spec/features/inline_thread_selector_spec.rb
@@ -32,6 +32,10 @@ describe 'InlineThreadSelector#buildAnchor', js: true do
     ].join("\n")
   end
 
+  # Build an anchor by simulating what getSelection().toString() returns.
+  # We read innerText from the DOM to discover the actual separator between
+  # block elements (e.g. \n\n between h5 and p), then extract the substring
+  # that corresponds to the described selection.
   def build_anchor(selected_text)
     page.evaluate_script(<<~JS)
       (function() {
@@ -42,8 +46,31 @@ describe 'InlineThreadSelector#buildAnchor', js: true do
     JS
   end
 
+  def rendered_text
+    @rendered_text ||= page.evaluate_script(<<~JS)
+      (function() {
+        var container = document.querySelector('[data-behavior~=inline-threads-container]');
+        var selector = $(container).data('inlineThreadSelector');
+        return selector.renderedText;
+      })()
+    JS
+  end
+
+  # Extract a substring from the rendered text between two landmarks.
+  # This ensures test selections match innerText exactly.
+  def selection_between(from_text, to_text)
+    text = rendered_text
+    start_idx = text.index(from_text)
+    end_idx = text.index(to_text)
+    text[start_idx..(end_idx + to_text.length - 1)]
+  end
+
   it 'handles selection of multi-line content (no fields)' do
-    anchor = build_anchor("The application is vulnerable to SQL injection.\nAn attacker can extract data from the database.")
+    selected = selection_between(
+      'The application is vulnerable',
+      'An attacker can extract data from the database.'
+    )
+    anchor = build_anchor(selected)
 
     expect(anchor).to be_present
     expect(anchor['exact']).to include('The application is vulnerable')
@@ -57,15 +84,15 @@ describe 'InlineThreadSelector#buildAnchor', js: true do
 
     expect(anchor).to be_present
     expect(anchor['exact']).to eq('Description')
-    # "Description" is a heading — findFieldName walks h5 elements
-    # and returns the last heading whose offset <= position.
-    # Since Description IS the h5, its offset equals the selection position,
-    # so findFieldName returns "Description".
     expect(anchor['field_name']).to eq('Description')
   end
 
   it 'handles selection of a field name + 1 line of content' do
-    anchor = build_anchor("Description\nThe application is vulnerable to SQL injection.")
+    selected = selection_between(
+      'Description',
+      'The application is vulnerable to SQL injection.'
+    )
+    anchor = build_anchor(selected)
 
     expect(anchor).to be_present
     expect(anchor['exact']).to include('Description')
@@ -74,7 +101,11 @@ describe 'InlineThreadSelector#buildAnchor', js: true do
   end
 
   it 'handles selection of a field name + 2 lines of content' do
-    anchor = build_anchor("Description\nThe application is vulnerable to SQL injection.\nAn attacker can extract data from the database.")
+    selected = selection_between(
+      'Description',
+      'An attacker can extract data from the database.'
+    )
+    anchor = build_anchor(selected)
 
     expect(anchor).to be_present
     expect(anchor['exact']).to include('Description')
@@ -84,7 +115,11 @@ describe 'InlineThreadSelector#buildAnchor', js: true do
   end
 
   it 'handles selection spanning across 2 fields' do
-    anchor = build_anchor("An attacker can extract data from the database.\nRecommendation\nUse parameterized queries.")
+    selected = selection_between(
+      'An attacker can extract data from the database.',
+      'Use parameterized queries.'
+    )
+    anchor = build_anchor(selected)
 
     expect(anchor).to be_present
     expect(anchor['exact']).to include('An attacker can extract data')

--- a/spec/features/inline_thread_selector_spec.rb
+++ b/spec/features/inline_thread_selector_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe 'InlineThreadSelector#buildAnchor', js: true do
+  before do
+    login_to_project_as_user
+    allow_any_instance_of(Project).to receive(:reviewers).and_return(User.all)
+
+    @issue = create(:issue,
+      state: :ready_for_review,
+      node: current_project.issue_library,
+      text: issue_text
+    )
+
+    visit project_qa_issue_path(current_project, @issue)
+
+    # Wait for the inline thread selector to initialize
+    expect(page).to have_css('[data-behavior~=inline-threads-container]')
+  end
+
+  let(:issue_text) do
+    [
+      '#[Title]#',
+      'SQL Injection in Login',
+      '',
+      '#[Description]#',
+      'The application is vulnerable to SQL injection.',
+      'An attacker can extract data from the database.',
+      '',
+      '#[Recommendation]#',
+      'Use parameterized queries.',
+      'Validate all user input.'
+    ].join("\n")
+  end
+
+  def build_anchor(selected_text)
+    page.evaluate_script(<<~JS)
+      (function() {
+        var container = document.querySelector('[data-behavior~=inline-threads-container]');
+        var selector = $(container).data('inlineThreadSelector');
+        return selector.buildAnchor(#{selected_text.to_json});
+      })()
+    JS
+  end
+
+  it 'handles selection of multi-line content (no fields)' do
+    anchor = build_anchor("The application is vulnerable to SQL injection.\nAn attacker can extract data from the database.")
+
+    expect(anchor).to be_present
+    expect(anchor['exact']).to include('The application is vulnerable')
+    expect(anchor['exact']).to include('An attacker can extract data')
+    expect(anchor['field_name']).to eq('Description')
+    expect(anchor['position']['start']).to be < anchor['position']['end']
+  end
+
+  it 'handles selection of a field name only' do
+    anchor = build_anchor('Description')
+
+    expect(anchor).to be_present
+    expect(anchor['exact']).to eq('Description')
+    # "Description" is a heading — findFieldName walks h5 elements
+    # and returns the last heading whose offset <= position.
+    # Since Description IS the h5, its offset equals the selection position,
+    # so findFieldName returns "Description".
+    expect(anchor['field_name']).to eq('Description')
+  end
+
+  it 'handles selection of a field name + 1 line of content' do
+    anchor = build_anchor("Description\nThe application is vulnerable to SQL injection.")
+
+    expect(anchor).to be_present
+    expect(anchor['exact']).to include('Description')
+    expect(anchor['exact']).to include('The application is vulnerable')
+    expect(anchor['field_name']).to eq('Description')
+  end
+
+  it 'handles selection of a field name + 2 lines of content' do
+    anchor = build_anchor("Description\nThe application is vulnerable to SQL injection.\nAn attacker can extract data from the database.")
+
+    expect(anchor).to be_present
+    expect(anchor['exact']).to include('Description')
+    expect(anchor['exact']).to include('The application is vulnerable')
+    expect(anchor['exact']).to include('An attacker can extract data')
+    expect(anchor['field_name']).to eq('Description')
+  end
+
+  it 'handles selection spanning across 2 fields' do
+    anchor = build_anchor("An attacker can extract data from the database.\nRecommendation\nUse parameterized queries.")
+
+    expect(anchor).to be_present
+    expect(anchor['exact']).to include('An attacker can extract data')
+    expect(anchor['exact']).to include('Recommendation')
+    expect(anchor['exact']).to include('Use parameterized queries')
+    expect(anchor['field_name']).to eq('Description')
+  end
+end


### PR DESCRIPTION
Instead of maintaining a client-side reimplementation of FieldParser to map rendered text positions back to raw DB text, read textContent directly from the DOM after rendering. This eliminates the field map machinery (_buildFieldMap, _strippedText, _strippedToRaw) and the fast/slow path branching in buildAnchor.

The key insight is that anchors don't need to reference raw text positions — prefix/suffix/exact are sufficient for re-locating highlights, and the position fields just need internal consistency.

On dradis:liquid-rendered, textContent is re-read so Liquid-resolved content is picked up automatically, fixing the mismatch between raw text (containing Liquid tags) and what the user actually sees.

findFieldName now uses DOM traversal (h5 headings) instead of regex matching against raw text with #[...]# markers.

Also fixes highlights not appearing for multi-line selections: findTextInNodes in the highlighter was concatenating text nodes' textContent, which doesn't include `\n` at block boundaries (`<br>`, `<h5>`, `<p>`).

Since anchor.exact comes from getSelection().toString() (which mirrors innerText behavior), the indexOf match failed. Now uses innerText as the combined string.

Quoted text in the thread panel now preserves newlines (white-space: pre-line) and the blockquote margin is consistent between the JS-built new-thread form and the server-rendered partial.

### Check List

- ~~[ ] Added a CHANGELOG entry~~
- [x] Commit message has a detailed description of what changed and why.
