### PR TITLE
Simplify navbar partials and fix caching

### DIFF
--- a/app/views/layouts/hera/navbar/main_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/_ce.html.erb
@@ -1,13 +1,13 @@
-<li class="nav-item d-lg-none">
-  <%= render "layouts/hera/navbar/projects/search" %>
-</li>
+<% cache(['navbar-left', Dradis::Plugins.with_feature(:addon)]) do %>
+  <li class="nav-item d-lg-none">
+    <%= render "layouts/hera/navbar/projects/search" %>
+  </li>
 
-<li class="nav-item">
-  <%= link_to 'javascript:void(0)', class: 'js-try-pro nav-link', data: { term: 'projects', url: 'https://dradis.com/pro/pages/projects.html' } do %>
-    <span>Projects</span>
-  <% end %>
-</li>
+  <li class="nav-item">
+    <%= link_to 'javascript:void(0)', class: 'js-try-pro nav-link', data: { term: 'projects', url: 'https://dradis.com/pro/pages/projects.html' } do %>
+      <span>Projects</span>
+    <% end %>
+  </li>
 
-<% cache(['navbar-tools', Dradis::Plugins.with_feature(:addon)]) do %>
   <%= render 'layouts/hera/navbar/main_nav/tools_menu' %>
 <% end %>

--- a/app/views/layouts/hera/navbar/main_nav/_help_menu.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/_help_menu.html.erb
@@ -1,3 +1,4 @@
+<% cache('navbar-help') do %>
 <li class="nav-item dropdown">
   <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" data-bs-toggle="dropdown" data-behavior="close-collapse" title="Help">
     <i class="fa-solid fa-question d-none d-lg-inline" title="Help"></i>
@@ -44,3 +45,4 @@
 
   </ul>
 </li>
+<% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -9,25 +9,23 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<% cache(['navbar-notifications', current_user.notifications.unread]) do %>
-  <li class="nav-item notifications dropdown">
-    <%= link_to main_app.project_notifications_path(current_project),
-      class: 'nav-link dropdown-toggle no-caret',
-      data: {
-        id: 'notifications',
-        bs_toggle: 'dropdown',
-        behavior: 'notifications-dropdown close-collapse',
-        project_id: current_project.id
-      },
-      role: 'button',
-      'aria-expanded': 'false' do %>
-      <i class="notifications-bell fa-solid fa-bell d-none d-lg-inline" title="Notifications"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
-      <span class="d-inline d-lg-none">Notifications</span>
-    <% end %>
-    <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>" aria-labelledby="notifications">
-    </div>
-  </li>
-<% end %>
+<li class="nav-item notifications dropdown">
+  <%= link_to main_app.project_notifications_path(current_project),
+    class: 'nav-link dropdown-toggle no-caret',
+    data: {
+      id: 'notifications',
+      bs_toggle: 'dropdown',
+      behavior: 'notifications-dropdown close-collapse',
+      project_id: current_project.id
+    },
+    role: 'button',
+    'aria-expanded': 'false' do %>
+    <i class="notifications-bell fa-solid fa-bell d-none d-lg-inline" title="Notifications"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
+    <span class="d-inline d-lg-none">Notifications</span>
+  <% end %>
+  <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>" aria-labelledby="notifications">
+  </div>
+</li>
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>
 

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -1,18 +1,24 @@
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/theme_menu' %>
 
-<li class="nav-item">
-  <%= link_to main_app.project_trash_path(current_project), class: 'nav-link' do %>
-    <i class="fa-solid fa-trash-can fa-fw d-none d-lg-inline" title="Trash"></i>
-    <span class="d-inline d-lg-none">Trash</span>
-  <% end %>
-</li>
+<% cache(['navbar-trash', current_project.id]) do %>
+  <li class="nav-item">
+    <%= link_to main_app.project_trash_path(current_project), class: 'nav-link' do %>
+      <i class="fa-solid fa-trash-can fa-fw d-none d-lg-inline" title="Trash"></i>
+      <span class="d-inline d-lg-none">Trash</span>
+    <% end %>
+  </li>
+<% end %>
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications',
-     project_id: current_project.id %>
+<% cache(['navbar-notifications', current_project.id]) do %>
+  <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications',
+       project_id: current_project.id %>
+<% end %>
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>
 
