### PR TITLE
document the capability-token model for job console logs

### DIFF
--- a/app/controllers/console_controller.rb
+++ b/app/controllers/console_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 # This controller is used by the console_updater js to retrieve logs
-# for a specific job
+# for a specific job.
+#
+# The job UUID is the authorization primitive: it's generated server-side
+# via SecureRandom.uuid (see Log#set_uid) and only returned to the user
+# that initiated the job. Possession of a valid UUID is treated as the
+# authorization to read the associated log stream -- we do not scope
+# Log records to a user or project at the row level.
 class ConsoleController < AuthenticatedController
   def status
     @job_id = params[:item_id]

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,6 +1,10 @@
 class Log < ApplicationRecord
   after_initialize :set_uid
 
+  # The UUID assigned here is the authorization primitive for reading
+  # the log stream. It's returned only to the user that initiated the
+  # job; ConsoleController#status treats possession of the UUID as the
+  # authorization to read the associated records.
   def set_uid
     self.uid ||= SecureRandom.uuid
   end


### PR DESCRIPTION
### Summary

Adds comments to `ConsoleController#status` and `Log#set_uid` recording the design intent: the job UUID (`SecureRandom.uuid`, 122 bits of entropy) is the authorization primitive for reading a log stream. Logs are not scoped by user or project at the row level; possession of a valid UUID is treated as the authorization to read.

### Why

Without these comments, the shape of `ConsoleController#status` invites future contributors to add row-level scoping that would require a substantial refactor (migration + threading `user_id` through every call site that creates a `Log`). The UUID-as-capability design is intentional and the comments flag that.

### Check List

- [x] Commit message has a detailed description of what changed and why.