### PR TITLE
restrict Echo configuration access to admin users when running under Pro

### DIFF
--- a/engines/dradis-echo/app/controllers/dradis/plugins/echo/configurations_controller.rb
+++ b/engines/dradis-echo/app/controllers/dradis/plugins/echo/configurations_controller.rb
@@ -21,7 +21,7 @@ module Dradis::Plugins::Echo
 
     def admin_required
       unless current_user && current_user.role?(:admin)
-        flash[:notice] = 'Access denied.'
+        flash[:alert] = 'Access denied.'
         redirect_to main_app.projects_path
       end
     end

--- a/engines/dradis-echo/app/controllers/dradis/plugins/echo/configurations_controller.rb
+++ b/engines/dradis-echo/app/controllers/dradis/plugins/echo/configurations_controller.rb
@@ -1,5 +1,7 @@
 module Dradis::Plugins::Echo
   class ConfigurationsController < ApplicationController
+    before_action :admin_required, if: -> { defined?(Dradis::Pro) }
+
     def index
       @configuration_form = ConfigurationForm.from_storage
     end
@@ -16,6 +18,13 @@ module Dradis::Plugins::Echo
     end
 
     private
+
+    def admin_required
+      unless current_user && current_user.role?(:admin)
+        flash[:notice] = 'Access denied.'
+        redirect_to main_app.projects_path
+      end
+    end
 
     def configuration_params
       params.require(:configuration_form).permit(:roslin_ollama_address, :roslin_ollama_model)


### PR DESCRIPTION
### Summary

Echo's `ConfigurationsController` controls server-wide settings (the Ollama endpoint, model name) that should be administrator-only in a multi-tenant deployment. CE's single-user model is unaffected.

Adds:
```ruby
before_action :admin_required, if: -> { defined?(Dradis::Pro) }

private

def admin_required
  unless current_user && current_user.role?(:admin)
    flash[:notice] = 'Access denied.'
    redirect_to main_app.projects_path
  end
end
```

The `if: defined?(Dradis::Pro)` guard means the check is a no-op in CE.

### Check List

- [x] Commit message has a detailed description of what changed and why.
EOF