-<%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/user_dropdown' do %>
+<% cache(['navbar-user-dropdown', current_user.id, current_user.updated_at]) do %>
+  <%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/user_dropdown' do %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -9,23 +9,8 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<li class="nav-item notifications dropdown">
-  <%= link_to main_app.project_notifications_path(current_project),
-    class: 'nav-link dropdown-toggle no-caret',
-    data: {
-      id: 'notifications',
-      bs_toggle: 'dropdown',
-      behavior: 'notifications-dropdown close-collapse',
-      project_id: current_project.id
-    },
-    role: 'button',
-    'aria-expanded': 'false' do %>
-    <i class="notifications-bell fa-solid fa-bell d-none d-lg-inline" title="Notifications"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
-    <span class="d-inline d-lg-none">Notifications</span>
-  <% end %>
-  <div class="dropdown-menu dropdown-menu-end" data-url="<%= main_app.notifications_path %>" aria-labelledby="notifications">
-  </div>
-</li>
+<%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications',
+     project_id: current_project.id %>
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>
 

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -14,17 +14,5 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>
 
-<li class="nav-item dropdown me-0 mb-3 mb-lg-0">
-  <a class="nav-link dropdown-toggle pe-0 py-lg-0 d-flex align-items-center no-caret-xl" href="javascript:void(0)" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="user-profile">
-    <%= avatar_image(current_user, size: 32) %>
-    <span class="d-block d-lg-none ms-1"><%= current_user.name %></span>
-  </a>
-  <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="user-profile">
-    <li>
-      <%= link_to main_app.logout_path,  class: 'dropdown-item', data: { turbo: false } do %>
-        <i class="fa-solid fa-arrow-right-from-bracket"></i>
-        <span class="ms-1">Logout</span>
-      <% end %>
-    </li>
-  </ul>
-</li>
+<%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/user_dropdown' do %>
+<% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -9,7 +9,11 @@
   </li>
 <% end %>
 
-<%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
+<% cache(['navbar-config', current_project.id]) do %>
+  <%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' do %>
+    <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
+  <% end %>
+<% end %>
 
 <% cache('navbar-notifications') do %>
   <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications' %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -17,7 +17,7 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>
 
-<% cache(['navbar-user-dropdown', current_user.id, current_user.updated_at]) do %>
+<% cache(['navbar-user-dropdown', current_user]) do %>
   <%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/user_dropdown' do %>
   <% end %>
 <% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/theme_menu' %>
 
-<% cache(['navbar-trash', current_project.id]) do %>
+<% cache(['navbar-trash', current_project]) do %>
   <li class="nav-item">
     <%= link_to main_app.project_trash_path(current_project), class: 'nav-link' do %>
       <i class="fa-solid fa-trash-can fa-fw d-none d-lg-inline" title="Trash"></i>
@@ -9,7 +9,7 @@
   </li>
 <% end %>
 
-<% cache(['navbar-config', current_project.id]) do %>
+<% cache(['navbar-config', current_project]) do %>
   <%= render layout: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' do %>
     <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
   <% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -11,9 +11,8 @@
 
 <%= render partial: 'layouts/hera/navbar/main_nav/utility_nav/configuration_menu' %>
 
-<% cache(['navbar-notifications', current_project.id]) do %>
-  <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications',
-       project_id: current_project.id %>
+<% cache('navbar-notifications') do %>
+  <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications' %>
 <% end %>
 
 <%= render partial: 'layouts/hera/navbar/main_nav/help_menu' %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_configuration_menu.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_configuration_menu.html.erb
