### PR TITLE
render Liquid fields by default via thread-local context

### DIFF
--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -10,13 +10,6 @@ module LiquidEnabledResource
     @liquid_assigns ||= default_liquid_assigns.merge!(liquid_resource_assigns)
   end
 
-  def with_liquid_render_context
-    LiquidRenderContext.set(-> { liquid_assigns })
-    yield
-  ensure
-    LiquidRenderContext.clear
-  end
-
   # To be overwritten by each controller
   def liquid_resource_assigns
     {}
@@ -25,6 +18,13 @@ module LiquidEnabledResource
   def preview
     @text = params[:text]
     render 'markup/preview', layout: false
+  end
+
+  def with_liquid_render_context
+    LiquidRenderContext.set(-> { liquid_assigns })
+    yield
+  ensure
+    LiquidRenderContext.clear
   end
 
   private

--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -2,11 +2,19 @@ module LiquidEnabledResource
   extend ActiveSupport::Concern
 
   included do
+    around_action :with_liquid_render_context
     helper_method :liquid_assigns
   end
 
   def liquid_assigns
     @liquid_assigns ||= default_liquid_assigns.merge!(liquid_resource_assigns)
+  end
+
+  def with_liquid_render_context
+    LiquidRenderContext.set(-> { liquid_assigns })
+    yield
+  ensure
+    LiquidRenderContext.clear
   end
 
   # To be overwritten by each controller

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -1,0 +1,13 @@
+module LiquidRenderContext
+  def self.current
+    Thread.current[:liquid_render_context]&.call
+  end
+
+  def self.set(assigns_provider)
+    Thread.current[:liquid_render_context] = assigns_provider
+  end
+
+  def self.clear
+    Thread.current[:liquid_render_context] = nil
+  end
+end

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -1,13 +1,13 @@
 module LiquidRenderContext
+  def self.clear
+    Thread.current[:liquid_render_context] = nil
+  end
+
   def self.current
     Thread.current[:liquid_render_context]&.call
   end
 
   def self.set(assigns_provider)
     Thread.current[:liquid_render_context] = assigns_provider
-  end
-
-  def self.clear
-    Thread.current[:liquid_render_context] = nil
   end
 end

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -49,9 +49,11 @@ module HasFields
         return raw unless ctx
 
         @_rendered_fields ||= raw.transform_values do |v|
-          Liquid::Template.parse(v.to_s).render(ctx, strict_variables: true, strict_filters: true).strip
-        rescue StandardError
-          v
+          begin
+            Liquid::Template.parse(v.to_s).render(ctx, filters: [], strict_filters: true, strict_variables: true).strip
+          rescue Liquid::Error
+            v
+          end
         end
       end
 

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -35,11 +35,23 @@ module HasFields
     # If the given field format does not conform to the expected syntax, an
     # empty Hash is returned.
     def dradis_has_fields_for(container_field)
-      define_method :fields do
+      define_method :raw_fields do
         if raw_content = self.send(container_field)
           local_fields.merge(FieldParser.source_to_fields(raw_content))
-        else # if the container field is empty, just return an empty hash:
+        else
           {}
+        end
+      end
+
+      define_method :fields do
+        raw = raw_fields
+        ctx = LiquidRenderContext.current
+        return raw unless ctx
+
+        @_rendered_fields ||= raw.transform_values do |v|
+          Liquid::Template.parse(v.to_s).render(ctx, strict_variables: true, strict_filters: true).strip
+        rescue StandardError
+          v
         end
       end
 
@@ -59,16 +71,16 @@ module HasFields
       #   evidence.set_field "Foo", "Buzz"
       #
       define_method :set_field do |field, value|
-        # Don't use 'fields' as a local variable name or it conflicts with the
-        # #fields getter method
-        updated_fields = fields
+        @_rendered_fields = nil
+        updated_fields = raw_fields
         updated_fields[field] = value
         self.update_container(container_field, updated_fields)
       end
 
       # Completely removes the field (field header and value) from the content
       define_method :delete_field do |field|
