### PR TITLE
scope TagsController resource loading through current_project

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,16 +4,13 @@ class TagsController < AuthenticatedController
   include Sortable
 
   before_action :set_columns, only: :index
-  load_and_authorize_resource
+  load_and_authorize_resource through: :current_project
 
-  def index
-    @tags = current_project.tags
-  end
+  def index; end
 
   def new; end
 
   def create
-    @tag.project = current_project
     if @tag.save
       track_created(@tag)
       redirect_to request.referer, notice: 'Tag created.'


### PR DESCRIPTION
### Summary

Uses CanCan's `through:` option to load tags via the current project's association:

```ruby
load_and_authorize_resource through: :current_project
```

No behaviour change -- tags are not scoped per project in CE. This keeps the controller shape aligned with the pattern used elsewhere in the codebase.

### Check List

- [x] Commit message has a detailed description of what changed and why.