### PR TITLE
Create activity when Issues are updated via REST API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
       - [future tense verb] [reporting enhancement]
   - REST/JSON API enhancements:
     - Issues: Add support for search
+    - Issues: show in Recent Activity when edited via the API
   - Security Fixes:
     - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
     - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v1/issues_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v1/issues_controller.rb
@@ -2,6 +2,7 @@ module Dradis::CE::API
   module V1
     class IssuesController < Dradis::CE::API::APIController
       include ActivityTracking
+      include EventPublisher
       include Dradis::CE::API::ProjectScoped
 
       before_action :set_issue, except: [:index]
@@ -24,6 +25,7 @@ module Dradis::CE::API
 
         if @issue.save
           track_created(@issue)
+          publish_event('issue.created', @issue.to_event_payload)
           @issue.tag_from_field_content!
           render status: 201, location: dradis_api.issue_url(@issue)
         else
@@ -34,6 +36,7 @@ module Dradis::CE::API
       def update
         if @issue.update(issue_params)
           track_updated(@issue)
+          publish_event('issue.updated', @issue.to_event_payload)
           render node: @node
         else
           render_validation_errors(@issue)
@@ -43,6 +46,7 @@ module Dradis::CE::API
       def destroy
         @issue.destroy
         track_destroyed(@issue)
+        publish_event('issue.destroyed', @issue.to_event_payload)
         render_successful_destroy_message
       end
 


### PR DESCRIPTION
### Summary

Currently, when an Issue is edited via the REST API, the Revision History is updated, but the edit does not appear in the Recent Activity. This PR resolves the situation so that edits are tracked in both places, regardless of whether they were done in the UI vs the REST API. 


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
