### PR TITLE
Render Liquid fields by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ v5.0.1 (April 2026)
 
 v5.0.0 (March 2026)
   - Activities: Remove ActivityTracking for Issues and use EventPublisher
+  - Liquid: render field values as Liquid templates during requests; use raw_fields to access unrendered values
   - Docker:
     - Update default attachments & templates locations to storage/
     - Include assets for all integrations regardless of enabled/disabled status

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 [v#.#.#] ([month] [YYYY])
   - [entity]:
     - [future tense verb] [feature]
+  - Liquid: render field values as Liquid templates during requests; use raw_fields to access unrendered values
   - Mail: add support for SMTP configuration via environment variables for Docker deployments; smtp.yml remains supported for VM deployments during the deprecation transition
   - Upgraded gems:
     - [gem]
@@ -35,7 +36,6 @@ v5.0.1 (April 2026)
 
 v5.0.0 (March 2026)
   - Activities: Remove ActivityTracking for Issues and use EventPublisher
-  - Liquid: render field values as Liquid templates during requests; use raw_fields to access unrendered values
   - Docker:
     - Update default attachments & templates locations to storage/
     - Include assets for all integrations regardless of enabled/disabled status

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 
 class ApplicationController < ActionController::Base
   include Authentication
+  include LiquidEnabledResource
   include Turbo::Redirection
 
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -10,13 +10,6 @@ module LiquidEnabledResource
     @liquid_assigns ||= default_liquid_assigns.merge!(liquid_resource_assigns)
   end
 
-  def with_liquid_render_context
-    LiquidRenderContext.set(-> { liquid_assigns })
-    yield
-  ensure
-    LiquidRenderContext.clear
-  end
-
   # To be overwritten by each controller
   def liquid_resource_assigns
     {}
@@ -25,6 +18,13 @@ module LiquidEnabledResource
   def preview
     @text = params[:text]
     render 'markup/preview', layout: false
+  end
+
+  def with_liquid_render_context
+    LiquidRenderContext.set(-> { liquid_assigns })
+    yield
+  ensure
+    LiquidRenderContext.clear
   end
 
   private

--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -7,7 +7,13 @@ module LiquidEnabledResource
   end
 
   def liquid_assigns
-    @liquid_assigns ||= default_liquid_assigns.merge!(liquid_resource_assigns)
+    # allows liquid_resource_assigns to be set even without project-level assigns
+    @liquid_assigns ||= begin
+      base = default_liquid_assigns
+      extra = liquid_resource_assigns
+      return nil if base.nil? && extra.empty?
+      (base || {}).merge!(extra)
+    end
   end
 
   # To be overwritten by each controller
@@ -35,11 +41,7 @@ module LiquidEnabledResource
   private
 
   def default_liquid_assigns
-    if params[:project_id]
-      project_assigns
-    else
-      {}
-    end
+    project_assigns if params[:project_id]
   end
 
   def project_assigns

--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -2,7 +2,7 @@ module LiquidEnabledResource
   extend ActiveSupport::Concern
 
   included do
-    around_action :with_liquid_render_context
+    around_action :liquid_render_context
     helper_method :liquid_assigns
   end
 
@@ -20,7 +20,12 @@ module LiquidEnabledResource
     render 'markup/preview', layout: false
   end
 
-  def with_liquid_render_context
+  # Makes Liquid assigns available to HasFields#fields for the duration of the request,
+  # so field values are rendered as Liquid templates. 
+  # `around_action` ensures cleanup via ensure even when the action raises
+  # The proc defers liquid_assigns evaluation until first use, after all before_actions
+  # have run and liquid_resource_assigns has had a chance to merge in resource-specific assigns.
+  def liquid_render_context
     LiquidRenderContext.set(-> { liquid_assigns })
     yield
   ensure

--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -2,11 +2,19 @@ module LiquidEnabledResource
   extend ActiveSupport::Concern
 
   included do
+    around_action :with_liquid_render_context
     helper_method :liquid_assigns
   end
 
   def liquid_assigns
     @liquid_assigns ||= default_liquid_assigns.merge!(liquid_resource_assigns)
+  end
+
+  def with_liquid_render_context
+    LiquidRenderContext.set(-> { liquid_assigns })
+    yield
+  ensure
+    LiquidRenderContext.clear
   end
 
   # To be overwritten by each controller

--- a/app/controllers/concerns/liquid_enabled_resource.rb
+++ b/app/controllers/concerns/liquid_enabled_resource.rb
@@ -21,7 +21,7 @@ module LiquidEnabledResource
   end
 
   # Makes Liquid assigns available to HasFields#fields for the duration of the request,
-  # so field values are rendered as Liquid templates. 
+  # so field values are rendered as Liquid templates.
   # `around_action` ensures cleanup via ensure even when the action raises
   # The proc defers liquid_assigns evaluation until first use, after all before_actions
   # have run and liquid_resource_assigns has had a chance to merge in resource-specific assigns.

--- a/app/controllers/concerns/project_scoped.rb
+++ b/app/controllers/concerns/project_scoped.rb
@@ -1,6 +1,8 @@
 module ProjectScoped
   extend ActiveSupport::Concern
 
+  include LiquidEnabledResource
+
   included do
     before_action :set_project
     before_action :set_nodes

--- a/app/controllers/concerns/project_scoped.rb
+++ b/app/controllers/concerns/project_scoped.rb
@@ -1,8 +1,6 @@
 module ProjectScoped
   extend ActiveSupport::Concern
 
-  include LiquidEnabledResource
-
   included do
     before_action :set_project
     before_action :set_nodes

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -2,7 +2,6 @@ class EvidenceController < NestedNodeResourceController
   include AttachmentsCopier
   include ConflictResolver
   include EvidenceHelper
-  include LiquidEnabledResource
   include Mentioned
   include MultipleDestroy
   include NodesSidebar

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -135,7 +135,7 @@ class EvidenceController < NestedNodeResourceController
   end
 
   def set_auto_save_key
-    @auto_save_key =  if @evidence&.persisted?
+    @auto_save_key = if @evidence&.persisted?
       "evidence-#{@evidence.id}"
     elsif params[:template]
       "node-#{@node.id}-evidence-#{params[:template]}"

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -4,7 +4,6 @@ class IssuesController < AuthenticatedController
   include DynamicFieldNamesCacher
   include EventPublisher
   include IssuesHelper
-  include LiquidEnabledResource
   include Mentioned
   include MultipleDestroy
   include NotificationsReader

--- a/app/controllers/markup_controller.rb
+++ b/app/controllers/markup_controller.rb
@@ -1,5 +1,4 @@
 class MarkupController < AuthenticatedController
-  include LiquidEnabledResource
   layout false
 
   # Returns the markup cheatsheet that is used by the jQuery.Textile plugin Help

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,7 +3,6 @@
 class NotesController < NestedNodeResourceController
   include AttachmentsCopier
   include ConflictResolver
-  include LiquidEnabledResource
   include Mentioned
   include MultipleDestroy
   include NodesSidebar

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -1,6 +1,5 @@
 class QA::IssuesController < AuthenticatedController
   include ActivityTracking
-  include LiquidEnabledResource
   include Mentioned
   include ProjectScoped
   include Publishable

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -16,7 +16,7 @@ module LiquidRenderContext
     value
   end
 
-  def self.set(assigns_provider)
-    Thread.current[:liquid_render_context] = assigns_provider
+  def self.set(assigns)
+    Thread.current[:liquid_render_context] = assigns
   end
 end

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -1,0 +1,13 @@
+module LiquidRenderContext
+  def self.current
+    Thread.current[:liquid_render_context]&.call
+  end
+
+  def self.set(assigns_provider)
+    Thread.current[:liquid_render_context] = assigns_provider
+  end
+
+  def self.clear
+    Thread.current[:liquid_render_context] = nil
+  end
+end

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -7,6 +7,15 @@ module LiquidRenderContext
     Thread.current[:liquid_render_context]&.call
   end
 
+  def self.render(value)
+    assigns = current
+    return value unless assigns
+
+    HTML::Pipeline::Dradis::LiquidFilter.call(value, liquid_assigns: assigns)
+  rescue Liquid::Error
+    value
+  end
+
   def self.set(assigns_provider)
     Thread.current[:liquid_render_context] = assigns_provider
   end

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -1,13 +1,13 @@
 module LiquidRenderContext
+  def self.clear
+    Thread.current[:liquid_render_context] = nil
+  end
+
   def self.current
     Thread.current[:liquid_render_context]&.call
   end
 
   def self.set(assigns_provider)
     Thread.current[:liquid_render_context] = assigns_provider
-  end
-
-  def self.clear
-    Thread.current[:liquid_render_context] = nil
   end
 end

--- a/app/lib/liquid_render_context.rb
+++ b/app/lib/liquid_render_context.rb
@@ -17,6 +17,6 @@ module LiquidRenderContext
   end
 
   def self.set(assigns)
-    Thread.current[:liquid_render_context] = assigns
+    Thread.current[:liquid_render_context] = assigns.respond_to?(:call) ? assigns : -> { assigns }
   end
 end

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -49,9 +49,11 @@ module HasFields
         return raw unless ctx
 
         @_rendered_fields ||= raw.transform_values do |v|
-          Liquid::Template.parse(v.to_s).render(ctx, strict_variables: true, strict_filters: true).strip
-        rescue StandardError
-          v
+          begin
+            Liquid::Template.parse(v.to_s).render(ctx, filters: [], strict_filters: true, strict_variables: true).strip
+          rescue Liquid::Error
+            v
+          end
         end
       end
 

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -45,16 +45,17 @@ module HasFields
 
       define_method :fields do
         raw = raw_fields
-        ctx = LiquidRenderContext.current
-        return raw unless ctx
+        return raw unless LiquidRenderContext.current
+        return @_rendered_fields if @_rendered_fields
+        return raw if @_rendering_fields
 
-        @_rendered_fields ||= raw.transform_values do |v|
-          begin
-            Liquid::Template.parse(v.to_s).render(ctx, filters: [], strict_filters: true, strict_variables: true).strip
-          rescue Liquid::Error
-            v
-          end
+        @_rendering_fields = true
+        begin
+          @_rendered_fields = raw.transform_values { |v| LiquidRenderContext.render(v) }
+        ensure
+          @_rendering_fields = false
         end
+        @_rendered_fields
       end
 
       # Setting fields using model.fields["field_name"] = "value" currently

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -35,11 +35,23 @@ module HasFields
     # If the given field format does not conform to the expected syntax, an
     # empty Hash is returned.
     def dradis_has_fields_for(container_field)
-      define_method :fields do
+      define_method :raw_fields do
         if raw_content = self.send(container_field)
           local_fields.merge(FieldParser.source_to_fields(raw_content))
-        else # if the container field is empty, just return an empty hash:
+        else
           {}
+        end
+      end
+
+      define_method :fields do
+        raw = raw_fields
+        ctx = LiquidRenderContext.current
+        return raw unless ctx
+
+        @_rendered_fields ||= raw.transform_values do |v|
+          Liquid::Template.parse(v.to_s).render(ctx, strict_variables: true, strict_filters: true).strip
+        rescue StandardError
+          v
         end
       end
 
@@ -59,16 +71,16 @@ module HasFields
       #   evidence.set_field "Foo", "Buzz"
       #
       define_method :set_field do |field, value|
-        # Don't use 'fields' as a local variable name or it conflicts with the
-        # #fields getter method
-        updated_fields = fields
+        @_rendered_fields = nil
+        updated_fields = raw_fields
         updated_fields[field] = value
         self.update_container(container_field, updated_fields)
       end
 
       # Completely removes the field (field header and value) from the content
       define_method :delete_field do |field|
-        updated_fields = fields
+        @_rendered_fields = nil
+        updated_fields = raw_fields
         updated_fields.except!(field)
         self.update_container(container_field, updated_fields)
       end

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -47,6 +47,11 @@ module HasFields
         raw = raw_fields
         return raw unless LiquidRenderContext.current
         return @_rendered_fields if @_rendered_fields
+
+        # Guard against reentrancy: a Drop accessing this record's fields during
+        # LiquidFilter evaluation would loop infinitely. While rendering is in progress, return raw values to break the cycle.
+        # ensure is scoped to the begin block below, not the method — an ensure on
+        # the method fires on all return paths and would clear the flag prematurely.
         return raw if @_rendering_fields
 
         @_rendering_fields = true

--- a/app/services/diffed_content.rb
+++ b/app/services/diffed_content.rb
@@ -23,12 +23,12 @@ class DiffedContent
   def unsynced_fields
     @unsynced_fields ||=
       begin
-        fields = @source.fields.except(*EXCLUDED_FIELDS).keys |
-          @target.fields.except(*EXCLUDED_FIELDS).keys
+        fields = @source.raw_fields.except(*EXCLUDED_FIELDS).keys |
+          @target.raw_fields.except(*EXCLUDED_FIELDS).keys
 
         fields.filter_map do |field|
-          source_value = source.fields[field] || ''
-          target_value = target.fields[field] || ''
+          source_value = source.raw_fields[field] || ''
+          target_value = target.raw_fields[field] || ''
 
           if source_value != target_value
             [field, diff_by_word(source_value, target_value)]
@@ -64,17 +64,17 @@ class DiffedContent
   # 2) If the source record is missing the field, delete the field in the
   #   target record
   def content_with_updated_field_from_target(field:, source:, target:)
-    source_fields = source.fields.keys
+    source_fields = source.raw_fields.keys
     source_index = source_fields.excluding(*EXCLUDED_FIELDS).index(field)
 
     # Case 1)
     if source_fields.include?(field)
       # Case 1.1)
-      if target.fields.keys.include?(field)
-        target.set_field(field, source.fields[field])
+      if target.raw_fields.keys.include?(field)
+        target.set_field(field, source.raw_fields[field])
       # Case 1.2)
       else
-        updated_fields = target.fields.to_a.insert(source_index, [field, source.fields[field]])
+        updated_fields = target.raw_fields.to_a.insert(source_index, [field, source.raw_fields[field]])
         FieldParser.fields_hash_to_source(updated_fields.compact)
       end
     # Case 2)
@@ -89,7 +89,7 @@ class DiffedContent
   end
 
   def normalize_content(record)
-    fields = record.fields.except(*EXCLUDED_FIELDS)
+    fields = record.raw_fields.except(*EXCLUDED_FIELDS)
 
     record.content =
       fields.map do |field, value|

--- a/engines/dradis-api/app/controllers/dradis/ce/api/api_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/api_controller.rb
@@ -2,6 +2,8 @@ module Dradis::CE::API
   class APIController < ApplicationController
     after_action :skip_set_cookies_header
 
+    skip_around_action :liquid_render_context
+
     before_action :api_authentication_required
     before_action :json_required, only: [:create, :update]
     before_action :set_paper_trail_whodunnit

--- a/spec/lib/liquid_render_context_spec.rb
+++ b/spec/lib/liquid_render_context_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe LiquidRenderContext do
+  after { described_class.clear }
+
+  describe '.set and .current' do
+    it 'evaluates the stored proc on access' do
+      assigns = { 'key' => 'value' }
+      described_class.set(-> { assigns })
+      expect(described_class.current).to eq(assigns)
+    end
+  end
+
+  describe '.clear' do
+    it 'removes the stored context' do
+      described_class.set(-> { {} })
+      described_class.clear
+      expect(described_class.current).to be_nil
+    end
+  end
+
+  describe '.render' do
+    context 'without a render context' do
+      it 'returns the value unchanged' do
+        expect(described_class.render('{{project.name}}')).to eq('{{project.name}}')
+      end
+    end
+
+    context 'with a render context' do
+      let(:project) { create(:project, name: 'ACME Corp') }
+      let(:assigns) { LiquidCachedAssigns.new(project: project) }
+
+      before { described_class.set(-> { assigns }) }
+
+      it 'renders Liquid templates against the assigns' do
+        expect(described_class.render('{{project.name}}')).to eq('ACME Corp')
+      end
+
+      it 'returns the raw value when a Liquid::Error is raised' do
+        allow(HTML::Pipeline::Dradis::LiquidFilter).to receive(:call).and_raise(Liquid::Error)
+        expect(described_class.render('{{invalid}}')).to eq('{{invalid}}')
+      end
+    end
+  end
+end

--- a/spec/support/has_fields_shared_examples.rb
+++ b/spec/support/has_fields_shared_examples.rb
@@ -23,4 +23,45 @@ shared_examples "a model that has fields" do |model|
     end
   end
 
+  describe '#fields' do
+    let(:record) { model.new(fields_column => "#[Title]#\n{{project.name}}") }
+
+    context 'without a Liquid render context' do
+      it 'returns raw field values' do
+        expect(record.fields['Title']).to eq('{{project.name}}')
+      end
+    end
+
+    context 'with a Liquid render context' do
+      around do |example|
+        LiquidRenderContext.set(-> { {} })
+        example.run
+      ensure
+        LiquidRenderContext.clear
+      end
+
+      before do
+        allow(LiquidRenderContext).to receive(:render) { |v| "rendered:#{v}" }
+      end
+
+      it 'renders each field value through the Liquid context' do
+        expect(record.fields['Title']).to eq('rendered:{{project.name}}')
+      end
+
+      it 'caches the rendered result' do
+        expect(record.fields).to be(record.fields)
+      end
+    end
+  end
+
+  describe '#raw_fields' do
+    it 'always returns unrendered values regardless of render context' do
+      LiquidRenderContext.set(-> { {} })
+      record = model.new(fields_column => "#[Title]#\n{{project.name}}")
+      expect(record.raw_fields['Title']).to eq('{{project.name}}')
+    ensure
+      LiquidRenderContext.clear
+    end
+  end
+
 end


### PR DESCRIPTION
## Problem

Liquid template tags in field values (e.g. \`{{ project.name }}\` in a Title or Description field) were not evaluated automatically. Each view that wanted rendered output had to opt in explicitly — calling a helper, passing assigns, or wiring up a filter. This led to inconsistent behaviour: the same field could appear raw in one place and rendered in another, and new views silently showed unrendered templates.

## Solution

Render-by-default: \`fields\` and \`title\` on models always return Liquid-evaluated values in request contexts. \`raw_fields\` is the explicit escape hatch, used only when editing, diffing, or writing to the database.

Three moving parts:

**1. `LiquidRenderContext` (`app/lib/liquid_render_context.rb`, new)**
- Thread-local context holder with \`set\`, \`clear\`, \`current\`, and \`render\`. 
- Controllers store a lazy proc before the action runs; \`render\` resolves it on first use — after all \`before_action\`s have run and instance variables are set (so that `liquid_resource_assigns` has been set). 
- Errors from Liquid evaluation fall back to the raw value rather than raising.

**2. \`HasFields#dradis_has_fields_for\`**
- `raw_fields` contains the existing parser logic, unchanged. 
- `fields` renders via `LiquidRenderContext.render` when a context is present and memoizes the result on the instance. 
- A reentrancy guard (`@_rendering_fields`) prevents infinite loops when a field value references the same record's fields via a drop (e.g. `{{ issue.fields['Impact'] }}` inside another field). 
- `set_field` and `delete_field` write through `raw_fields` so rendered output is never saved back to the database.
- `title` inherits rendering automatically since it delegates to `fields.fetch('Title', ...)`.

**3. `LiquidEnabledResource` + `ProjectScoped`**

- `with_liquid_render_context` lives in `LiquidEnabledResource`, which is now included by `ProjectScoped`. All project-scoped controllers get Liquid rendering automatically. Non-project controllers that need it (e.g. `MarkupController`) include `LiquidEnabledResource` directly.

**`DiffedContent`** is updated to use `raw_fields` so sync and diff operations always work on raw Liquid templates.

## Testing Steps
- Field containing \`{{ project.name }}\`: renders correctly in index tables, show headings, breadcrumbs, and page \`<title>\`
- Field containing cross-field references (e.g. \`{{ issue.fields['Impact'] }}\`): reentrancy guard prevents infinite loops, raw value returned as fallback
- Edit form shows the raw Liquid template (form binds to \`:text\`, not \`fields\`)
- Background and API contexts never set a \`LiquidRenderContext\`, so \`fields\` returns raw values — no behaviour change for jobs or API consumers

## Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.