### PR TITLE
bump addressable to 2.9.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
     - [future tense verb] [feature]
   - Mail: add support for SMTP configuration via environment variables for Docker deployments; smtp.yml remains supported for VM deployments during the deprecation transition
   - Upgraded gems:
-    - nokogiri, rack
+    - addressable, nokogiri, rack
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,8 +100,8 @@ GEM
       activerecord (>= 3.0)
     acts_as_tree (2.9.1)
       activerecord (>= 3.0.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
@@ -388,7 +388,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (5.0.3)
+    public_suffix (7.0.5)
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)


### PR DESCRIPTION
### Summary

Updates the `addressable` gem to 2.9.0 for a security fix.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.