-        updated_fields = fields
+        @_rendered_fields = nil
+        updated_fields = raw_fields
         updated_fields.except!(field)
         self.update_container(container_field, updated_fields)
       end

--- a/app/services/diffed_content.rb
+++ b/app/services/diffed_content.rb
@@ -23,12 +23,12 @@ class DiffedContent
   def unsynced_fields
     @unsynced_fields ||=
       begin
-        fields = @source.fields.except(*EXCLUDED_FIELDS).keys |
-          @target.fields.except(*EXCLUDED_FIELDS).keys
+        fields = @source.raw_fields.except(*EXCLUDED_FIELDS).keys |
+          @target.raw_fields.except(*EXCLUDED_FIELDS).keys
 
         fields.filter_map do |field|
-          source_value = source.fields[field] || ''
-          target_value = target.fields[field] || ''
+          source_value = source.raw_fields[field] || ''
+          target_value = target.raw_fields[field] || ''
 
           if source_value != target_value
             [field, diff_by_word(source_value, target_value)]
@@ -64,17 +64,17 @@ class DiffedContent
   # 2) If the source record is missing the field, delete the field in the
   #   target record
   def content_with_updated_field_from_target(field:, source:, target:)
-    source_fields = source.fields.keys
+    source_fields = source.raw_fields.keys
     source_index = source_fields.excluding(*EXCLUDED_FIELDS).index(field)
 
     # Case 1)
     if source_fields.include?(field)
       # Case 1.1)
-      if target.fields.keys.include?(field)
-        target.set_field(field, source.fields[field])
+      if target.raw_fields.keys.include?(field)
+        target.set_field(field, source.raw_fields[field])
       # Case 1.2)
       else
-        updated_fields = target.fields.to_a.insert(source_index, [field, source.fields[field]])
+        updated_fields = target.raw_fields.to_a.insert(source_index, [field, source.raw_fields[field]])
         FieldParser.fields_hash_to_source(updated_fields.compact)
       end
     # Case 2)
@@ -89,7 +89,7 @@ class DiffedContent
   end
 
   def normalize_content(record)
-    fields = record.fields.except(*EXCLUDED_FIELDS)
+    fields = record.raw_fields.except(*EXCLUDED_FIELDS)
 
     record.content =
       fields.map do |field, value|


### PR DESCRIPTION
## Summary

This is a proof of concept for a render-by-default architecture where `issue.fields`, `issue.title`, and equivalent evidence/note accessors return Liquid-rendered values automatically in request contexts, with no view changes required.

Three moving parts, all in CE:

**1. `LiquidRenderContext` (`app/lib/liquid_render_context.rb`, new)**
Thread-local context holder. Controllers set a lazy evaluator (proc) before the view renders; it is cleared in an `ensure` block. The lazy proc defers `liquid_assigns` evaluation until the first field access, after all `before_actions` have run.

**2. `HasFields#dradis_has_fields_for`**
`raw_fields` contains the existing parser logic, unchanged. `fields` calls `raw_fields`, renders Liquid values when a context is present, and memoizes the result on the instance. `set_field` and `delete_field` now write through `raw_fields` so rendered output is never saved back to the database. `title` inherits rendering automatically since it delegates to `fields.fetch('Title', ...)`.

**3. `LiquidEnabledResource`**
One `around_action :with_liquid_render_context` added to the concern already included by `IssuesController`, `EvidenceController`, `NotesController`, and others. No per-controller changes needed.

**`DiffedContent`** updated throughout to call `raw_fields` instead of `fields` so sync/diff operations always work with raw Liquid templates and cannot write rendered output back to the database.

## Verified

- Issue with `{{ project.name }}` in Title: index table, show heading, breadcrumb, and page `<title>` all render the project name
- Edit form textarea shows the raw Liquid template (form binds to `:text`, not `fields`)
- Background/API contexts never set a context, so `fields` returns raw values, unchanged behavior

## Check List

- [ ] Added a CHANGELOG entry
- [ ] Commit message has a detailed description of what changed and why.