### PR TITLE
fix project-aware navbar fragment cache keys

### DIFF
--- a/app/views/layouts/hera/navbar/main_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/_ce.html.erb
@@ -1,8 +1,6 @@
-<% cache(['navbar-left', Dradis::Plugins.with_feature(:addon)]) do %>
-  <li class="nav-item d-lg-none">
-    <%= render "layouts/hera/navbar/projects/search" %>
-  </li>
+<%= yield(:search) if content_for?(:search) %>
 
+<% cache(['navbar-left', Dradis::Plugins.with_feature(:addon)]) do %>
   <li class="nav-item">
     <%= link_to 'javascript:void(0)', class: 'js-try-pro nav-link', data: { term: 'projects', url: 'https://dradis.com/pro/pages/projects.html' } do %>
       <span>Projects</span>

--- a/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
+++ b/app/views/layouts/hera/navbar/main_nav/utility_nav/_ce.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 <% end %>
 
-<% cache('navbar-notifications') do %>
+<% cache(['navbar-notifications', current_project]) do %>
   <%= render 'layouts/hera/navbar/main_nav/utility_nav/notifications' %>
 <% end %>
 


### PR DESCRIPTION
### Summary

Two navbar fragment cache keys introduced in #1559 didn't account for project scope, so cached markup could be served to the wrong project:

- `navbar-notifications` was a static key — whichever project's notification link was cached first would be served to all subsequent projects.
- `navbar-left` cached the mobile search form, which bakes `project_search_path(current_project)` into the action attribute — switching projects would leave the form pointing at the old one.

### Check List

~- [ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.