### PR TITLE
Fix contrast ratio in notifications

### DIFF
--- a/app/assets/stylesheets/hera/modules/_notifications.scss
+++ b/app/assets/stylesheets/hera/modules/_notifications.scss
@@ -114,6 +114,10 @@
 
           .body {
             white-space: initial;
+
+            .time {
+              color: $grey-700;
+            }
           }
 
           &:last-child {

--- a/app/assets/stylesheets/hera/modules/_notifications.scss
+++ b/app/assets/stylesheets/hera/modules/_notifications.scss
@@ -11,7 +11,7 @@
     z-index: 2;
 
     .time {
-      color: $grey-800;
+      color: var(--text-muted);
     }
   }
 
@@ -59,14 +59,18 @@
       opacity: 0.15;
     }
 
+    .time {
+      color: $grey-700;
+    }
+
     .title {
       a {
-        color: var(--text-link);
+        color: $brand-700;
 
         &:active,
         &:focus,
         &:hover {
-          color: var(--text-link-hover);
+          color: $brand-900;
         }
       }
     }


### PR DESCRIPTION
### Summary

Unread notifications use a light brand background ($brand-100). The link color ($brand-500) only achieves ~3.5:1 contrast against it, below the WCAG AA threshold of 4.5:1. Bump to $brand-700 which achieves sufficient contrast while keeping the branded feel.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