@@ -1,9 +1,11 @@
-<li class="nav-item dropdown">
-  <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" id="configurationDropdown" title="Configuration" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-    <i class="fa-solid fa-cog fa-fw d-none d-lg-inline" title="Configuration"></i>
-    <span class="d-inline d-lg-none">Configuration</span>
-  </a>
-  <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="configurationDropdown">
-    <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
-  </ul>
-</li>
+<% cache(['navbar-config', current_project.id]) do %>
+  <li class="nav-item dropdown">
+    <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" id="configurationDropdown" title="Configuration" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <i class="fa-solid fa-cog fa-fw d-none d-lg-inline" title="Configuration"></i>
+      <span class="d-inline d-lg-none">Configuration</span>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="configurationDropdown">
+      <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
+    </ul>
+  </li>
+<% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_configuration_menu.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_configuration_menu.html.erb
@@ -1,11 +1,9 @@
-<% cache(['navbar-config', current_project.id]) do %>
-  <li class="nav-item dropdown">
-    <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" id="configurationDropdown" title="Configuration" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-      <i class="fa-solid fa-cog fa-fw d-none d-lg-inline" title="Configuration"></i>
-      <span class="d-inline d-lg-none">Configuration</span>
-    </a>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="configurationDropdown">
-      <%= render partial: 'layouts/hera/navbar/projects/project_configurations' %>
-    </ul>
-  </li>
-<% end %>
+<li class="nav-item dropdown">
+  <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" id="configurationDropdown" title="Configuration" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+    <i class="fa-solid fa-cog fa-fw d-none d-lg-inline" title="Configuration"></i>
+    <span class="d-inline d-lg-none">Configuration</span>
+  </a>
+  <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="configurationDropdown">
+    <%= yield %>
+  </ul>
+</li>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_notifications.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_notifications.html.erb
@@ -1,0 +1,28 @@
+<li class="nav-item notifications dropdown">
+  <% if content_for?(:notifications) %>
+    <%= yield(:notifications) %>
+  <% else %>
+    <%
+      notifications_url = local_assigns[:project_id] ?
+        main_app.project_notifications_path(local_assigns[:project_id]) :
+        main_app.notifications_path
+    %>
+    <%= link_to notifications_url,
+      class: class_names('nav-link dropdown-toggle no-caret', local_assigns[:link_class]),
+      id: 'notifications',
+      data: {
+        id: 'notifications',
+        bs_toggle: 'dropdown',
+        behavior: 'notifications-dropdown close-collapse',
+        project_id: local_assigns[:project_id]
+      }.compact,
+      role: 'button',
+      title: 'Notifications',
+      'aria-expanded': 'false' do %>
+      <i class="notifications-bell fa-solid fa-bell d-none d-lg-inline" title="Notifications"><i class="notifications-dot d-none" data-behavior="notifications-dot"></i></i>
+      <span class="d-inline d-lg-none">Notifications</span>
+    <% end %>
+  <% end %>
+  <div class="<%= class_names('dropdown-menu dropdown-menu-end', local_assigns[:dropdown_class]) %>" data-url="<%= main_app.notifications_path %>" aria-labelledby="notifications">
+  </div>
+</li>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_theme_menu.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_theme_menu.html.erb
@@ -1,5 +1,5 @@
-<% cache(['navbar-theme', current_user.preferences.theme]) do %>
 <% dradis_theme = current_user.preferences.theme %>
+<% cache(['navbar-theme', dradis_theme]) do %>
 <li class="nav-item dropdown">
   <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" title="Theme" role="button" data-bs-toggle="dropdown" aria-expanded="false">
     <span class="d-none d-lg-inline">

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_theme_menu.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_theme_menu.html.erb
@@ -1,3 +1,4 @@
+<% cache(['navbar-theme', current_user.preferences.theme]) do %>
 <% dradis_theme = current_user.preferences.theme %>
 <li class="nav-item dropdown">
   <a href="javascript:void(0)" class="nav-link dropdown-toggle no-caret-xl" title="Theme" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -26,3 +27,4 @@
     </li>
   </ul>
 </li>
+<% end %>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_user_dropdown.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_user_dropdown.html.erb
@@ -1,0 +1,15 @@
+<li class="nav-item dropdown me-0 mb-3 mb-lg-0">
+  <a class="nav-link dropdown-toggle pe-0 py-lg-0 d-flex align-items-center no-caret-xl" href="javascript:void(0)" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="user-profile">
+    <%= avatar_image(current_user, size: 32) %>
+    <span class="d-block d-lg-none ms-1"><%= current_user.name %></span>
+  </a>
+  <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="user-profile">
+    <%= yield %>
+    <li>
+      <%= link_to main_app.logout_path, class: 'dropdown-item', data: { turbo: false } do %>
+        <i class="fa-solid fa-arrow-right-from-bracket"></i>
+        <span class="ms-1">Logout</span>
+      <% end %>
+    </li>
+  </ul>
+</li>


### PR DESCRIPTION
### Summary

Simplify navbar partials and fix caching.

**Before:** CE wrapped the entire navbar in `cache('navbar')`, one key for all users. Inner caches (`navbar-tools`, `navbar-notifications`) were no-ops under it. Everything was stale.

**After:** Granular per-section caching with proper keys:

  | Cache Key | Section | Key Components | Invalidated By |
  |-----------|---------|----------------|----------------|
  | `navbar-left` | Left nav + tools menu | plugins list | Plugin enable/disable + Puma restart |
  | `navbar-theme` | Theme menu | user's theme pref | User switches theme |
  | `navbar-trash` | Trash link | project ID | Navigating between projects |
  | `navbar-config` | Configuration menu | project ID | Navigating between projects |
  | `navbar-notifications` | Notifications bell | project ID | Navigating between projects (only in project context) |
  | `navbar-help` | Help menu | *(none — static)* | Never |
  | `navbar-user-dropdown` | Avatar + user menu | user ID + `updated_at` | Avatar upload, permission change, name change |

**Removed:** `navbar-notifications` AR scope cache. It ran a DB query on every request just to compute the cache key, for content that's trivially cheap to render. The notification dot is toggled by JavaScript, not by the server-rendered HTML anyway.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.