### PR TITLE
add testing steps section to PR template and align tooling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -307,4 +307,4 @@ document.addEventListener('turbo:load', function () {
 
 ## Acceptance testing
 
-After a feature is complete, generate an acceptance testing plan using `/testing-steps`. The plan goes in the task tracker under the "Acceptance" section.
+After a feature is complete, generate an acceptance testing plan using `/testing-steps`. The plan goes in the PR description under the "Testing steps" section.

--- a/.claude/skills/testing-steps/SKILL.md
+++ b/.claude/skills/testing-steps/SKILL.md
@@ -7,7 +7,7 @@ Based on the work done in this conversation, generate an acceptance testing plan
 
 The plan must follow this exact format:
 
-**How To Test**
+### Testing steps
 
 A numbered list of steps where each step is either:
 - An **action**: what the tester does (e.g. "Navigate to...", "Login as...", "Create a...", "Edit a...", "Delete a...", "Click on...")

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,10 @@ request... were there any bugs you had fixed? If so, mention them. If
 these bugs have open GitHub issues, be sure to tag them here as well,
 to keep the conversation linked together.
 
+### Testing steps
+
+<!-- Acceptance testing steps for this PR. Generate with /testing-steps.
+     Remove this section if not applicable. -->
 
 ### Other Information
 


### PR DESCRIPTION
### Summary

The PR template had no place for acceptance testing steps, while
`/testing-steps` generated them under a different heading (`**How To
Test**`) and CLAUDE.md pointed to "the task tracker" as the destination.
This left automated acceptance testing (product-acceptance agent) unable
to find steps in the PR body.

- Add a `### Testing steps` section to the PR template
- Change `/testing-steps` output heading from `**How To Test**` to `### Testing steps`
- Update CLAUDE.md to say testing steps go in the PR description

### Testing steps

1. Run `/testing-steps` in a conversation after completing some work
2. Assert the generated output starts with `### Testing steps`
3. Open a new PR and verify the template includes the Testing steps section between Summary and Other Information

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Commit message has a detailed description of what changed and why.