### PR TITLE
Fix dark-mode styling for alert close button and revision diff colours

### DIFF
--- a/app/assets/stylesheets/hera/modules/_buttons.scss
+++ b/app/assets/stylesheets/hera/modules/_buttons.scss
@@ -396,32 +396,3 @@
   }
 }
 
-@mixin dark-btn-close {
-  .alert .btn-close {
-    filter: none;
-    opacity: 0.75;
-
-    &:hover {
-      opacity: 1;
-    }
-  }
-
-  .btn-close {
-    filter: invert(1) grayscale(100%) brightness(200%);
-    opacity: 0.75;
-
-    &:hover {
-      opacity: 1;
-    }
-  }
-}
-
-[data-theme='dark'] {
-  @include dark-btn-close;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']) {
-    @include dark-btn-close;
-  }
-}

--- a/app/assets/stylesheets/hera/modules/_buttons.scss
+++ b/app/assets/stylesheets/hera/modules/_buttons.scss
@@ -396,7 +396,16 @@
   }
 }
 
-[data-theme='dark'] {
+@mixin dark-btn-close {
+  .alert .btn-close {
+    filter: none;
+    opacity: 0.75;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
   .btn-close {
     filter: invert(1) grayscale(100%) brightness(200%);
     opacity: 0.75;
@@ -404,5 +413,15 @@
     &:hover {
       opacity: 1;
     }
+  }
+}
+
+[data-theme='dark'] {
+  @include dark-btn-close;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    @include dark-btn-close;
   }
 }

--- a/app/assets/stylesheets/hera/modules/_revisions.scss
+++ b/app/assets/stylesheets/hera/modules/_revisions.scss
@@ -1,15 +1,15 @@
 del {
-  background-color: #FCC;
+  background-color: var(--del-bg);
 }
 
 ins {
-  background-color: #CFC;
+  background-color: var(--ins-bg);
 }
 
 .revisions-table {
   tr {
     &.active {
-      background-color: #FFE;
+      background-color: var(--revision-active-bg);
     }
 
     th {

--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -28,6 +28,11 @@
   --form-select-caret: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23d1d1d1' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
   --form-switch-bg:    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba(255, 255, 255, 0.25)'/%3e%3c/svg%3e");
 
+  // Revisions
+  --del-bg:             #{$red-800};
+  --ins-bg:             #{$green-800};
+  --revision-active-bg: #{$yellow-800};
+
   // Tables
   --table-stripe-bg: rgba(255, 255, 255, 0.05);
 
@@ -78,6 +83,11 @@
   // Forms
   --form-select-caret: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
   --form-switch-bg:    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba(0, 0, 0, 0.25)'/%3e%3c/svg%3e");
+
+  // Revisions
+  --del-bg:             #{$red-100};
+  --ins-bg:             #{$green-100};
+  --revision-active-bg: #{$yellow-100};
 
   // Tables
   --table-stripe-bg: rgba(0, 0, 0, 0.05);

--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -24,6 +24,24 @@
   --btn-outline-success-color:   #{$green-500};
   --btn-outline-warning-color:   #{$yellow-500};
 
+  .alert .btn-close {
+    filter: none;
+    opacity: 0.75;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+    opacity: 0.75;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
   // Forms
   --form-select-caret: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23d1d1d1' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
   --form-switch-bg:    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba(255, 255, 255, 0.25)'/%3e%3c/svg%3e");


### PR DESCRIPTION
### Summary
                                                                              
**Fix two dark mode styling issues:**

- Alert close button: The .btn-close dismiss button was being inverted to white in dark mode (via filter: invert(1)), making it invisible against alerts' light-coloured backgrounds. Added an exception to skip the filter for .btn-close inside .alert. Also extended the invert rule to cover auto dark mode (OS preference via media query), which was missing entirely.

- Revision diff colours: del, ins, and .revisions-table tr.active were using hardcoded hex values (#FCC, #CFC, #FFE) with no dark mode override, resulting in bright light-coloured highlights on a dark background. Replaced with CSS custom properties (--del-bg, --ins-bg, --revision-active-bg) defined in themes.scss for both light and dark themes. All six colour combinations pass WCAG AAA contrast (7:1+).

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
