### PR TITLE
Bump version to 5.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 v5.0.2 (May 2026)
+  - Update the Gemfile to use rubygems for dradis-pentera
   - Version bump to align with Pro
+  - Upgraded gems:
+    - addressable, nokogiri, rack
 
 v5.0.1 (April 2026)
   - Version bump to align with Pro

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v5.0.2 (May 2026)
+  - Version bump to align with Pro
+
 v5.0.1 (April 2026)
   - Version bump to align with Pro
 

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem 'bcrypt', '3.1.22'
 gem 'json', '2.3.0'
 
 # XML manipulation
-gem 'nokogiri', '>= 1.18.9'
+gem 'nokogiri', '>= 1.19.3'
 
 # MySQL backend
 # gem 'mysql2', '~> 0.5.6'
@@ -265,7 +265,7 @@ gem 'dradis-nipper', '~> 5.0.0'
 gem 'dradis-nmap', '~> 5.0.0'
 gem 'dradis-ntospider', '~> 5.0.0'
 gem 'dradis-openvas', '~> 5.0.0'
-gem 'dradis-pentera', github: 'dradis/dradis-pentera', branch: 'main'
+gem 'dradis-pentera', '~> 5.0.0'
 gem 'dradis-qualys', '~> 5.0.0'
 gem 'dradis-saint', '~> 5.0.0'
 gem 'dradis-veracode', '~> 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,13 @@ GIT
 PATH
   remote: engines/dradis-api
   specs:
-    dradis-api (5.0.1)
+    dradis-api (5.0.2)
       jbuilder
 
 PATH
   remote: engines/dradis-echo
   specs:
-    dradis-echo (5.0.1)
+    dradis-echo (5.0.2)
       dradis-plugins (>= 4.0)
       liquid
       ollama-ai (~> 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/dradis/dradis-pentera.git
-  revision: f24a97da349f2387ccac8f99cd6436b98ccfeb38
-  branch: main
-  specs:
-    dradis-pentera (5.0.0)
-      dradis-plugins (>= 4.0)
-
 PATH
   remote: engines/dradis-api
   specs:
@@ -100,8 +92,8 @@ GEM
       activerecord (>= 3.0)
     acts_as_tree (2.9.1)
       activerecord (>= 3.0.0)
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
@@ -196,6 +188,8 @@ GEM
     dradis-ntospider (5.0.0)
       dradis-plugins (>= 4.0)
     dradis-openvas (5.0.0)
+      dradis-plugins (>= 4.0)
+    dradis-pentera (5.0.0)
       dradis-plugins (>= 4.0)
     dradis-plugins (5.0.0)
     dradis-projects (5.0.0)
@@ -352,14 +346,14 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -388,11 +382,11 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (5.0.3)
+    public_suffix (7.0.5)
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.22)
+    rack (2.2.23)
     rack-mini-profiler (2.3.0)
       rack (>= 1.2.0)
     rack-protection (2.2.3)
@@ -648,7 +642,7 @@ DEPENDENCIES
   dradis-nmap (~> 5.0.0)
   dradis-ntospider (~> 5.0.0)
   dradis-openvas (~> 5.0.0)
-  dradis-pentera!
+  dradis-pentera (~> 5.0.0)
   dradis-plugins (~> 5.0.0)
   dradis-projects (~> 5.0.0)
   dradis-qualys (~> 5.0.0)
@@ -678,7 +672,7 @@ DEPENDENCIES
   net-imap (>= 0.5.7)
   net-pop
   net-smtp
-  nokogiri (>= 1.18.9)
+  nokogiri (>= 1.19.3)
   paper_trail (~> 16.0)
   parslet (~> 1.6.0)
   puma (>= 6.5.0)

--- a/lib/dradis/ce/version.rb
+++ b/lib/dradis/ce/version.rb
@@ -3,7 +3,7 @@ module Dradis
     module VERSION #:nodoc:
       MAJOR = 5
       MINOR = 0
-      TINY  = 1
+      TINY  = 2
       PRE = nil
 
       STRING = [[MAJOR, MINOR, TINY].join('.'), PRE].compact.join('-')


### PR DESCRIPTION
### Summary

Version bump to 5.0.2 for Pro parity

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
