### PR TITLE
add LanguageTool configuration to Roslin settings

### DIFF
--- a/engines/dradis-echo/app/models/dradis/plugins/echo/roslin/configuration_form.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/roslin/configuration_form.rb
@@ -4,21 +4,27 @@ module Dradis::Plugins::Echo
       attribute :issue_interaction_enabled, :boolean
       attribute :issue_interaction_model
       attribute :issue_interaction_provider_id
+      attribute :language_tool_enabled, :boolean
+      attribute :language_tool_address
 
       def self.components
         [
           Roslin,
-          Roslin::IssueInteraction
+          Roslin::IssueInteraction,
+          Roslin::LanguageTool
         ]
       end
 
       validates :issue_interaction_provider_id, presence: true, if: :issue_interaction_enabled
+      validates :language_tool_address, presence: true, if: :language_tool_enabled
 
       def self.permitted_params
         super + [
           :issue_interaction_enabled,
           :issue_interaction_model,
-          :issue_interaction_provider_id
+          :issue_interaction_provider_id,
+          :language_tool_address,
+          :language_tool_enabled
         ]
       end
 

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/roslin/language_tool.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/roslin/language_tool.rb
@@ -1,0 +1,27 @@
+module Dradis::Plugins::Echo
+  class Roslin
+    class LanguageTool
+      include Dradis::Plugins::Configurable
+
+      addon_settings :'echo-roslin-language-tool' do
+        settings.default_address = 'http://localhost:8010'
+        settings.default_enabled = false
+      end
+
+      def self.enabled?
+        Roslin.enabled? && settings.enabled
+      end
+
+      def self.load_configuration(form)
+        form.language_tool_address = settings.address
+        form.language_tool_enabled = settings.enabled
+      end
+
+      def self.save_configuration(form)
+        settings.address = form.language_tool_address
+        settings.enabled = form.language_tool_enabled
+        settings.save
+      end
+    end
+  end
+end

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/configurations/_roslin.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/configurations/_roslin.html.erb
@@ -38,5 +38,23 @@
       </div>
     </div>
 
+    <hr>
+
+    <%# LanguageTool %>
+    <div class="d-flex align-items-start justify-content-between mb-3">
+      <div>
+        <h6 class="mb-1">LanguageTool</h6>
+        <p class="text-body-secondary small mb-0">Open-source grammar and style checker. Requires a running LanguageTool instance.</p>
+      </div>
+      <div class="form-check form-switch ms-4 flex-shrink-0">
+        <%= f.check_box :language_tool_enabled, class: 'form-check-input', role: 'switch' %>
+      </div>
+    </div>
+    <div class="row g-3 mb-3 ps-3 border-start">
+      <div class="col-md-6">
+        <%= f.label :language_tool_address, 'Address', class: 'form-label' %>
+        <%= f.text_field :language_tool_address, class: 'form-control' %>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Add `Roslin::LanguageTool` model with configurable address and enabled flag
- Wire LanguageTool into `Roslin::ConfigurationForm` with validation
- Add LanguageTool section to the Roslin configuration UI

## How to test

- Navigate to Echo configuration page
- Confirm a LanguageTool toggle and address field appear under the Roslin card
- Enable LanguageTool with a blank address — confirm validation error
- Enter a valid address and save — confirm settings persist

## Affected areas

- Echo configuration page