### PR TITLE
upgrade net-imap to fix CVE-2026-42245, CVE-2026-42246, CVE-2026-42256, CVE-2026-42257, CVE-2026-42258

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
   - Mail: add support for SMTP configuration via environment variables for Docker deployments; smtp.yml remains supported for VM deployments during the deprecation transition
   - Show don't gate: Node-level Methodologies
   - Upgraded gems:
-    - addressable, nokogiri, rack
+    - addressable, net-imap, nokogiri, rack
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ gem 'whenever', require: false
 
 gem 'net-smtp'
 gem 'net-pop'
-gem 'net-imap', '>= 0.5.7'
+gem 'net-imap', '>= 0.6.4'
 
 gem 'puma', '>= 6.5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -669,7 +669,7 @@ DEPENDENCIES
   local_time (>= 2.0.0)
   matrix
   mini_racer
-  net-imap (>= 0.5.7)
+  net-imap (>= 0.6.4)
   net-pop
   net-smtp
   nokogiri (>= 1.19.3)


### PR DESCRIPTION
## Summary

- Upgrade `net-imap` from 0.6.3 to 0.6.4 to address five security vulnerabilities:
  - CVE-2026-42245: quadratic complexity when reading response literals
  - CVE-2026-42246: STARTTLS stripping via invalid response timing
  - CVE-2026-42256: denial of service via high iteration count for `SCRAM-*` authentication
  - CVE-2026-42257: command injection via "raw" arguments to multiple commands
  - CVE-2026-42258: command injection via unvalidated Symbol inputs

## Test plan

- Run `bundle exec bundler-audit --update --ignore CVE-2024-21510 CVE-2025-61921` and confirm no net-imap advisories are reported