### PR TITLE
Add brand variable for backgrounds

### DIFF
--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -6,6 +6,7 @@
 
 @mixin dark-theme {
   // Backgrounds
+  --brand-bg:            #{$brand-600};
   --nav-active-bg:       #{$brand-600};
   --primary-bg:          #{$grey-900};
   --primary-bg-subtle:   #{$grey-800};
@@ -57,6 +58,7 @@
 
 :root {
   // Backgrounds
+  --brand-bg:            #{$brand-500};
   --nav-active-bg:       #{$brand-500};
   --primary-bg:          #{$white};
   --primary-bg-subtle:   #{darken($white, 3%)};          // darken($primary-bg, 3%)

--- a/app/assets/stylesheets/hera/views/issues/_issues.scss
+++ b/app/assets/stylesheets/hera/views/issues/_issues.scss
@@ -19,7 +19,7 @@ body.qa-issues.edit {
 body.issues.edit {
   #cvss-tabs.nav-pills {
     .nav-link.active {
-      background-color: $primary;
+      background-color: var(--brand-bg);
       color: $white;
     }
   }
@@ -27,7 +27,7 @@ body.issues.edit {
 
 body.issues.index {
   .add-issues {
-    border: 1px solid $primary;
+    border: 1px solid var(--brand-bg);
     height: 100%;
 
     .card-body {

--- a/app/assets/stylesheets/hera/views/issues/_issues.scss
+++ b/app/assets/stylesheets/hera/views/issues/_issues.scss
@@ -37,7 +37,7 @@ body.issues.index {
     }
 
     .card-header {
-      background: $primary;
+      background: var(--brand-bg);
       color: $white;
 
       .card-title {


### PR DESCRIPTION
### Summary

Add a `--brand-bg` CSS custom property to `themes.scss` to provide a semantically correct, theme-aware variable for brand-coloured backgrounds.

  - Light: `$brand-500`
  - Dark: `$brand-600`

Use it to fix dark mode rendering of the empty state card headers in the Issues page, which were previously hardcoded to `$primary`.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
