### PR TITLE
render Liquid content in issue/evidence table columns asynchronously

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ v5.0.0 (March 2026)
   - Echo: Add configurable, reusable prompts for Issues
   - Forms: Improve visibility of form actions
   - Layout: Add light/dark/auto theme toggle to support dark mode
+  - Liquid: evaluate Liquid content before rendering all issues/evidence tables
   - Nodes:
     - Add more types and icons
     - Rename upload and parent node types and add distinguishing icons

--- a/app/assets/javascripts/hera/modules/liquid_async.js
+++ b/app/assets/javascripts/hera/modules/liquid_async.js
@@ -1,8 +1,15 @@
-document.addEventListener('turbo:load', function () {
+function updateLiquidSortValue(element, html) {
+  const liquidText = $('<div>').html(html).text().trim();
+  $(element).attr('data-sort', liquidText);
+}
+
+function liquidAsync() {
   $('[data-behavior~=liquid-async]').each(function () {
     const that = this,
       data = { text: $(that).attr('data-content') },
       $spinner = $(that).prev().find('[data-behavior~=liquid-spinner');
+
+    const requiresSortUpdate = $(that).is('[data-sort]');
 
     fetch($(that).attr('data-path'), {
       method: 'POST',
@@ -16,8 +23,18 @@ document.addEventListener('turbo:load', function () {
       .then((response) => response.text())
       .then(function (html) {
         $(that).html(html);
+
+        if (requiresSortUpdate) {
+          updateLiquidSortValue(that, html);
+        }
+
         $(that).trigger('dradis:liquid-rendered');
         $spinner.addClass('d-none');
       });
   });
+}
+
+document.addEventListener('turbo:load', liquidAsync);
+$(document).on('dradis:fetch', function () {
+  liquidAsync();
 });

--- a/app/assets/javascripts/hera/modules/liquid_async.js
+++ b/app/assets/javascripts/hera/modules/liquid_async.js
@@ -1,22 +1,22 @@
 function updateLiquidSortValue(element, html) {
-  const liquidText = $("<div>").html(html).text().trim();
-  $(element).attr("data-sort", liquidText);
+  const liquidText = $('<div>').html(html).text().trim();
+  $(element).attr('data-sort', liquidText);
 }
 
 function liquidAsync() {
-  $("[data-behavior~=liquid-async]").each(function () {
+  $('[data-behavior~=liquid-async]').each(function () {
     const that = this,
-      data = { text: $(that).attr("data-content") },
-      $spinner = $(that).prev().find("[data-behavior~=liquid-spinner");
+      data = { text: $(that).attr('data-content') },
+      $spinner = $(that).prev().find('[data-behavior~=liquid-spinner');
 
-    const requiresSortUpdate = $(that).is("[data-sort]");
+    const requiresSortUpdate = $(that).is('[data-sort]');
 
-    fetch($(that).attr("data-path"), {
-      method: "POST",
+    fetch($(that).attr('data-path'), {
+      method: 'POST',
       headers: {
-        Accept: "text/html",
-        "Content-Type": "application/json",
-        "X-CSRF-Token": $('meta[name="csrf-token"]').attr("content"),
+        Accept: 'text/html',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
       },
       body: JSON.stringify(data),
     })
@@ -28,13 +28,13 @@ function liquidAsync() {
           updateLiquidSortValue(that, html);
         }
 
-        $(that).trigger("dradis:liquid-rendered");
-        $spinner.addClass("d-none");
+        $(that).trigger('dradis:liquid-rendered');
+        $spinner.addClass('d-none');
       });
   });
 }
 
-document.addEventListener("turbo:load", liquidAsync);
-$(document).on("dradis:fetch", function () {
+document.addEventListener('turbo:load', liquidAsync);
+$(document).on('dradis:fetch', function () {
   liquidAsync();
 });

--- a/app/assets/javascripts/hera/modules/liquid_async.js
+++ b/app/assets/javascripts/hera/modules/liquid_async.js
@@ -1,22 +1,22 @@
 function updateLiquidSortValue(element, html) {
-  const liquidText = $('<div>').html(html).text().trim();
-  $(element).attr('data-sort', liquidText);
+  const liquidText = $("<div>").html(html).text().trim();
+  $(element).attr("data-sort", liquidText);
 }
 
 function liquidAsync() {
-  $('[data-behavior~=liquid-async]').each(function () {
+  $("[data-behavior~=liquid-async]").each(function () {
     const that = this,
-      data = { text: $(that).attr('data-content') },
-      $spinner = $(that).prev().find('[data-behavior~=liquid-spinner');
+      data = { text: $(that).attr("data-content") },
+      $spinner = $(that).prev().find("[data-behavior~=liquid-spinner");
 
-    const requiresSortUpdate = $(that).is('[data-sort]');
+    const requiresSortUpdate = $(that).is("[data-sort]");
 
-    fetch($(that).attr('data-path'), {
-      method: 'POST',
+    fetch($(that).attr("data-path"), {
+      method: "POST",
       headers: {
-        Accept: 'text/html',
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
+        Accept: "text/html",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": $('meta[name="csrf-token"]').attr("content"),
       },
       body: JSON.stringify(data),
     })
@@ -28,13 +28,13 @@ function liquidAsync() {
           updateLiquidSortValue(that, html);
         }
 
-        $(that).trigger('dradis:liquid-rendered');
-        $spinner.addClass('d-none');
+        $(that).trigger("dradis:liquid-rendered");
+        $spinner.addClass("d-none");
       });
   });
 }
 
-document.addEventListener('turbo:load', liquidAsync);
-$(document).on('dradis:fetch', function () {
+document.addEventListener("turbo:load", liquidAsync);
+$(document).on("dradis:fetch", function () {
   liquidAsync();
 });

--- a/app/controllers/issues/evidence_controller.rb
+++ b/app/controllers/issues/evidence_controller.rb
@@ -2,13 +2,15 @@ class Issues::EvidenceController < AuthenticatedController
   include ActivityTracking
   include ContentFromTemplate
   include DynamicFieldNamesCacher
+  include LiquidEnabledResource
   include MultipleDestroy
   include ProjectScoped
 
-  before_action :set_issues, only: [:create_multiple, :index, :new]
+  before_action :set_issues, only: [:create_multiple, :index, :new, :preview]
   before_action :set_affected_nodes, only: :index
   before_action :set_auto_save_key, only: :new
   before_action :set_columns, only: :index
+  before_action :set_evidence, only: :preview
 
   def index
     render layout: false
@@ -78,6 +80,10 @@ class Issues::EvidenceController < AuthenticatedController
     params.require(:evidence).permit(:author, :content, :issue_id, :node_id)
   end
 
+  def liquid_resource_assigns
+    { 'evidence' => EvidenceDrop.new(@evidence) }
+  end
+
   def node_params_empty?
     params[:evidence][:node_list].blank? &&
       (params[:evidence][:node_ids].reject(&:empty?).empty?)
@@ -112,6 +118,10 @@ class Issues::EvidenceController < AuthenticatedController
     else
       "issue-#{params[:issue_id]}-evidence"
     end
+  end
+
+  def set_evidence
+    @evidence = @issue.evidence.find_by(id: params[:id])
   end
 
   def set_issues

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -55,7 +55,7 @@
                   data_attrs[:behavior] = class_names(data_attrs[:behavior], 'liquid-async')
                   data_attrs[:path]     = preview_project_issue_path(current_project, issue)
                   data_attrs[:content]  = field_content
-                  [field_content, field_content]
+                  [field_content, spinner_tag(inline: true, spinner_class: 'spinner-border-sm text-primary')]
                 end
               %>
               <%= content_tag :td,

--- a/app/views/issues/_table.html.erb
+++ b/app/views/issues/_table.html.erb
@@ -26,6 +26,7 @@
           <tr id="issue-<%= issue.id %>" data-tag-url="<%= project_issue_path(current_project, issue) %>">
             <td class="select-checkbox" data-behavior="select-checkbox"></td>
             <% @all_columns.each do |column| %>
+              <% data_attrs = { behavior: class_names(tag: column == 'Tags') } %>
               <% sort, display =
                 case column
                 when 'Title'
@@ -50,16 +51,17 @@
                 when 'Updated'
                   [issue.updated_at.to_i, local_time_ago(issue.updated_at)]
                 else
-                  [issue.fields.fetch(column, ''), markup(issue.fields.fetch(column, ''))]
+                  field_content = issue.fields.fetch(column, '')
+                  data_attrs[:behavior] = class_names(data_attrs[:behavior], 'liquid-async')
+                  data_attrs[:path]     = preview_project_issue_path(current_project, issue)
+                  data_attrs[:content]  = field_content
+                  [field_content, field_content]
                 end
               %>
               <%= content_tag :td,
                   display,
                   class: class_names('text-break-spaces': column == 'Affected'),
-                  data: {
-                    behavior: class_names(tag: column == 'Tags'),
-                    sort: sort
-                  }
+                  data: data_attrs.merge({ sort: sort })
               %>
             <% end %>
             <td class="column-actions">

--- a/app/views/issues/evidence/_table.html.erb
+++ b/app/views/issues/evidence/_table.html.erb
@@ -36,7 +36,7 @@
                 data_attrs[:behavior] = 'liquid-async'
                 data_attrs[:path]     = preview_project_issue_evidence_path(current_project, @issue, evidence)
                 data_attrs[:content]  = field_content
-                [field_content, field_content]
+                [field_content, spinner_tag(inline: true, spinner_class: 'spinner-border-sm text-primary')]
               end
             %>
             <%= content_tag :td, display, data: data_attrs.merge({ sort: sort }) %>

--- a/app/views/issues/evidence/_table.html.erb
+++ b/app/views/issues/evidence/_table.html.erb
@@ -19,6 +19,7 @@
         <tr id="evidence-<%= evidence.id %>">
           <td class="select-checkbox" data-behavior="select-checkbox"></td>
           <% @all_columns.each do |column| %>
+            <% data_attrs = {} %>
             <%
               sort, display =
               case column
@@ -31,10 +32,14 @@
               when 'Updated'
                 [evidence.updated_at.to_i, local_time_ago(evidence.updated_at)]
               else
-                [evidence.fields.fetch(column, ''), markup(evidence.fields.fetch(column, ''))]
+                field_content = evidence.fields.fetch(column, '')
+                data_attrs[:behavior] = 'liquid-async'
+                data_attrs[:path]     = preview_project_issue_evidence_path(current_project, @issue, evidence)
+                data_attrs[:content]  = field_content
+                [field_content, field_content]
               end
             %>
-            <td data-sort="<%= sort %>"><%= display %></td>
+            <%= content_tag :td, display, data: data_attrs.merge({ sort: sort }) %>
           <% end  %>
           <td class="column-actions">
             <%= link_to edit_project_node_evidence_path(current_project, node, evidence, return_to: :issue) do %>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -55,7 +55,7 @@
                 data_attrs[:behavior] = 'liquid-async'
                 data_attrs[:path]     = preview_path
                 data_attrs[:content]  = field_content
-                [field_content, field_content]
+                [field_content, spinner_tag(inline: true, spinner_class: 'spinner-border-sm text-primary')]
               end
               %>
               <%= content_tag :td, display, data: data_attrs.merge({ sort: sort }) %>

--- a/app/views/nodes/items_table/_table.html.erb
+++ b/app/views/nodes/items_table/_table.html.erb
@@ -23,6 +23,7 @@
           <tr id="<%= class_name %>-<%= item.id %>">
             <td class="select-checkbox" data-behavior="select-checkbox"></td>
             <% columns.each do |column| %>
+              <% data_attrs = {} %>
               <%
               sort, display =
               case column
@@ -47,10 +48,17 @@
               when 'Updated'
                 [item.updated_at.to_i, local_time_ago(item.updated_at)]
               else
-                [item.fields.fetch(column, ''), markup(item.fields.fetch(column, ''))]
+                field_content = item.fields.fetch(column, '')
+                preview_path  = item.is_a?(Evidence) \
+                  ? preview_project_node_evidence_path(current_project, @node, item) \
+                  : preview_project_node_note_path(current_project, @node, item)
+                data_attrs[:behavior] = 'liquid-async'
+                data_attrs[:path]     = preview_path
+                data_attrs[:content]  = field_content
+                [field_content, field_content]
               end
               %>
-              <td data-sort="<%= sort %>"><%= display %></td>
+              <%= content_tag :td, display, data: data_attrs.merge({ sort: sort }) %>
             <% end %>
             <td class="column-actions">
               <%= link_to [:edit, @node.project, @node, item] do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
         resources :merge, only: [:new, :create], controller: 'issues/merge'
       end
 
-      resources :evidence, concerns: :multiple_destroy, controller: 'issues/evidence', only: [:index, :new]
+      resources :evidence, concerns: [:multiple_destroy, :previewable], controller: 'issues/evidence', only: [:index, :new]
       resources :nodes, only: [:show], controller: 'issues/nodes'
       resources :revisions, only: [:index, :show]
     end


### PR DESCRIPTION
### Summary

render Liquid content in issue/evidence table columns asynchronously

### Other Information

Custom fields containing Liquid (e.g. `{{ project.name }}`) were showing raw markup in the Issues, Issue Evidence, and Node items tables. Each custom-field `<td>` now gets `data-behavior="liquid-async"` with a path pointing to the record's preview endpoint, and `liquid_async.js` resolves it after page load. A small spinner shows while the request is in flight. Sort values are updated post-render so DataTables sorts on the evaluated text.

The only new wiring beyond the view changes is adding `:preview` to the `issues/evidence` routes and controller (that controller previously only had `:index` and `:new`).

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.