### PR TITLE
Additional comment threads cleanup

### DIFF
--- a/app/assets/javascripts/hera.js
+++ b/app/assets/javascripts/hera.js
@@ -22,6 +22,7 @@
 //= require hera/modules/differ
 //= require hera/modules/editor_toolbar
 //= require hera/modules/quote_selector
+//= require hera/modules/inline_thread_utils
 //= require hera/modules/inline_thread_selector
 //= require hera/modules/inline_thread_highlighter
 //= require hera/modules/inline_thread_turbo

--- a/app/assets/javascripts/hera/modules/inline_thread_highlighter.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_highlighter.js
@@ -131,7 +131,7 @@ class InlineThreadHighlighter {
       // Cross-browser: anchor.exact may use different whitespace than
       // the current browser's innerText (e.g. Safari uses spaces where
       // Firefox uses \n\n around block elements). Fuzzy-match whitespace.
-      const result = this.fuzzyIndexOf(combined, searchText);
+      const result = fuzzyIndexOf(combined, searchText);
       if (!result) return [];
       matchIndex = result.start;
       matchEnd = result.end;
@@ -180,19 +180,4 @@ class InlineThreadHighlighter {
     return segments;
   }
 
-  // Find `needle` in `haystack` allowing whitespace runs in the needle
-  // to match any whitespace run in the haystack. Returns { start, end }
-  // positions in the original haystack, or null.
-  fuzzyIndexOf(haystack, needle) {
-    const parts = needle.split(/\s+/).map(
-      s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    );
-    if (parts.length < 2) return null;
-
-    const pattern = new RegExp(parts.join('\\s+'));
-    const match = haystack.match(pattern);
-    if (!match) return null;
-
-    return { start: match.index, end: match.index + match[0].length };
-  }
 }

--- a/app/assets/javascripts/hera/modules/inline_thread_selector.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_selector.js
@@ -125,7 +125,7 @@ class InlineThreadSelector {
     // whitespace in both strings to find the match, then map back to
     // original positions.
     if (index === -1) {
-      const result = this.fuzzyIndexOf(text, selectedText);
+      const result = fuzzyIndexOf(text, selectedText);
       if (result) {
         index = result.start;
         selectedText = text.substring(result.start, result.end);
@@ -152,23 +152,6 @@ class InlineThreadSelector {
       },
       field_name: fieldName
     };
-  }
-
-  // Find `needle` in `haystack` allowing whitespace runs in the needle
-  // to match any whitespace run in the haystack. Returns { start, end }
-  // positions in the original haystack, or null.
-  fuzzyIndexOf(haystack, needle) {
-    // Build a regex that treats each whitespace run in the needle as \s+
-    const parts = needle.split(/\s+/).map(
-      s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    );
-    if (parts.length < 2) return null;
-
-    const pattern = new RegExp(parts.join('\\s+'));
-    const match = haystack.match(pattern);
-    if (!match) return null;
-
-    return { start: match.index, end: match.index + match[0].length };
   }
 
   findFieldName(position) {

--- a/app/assets/javascripts/hera/modules/inline_thread_utils.js
+++ b/app/assets/javascripts/hera/modules/inline_thread_utils.js
@@ -1,0 +1,17 @@
+// Shared utilities for inline thread text matching and form building.
+
+// Find `needle` in `haystack` allowing whitespace runs in the needle
+// to match any whitespace run in the haystack. Returns { start, end }
+// positions in the original haystack, or null.
+function fuzzyIndexOf(haystack, needle) {
+  const parts = needle.split(/\s+/).map(
+    s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  );
+  if (parts.length < 2) return null;
+
+  const pattern = new RegExp(parts.join('\\s+'));
+  const match = haystack.match(pattern);
+  if (!match) return null;
+
+  return { start: match.index, end: match.index + match[0].length };
+}

--- a/app/controllers/inline_threads/comments_controller.rb
+++ b/app/controllers/inline_threads/comments_controller.rb
@@ -18,8 +18,6 @@ class InlineThreads::CommentsController < AuthenticatedController
         notifiable: @comment,
         user: current_user
       )
-      @inline_thread.reload
-      @inline_thread.comments.includes(:user).load
     else
       head :unprocessable_entity
     end

--- a/app/controllers/inline_threads_controller.rb
+++ b/app/controllers/inline_threads_controller.rb
@@ -26,9 +26,9 @@ class InlineThreadsController < AuthenticatedController
 
   def create
     @inline_thread = commentable.inline_threads.build(inline_thread_params_for_create)
+    comment = @inline_thread.comments.first
 
     if @inline_thread.save
-      comment = @inline_thread.comments.first
       publish_event('comment.created', comment.to_event_payload)
       broadcast_notifications(
         action: :create,

--- a/app/views/inline_threads/_inline_thread.html.erb
+++ b/app/views/inline_threads/_inline_thread.html.erb
@@ -12,14 +12,5 @@
 
   <hr class="mt-0">
 
-  <div id="thread_<%= inline_thread.id %>_reply_form">
-    <%= form_with url: inline_thread_comments_path(inline_thread) do |f| %>
-      <%= f.text_area :content,
-            name: 'comment[content]',
-            class: 'form-control form-control-sm mb-2',
-            placeholder: 'Reply...',
-            rows: 2 %>
-      <%= f.submit 'Reply', class: 'btn btn-sm btn-primary' %>
-    <% end %>
-  </div>
+  <%= render 'inline_threads/reply_form', inline_thread: inline_thread %>
 </div>

--- a/app/views/inline_threads/_reply_form.html.erb
+++ b/app/views/inline_threads/_reply_form.html.erb
@@ -1,0 +1,10 @@
+<div id="thread_<%= inline_thread.id %>_reply_form">
+  <%= form_with url: inline_thread_comments_path(inline_thread) do |f| %>
+    <%= f.text_area :content,
+          name: 'comment[content]',
+          class: 'form-control form-control-sm mb-2',
+          placeholder: 'Reply...',
+          rows: 2 %>
+    <%= f.submit 'Reply', class: 'btn btn-sm btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/inline_threads/comments/create.turbo_stream.erb
+++ b/app/views/inline_threads/comments/create.turbo_stream.erb
@@ -1,3 +1,7 @@
-<%= turbo_stream.update 'inline_thread_content' do %>
-  <%= render 'inline_threads/inline_thread', inline_thread: @inline_thread %>
+<%= turbo_stream.append "thread_#{@inline_thread.id}_comments" do %>
+  <%= render 'inline_threads/inline_comment', comment: @comment %>
+<% end %>
+
+<%= turbo_stream.replace "thread_#{@inline_thread.id}_reply_form" do %>
+  <%= render 'inline_threads/reply_form', inline_thread: @inline_thread %>
 <% end %>


### PR DESCRIPTION
### Summary

Some additional cleanup of the comment threads feature
- Move fuzzyIndexOf into a module so it can be reused rather than duplicated
- Append new comment to thread via turbo instead of re-rendering the entire frame

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
