### PR TITLE
avoid ghost requests in merge spec textile form example

### DIFF
--- a/spec/features/issue_pages/merge_spec.rb
+++ b/spec/features/issue_pages/merge_spec.rb
@@ -8,45 +8,40 @@ describe 'issue pages' do
       # create 2 issues
       @issue1 = create(:issue, node: current_project.issue_library)
       @issue2 = create(:issue, node: current_project.issue_library)
-
-      visit project_issues_path(current_project)
-
-      # click > 1 issue checkboxes
-      page.all('td.select-checkbox').each(&:click)
-
-      # click the merge button
-      find('span', text: 'Merge').click
     end
 
-    it 'merges issues into an existing one' do
-      expect(page).to have_content /You're merging 2 Issues into a target Issue/i
-
-      click_button 'Merge issues'
-
-      expect(page).to have_content('1 issue merged into ')
+    describe 'textile form view' do
+      let(:action_path) { new_project_merge_path(current_project, ids: [@issue1.id, @issue2.id]) }
+      it_behaves_like 'a .textile form'
     end
 
-    context 'merge issues into a new one', js: true do
-      describe 'textile form view' do
-        let(:action_path) { new_project_merge_path(current_project, ids: [@issue1.id, @issue2.id]) }
-        it_behaves_like 'a .textile form'
+    context 'merge actions' do
+      before do
+        visit new_project_merge_path(current_project, ids: [@issue1.id, @issue2.id])
+        expect(page).to have_content /You're merging 2 Issues into a target Issue/i
+      end
+
+      # After the merge form submits, the redirect lands on Issues#show
+      # which fires an async fetch (liquid_async). Wait for it to
+      # complete (spinner hidden) so it doesn't become a ghost request
+      # after the transactional fixture rolls back.
+      def submit_and_wait
+        click_button 'Merge issues'
+        expect(page).to have_css('[data-behavior~="liquid-spinner"].d-none', visible: :all)
+      end
+
+      it 'merges issues into an existing one' do
+        submit_and_wait
+
+        expect(page).to have_content('1 issue merged into ')
       end
 
       it 'creates a new issue' do
-        expect(page).to have_content /You're merging 2 Issues into a target Issue/i
-
-        # new issue form should not be visible yet
-        expect(page).to have_selector('#new_issue', visible: false)
-
         choose('Merge into a new issue')
+        expect(page).to have_css('#preview_issue_new.show')
         click_link 'Source'
 
-        # new issue form should be visible now
-        expect(page).to have_selector('#new_issue', visible: true)
-
-        # click button like this because the button may be moving down
-        # due to bootstrap accordion unfold transition
-        find_button('Merge issues').send_keys(:return) # click_button "Merge issues"
+        submit_and_wait
 
         expect(page).to have_content(/2 issues merged into/i)
 
@@ -56,32 +51,23 @@ describe 'issue pages' do
       end
 
       it 'tags the new issue based on the #[Tags]#' do
-        expect(page).to have_content /You're merging 2 Issues into a target Issue/i
-
-        # new issue form should not be visible yet
-        expect(page).to have_selector('#new_issue', visible: false)
-
         choose('Merge into a new issue')
-
-        # new issue form should be visible now
-        expect(page).to have_selector('#new_issue', visible: true)
+        expect(page).to have_css('#preview_issue_new.show')
 
         tag_name = '!2ca02c_info'
         click_link 'Source'
         fill_in :issue_text, with: "#[Title]#\nMerged issue\n\n#[Tags]#\n#{tag_name}\n\n"
 
-        # click button like this because the button may be moving down
-        # due to bootstrap accordion unfold transition
-        find_button('Merge issues').send_keys(:return) # click_button "Merge issues"
+        submit_and_wait
 
         expect(page).to have_content(/2 issues merged into Merged issue/i)
         expect(Issue.last.reload.tag_list).to eq(tag_name)
       end
-    end
 
-    let(:submit_form) {
-      click_button 'Merge issues'
-    }
-    include_examples 'deleted item is listed in Trash', :issue
+      let(:submit_form) {
+        submit_and_wait
+      }
+      include_examples 'deleted item is listed in Trash', :issue
+    end
   end
 end


### PR DESCRIPTION
### Summary

Fixes flaky CI failures in `spec/features/issue_pages/merge_spec.rb` caused by ghost requests from `liquid_async.js`.

**Root cause:** After the merge form submits, Rails redirects to Issues#show, which fires an async `fetch` via `liquid_async.js` to render Liquid content. When the transactional fixture rolls back before that fetch completes, the server hits `RecordNotFound` for the project — a ghost request.

**Fix:**
1. **Structural:** Split the `before` block so the `'a .textile form'` shared example visits the merge page URL directly instead of navigating through the issues index (avoids unrelated ghost requests).
2. **`submit_and_wait` helper:** After clicking "Merge issues", wait for `[data-behavior~="liquid-spinner"].d-none` — the spinner gets `d-none` once the `liquid_async` fetch completes. This ensures the async request finishes before the transaction rolls back.

Also replaces `send_keys(:return)` with `click_button` + accordion `.show` class wait for reliability, and uses direct `visit` to the merge page instead of navigating through the issues index.

Introduced in #1540.

### Check List

- [ ] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.