### PR TITLE
cache Liquid-rendered fields in the DB, populated lazily on first read

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -174,7 +174,7 @@ class IssuesController < AuthenticatedController
     # index and a TOCTOR can appear between the Note read and the Issue.find
     Note.transaction do
       @unsorted_issues = Issue.where(node_id: @issuelib.id).select(
-        'notes.id, notes.author, notes.text, notes.state, '\
+        'notes.id, notes.author, notes.text, notes.state, notes.rendered_text, notes.node_id, '\
         'count(evidence.id) as affected_count, notes.created_at, notes.updated_at'
       ).
       joins('LEFT OUTER JOIN evidence on notes.id = evidence.issue_id').

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -30,45 +30,46 @@ module HasFields
   end
 
   module ClassMethods
-    # Method for models to define which attribute is to be converted to fields.
-    #
-    # If the given field format does not conform to the expected syntax, an
-    # empty Hash is returned.
     def dradis_has_fields_for(container_field)
-      define_method :fields do
+      rendered_field = :"rendered_#{container_field}"
+
+      # Always returns raw (unrendered) field values.
+      define_method :raw_fields do
         if raw_content = self.send(container_field)
           local_fields.merge(FieldParser.source_to_fields(raw_content))
-        else # if the container field is empty, just return an empty hash:
+        else
           {}
         end
       end
 
-      # Setting fields using model.fields["field_name"] = "value" currently
-      # doesn't work (the hash in local memory will change, but the underlying
-      # attribute in the ActiveRecord model won't be affected). So the
-      # following code won't do what you might expect:
-      #
-      #   evidence = Evidence.find(1)
-      #   evidence.content = "#[Foo]#\nBar"
-      #   evidence.fields["Foo"] = "Buzz"
-      #   evidence.save!
-      #   evidence.reload.content # => "#[Foo]#\nBar" # Oh noes! It hasn't changed
-      #
-      # So use set_field instead:
-      #
-      #   evidence.set_field "Foo", "Buzz"
-      #
+      # Returns Liquid-rendered field values. If a rendered cache exists,
+      # returns it directly. If not, renders lazily using the record's
+      # project context, writes the result to the cache, and returns it.
+      define_method :fields do
+        @fields ||= if (cached = self.send(rendered_field)).present?
+          local_fields.merge(FieldParser.source_to_fields(cached))
+        else
+          assigns = LiquidCachedAssigns.new(project: node.project)
+
+          rendered = raw_fields.transform_values do |value|
+            HTML::Pipeline::Dradis::LiquidFilter.call(value, liquid_assigns: assigns)
+          rescue Liquid::Error
+            value
+          end
+
+          update_column(rendered_field, FieldParser.fields_hash_to_source(rendered))
+          local_fields.merge(FieldParser.source_to_fields(self.send(rendered_field)))
+        end
+      end
+
       define_method :set_field do |field, value|
-        # Don't use 'fields' as a local variable name or it conflicts with the
-        # #fields getter method
-        updated_fields = fields
+        updated_fields = raw_fields
         updated_fields[field] = value
         self.update_container(container_field, updated_fields)
       end
 
-      # Completely removes the field (field header and value) from the content
       define_method :delete_field do |field|
-        updated_fields = fields
+        updated_fields = raw_fields
         updated_fields.except!(field)
         self.update_container(container_field, updated_fields)
       end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -14,6 +14,8 @@ class Evidence < ApplicationRecord
   delegate :project, to: :node
 
   # -- Callbacks ------------------------------------------------------------
+  before_save { self[:rendered_content] = nil }
+  after_touch  { update_column(:rendered_content, nil) }
 
   # -- Validations ----------------------------------------------------------
   validates :content, length: { maximum: DB_MAX_TEXT_LENGTH }
@@ -33,7 +35,7 @@ class Evidence < ApplicationRecord
   def local_fields
     {
       'Label' => node.try(:label),
-      'Title' => issue.try(:title)
+      'Title' => issue&.raw_fields&.fetch('Title', nil)
     }
   end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -77,6 +77,11 @@ class Issue < Note
     self.category = Category.issue unless self.category
   end
 
+  # When an issue changes, evidence that references it via Liquid is stale.
+  # update_all clears the cache in one query without firing callbacks, avoiding
+  # a cascade through evidence's belongs_to :node, touch: true.
+  after_touch { evidence.update_all(rendered_content: nil) }
+
   # -- Validations ----------------------------------------------------------
 
   # -- Scopes ---------------------------------------------------------------

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -51,6 +51,9 @@ class Note < ApplicationRecord
   delegate :project, :project=, to: :node
 
   # -- Callbacks ------------------------------------------------------------
+  before_save { self[:rendered_text] = nil }
+  after_touch  { update_column(:rendered_text, nil) }
+
   # FIXME - ISSUE/NOTE INHERITANCE
   # `has_many :comments, dependent: :destroy` and
   # `has_many :subscriptions, dependent: :destroy`

--- a/db/migrate/20260504000001_add_rendered_cache_to_notes_and_evidence.rb
+++ b/db/migrate/20260504000001_add_rendered_cache_to_notes_and_evidence.rb
@@ -1,0 +1,6 @@
+class AddRenderedCacheToNotesAndEvidence < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notes, :rendered_text, :text
+    add_column :evidence, :rendered_content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_02_034852) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_04_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -124,6 +124,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_02_034852) do
     t.string "author"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.text "rendered_content"
     t.index ["issue_id"], name: "index_evidence_on_issue_id"
     t.index ["node_id"], name: "index_evidence_on_node_id"
   end
@@ -202,6 +203,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_02_034852) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "state", default: 0, null: false
+    t.text "rendered_text"
     t.index ["category_id"], name: "index_notes_on_category_id"
     t.index ["node_id"], name: "index_notes_on_node_id"
   end


### PR DESCRIPTION
## Summary

- Adds `rendered_text` (notes/issues) and `rendered_content` (evidence) cache columns via migration
- `HasFields#fields` renders lazily on first read: returns cached content if present, otherwise renders through Liquid using the record's project context, writes the result to the cache, and returns it
- `raw_fields` always returns unrendered values; used by `set_field`, `delete_field`, and cache population
- Cache is cleared on `before_save` and `after_touch` on Note and Evidence; Issue cascades to evidence via `update_all` to avoid touch callback chain
- `IssuesController#set_issues` includes `rendered_text` and `node_id` in its limited select to support lazy rendering on cache miss

## Test plan

- Visit issues index — verify Liquid variables render correctly on first load
- Edit an issue — verify rendered content updates after save
- Visit a node's evidence — verify Liquid variables render in evidence fields
- Update an issue — verify evidence cached renders are cleared and re-rendered on next read