### PR TITLE
Set the default theme in userpreferences during serialize-time

### DIFF
--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -76,6 +76,8 @@ class UserPreferences
         instance_variable_set(:"@#{key}", value)
       end
     end
+
+    @theme ||= DEFAULT_THEME
   end
 
   VALID_TOURS.each do |tour|


### PR DESCRIPTION
### Summary
The error happens because the pre-existing userpreferences does not yet have a theme attribute. So when `authenticate` is called, which then calls `unlock`:
```
def unlock!
  preferences.failed_auth_count = 0
  save!
end
```
The preferences in this case won't have a theme attribute, so it's invalid and `save!` fails.

Solution: when the userpreferences is serialized from the DB we set the `@theme` as the DEFAULT_THEME if it doesn't exist
```
@theme ||= DEFAULT_THEME
```

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Commit message has a detailed description of what changed and why.
