### PR TITLE
replace ollama-ai gem with direct HTTP using native /api/chat endpoint

### DIFF
--- a/engines/dradis-echo/app/models/concerns/dradis/plugins/echo/provider/http_streaming.rb
+++ b/engines/dradis-echo/app/models/concerns/dradis/plugins/echo/provider/http_streaming.rb
@@ -103,5 +103,46 @@ module Dradis::Plugins::Echo
     def end_of_stream_marker
       nil
     end
+
+    # Makes a POST request and parses an NDJSON response line by line, calling
+    # the block with each extracted text chunk. Used by providers whose streaming
+    # format is newline-delimited JSON rather than SSE (e.g. Ollama's native API).
+    # Subclasses must implement #extract_text and #end_of_stream?(parsed).
+    def parse_ndjson_response(uri, headers:, body:, &block)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      http.read_timeout = READ_TIMEOUT
+
+      request = Net::HTTP::Post.new(uri)
+      request['Content-Type'] = 'application/json'
+      headers.each { |k, v| request[k] = v }
+      request.body = JSON.generate(body)
+
+      buffer = +''
+
+      http.request(request) do |response|
+        raise "#{self.class.name} API error (#{response.code}): #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+        response.read_body do |chunk|
+          buffer << chunk
+          while (line_end = buffer.index("\n"))
+            line = buffer.slice!(0, line_end + 1).strip
+            next if line.empty?
+
+            parsed = JSON.parse(line) rescue next
+            break if end_of_stream?(parsed)
+
+            text = extract_text(parsed)
+            block.call(text) if text.present? && block
+          end
+        end
+      end
+    end
+
+    # Returns true when the NDJSON stream is complete. Override in subclasses
+    # that use #parse_ndjson_response.
+    def end_of_stream?(_parsed)
+      false
+    end
   end
 end

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/provider/ollama.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/provider/ollama.rb
@@ -1,23 +1,22 @@
 module Dradis::Plugins::Echo
   class Provider::Ollama < Provider
+    ENDPOINT = '/api/chat'.freeze
+
     validates :address, presence: true
 
     def generate(prompt:, model: nil, &block)
-      resolved_model = model || self.model
-      buffer = block_given? ? nil : +''
+      resolved_model = model.presence || self.model
+      uri = build_uri(resolved_model)
+      headers = build_headers
+      body = build_body(prompt: prompt, model: resolved_model)
 
-      client.generate({ model: resolved_model, prompt: prompt }) do |event, _raw|
-        next if event['done']
+      buffer = block ? nil : +''
 
-        chunk = event['response'].to_s
-        next if chunk.strip.empty?
-
-        chunk = chunk.sub('<think>', '{thinking}').sub('</think>', '{/thinking}')
-
-        if block_given?
-          yield chunk
+      parse_ndjson_response(uri, headers: headers, body: body) do |text|
+        if block
+          block.call(text)
         else
-          buffer << chunk
+          buffer << text
         end
       end
 
@@ -26,11 +25,35 @@ module Dradis::Plugins::Echo
 
     private
 
-    def client
-      @client ||= ::Ollama.new(
-        credentials: { address: address },
-        options: { server_sent_events: true }
-      )
+    def build_uri(_model)
+      URI("#{address.chomp('/')}#{ENDPOINT}")
+    end
+
+    def build_headers
+      {}
+    end
+
+    def build_body(prompt:, model:)
+      {
+        model: model,
+        messages: [{ role: 'user', content: prompt }],
+        stream: true
+      }
+    end
+
+    # Ollama NDJSON envelope (/api/chat):
+    #   {"message":{"role":"assistant","content":"Hello"},"done":false}
+    #   {"message":{"role":"assistant","content":""},"done":true}
+    # Some reasoning models (e.g. Qwen) emit <think>...</think> tags around
+    # internal reasoning tokens — replace them with a readable marker.
+    def extract_text(parsed)
+      parsed.dig('message', 'content')
+            &.sub('<think>', '{thinking}')
+            &.sub('</think>', '{/thinking}')
+    end
+
+    def end_of_stream?(parsed)
+      parsed['done'] == true
     end
   end
 end

--- a/engines/dradis-echo/dradis-echo.gemspec
+++ b/engines/dradis-echo/dradis-echo.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'dradis-plugins', '>= 4.0'
   spec.add_dependency 'liquid'
-  spec.add_dependency 'ollama-ai', '~> 1.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/engines/dradis-echo/lib/dradis-echo.rb
+++ b/engines/dradis-echo/lib/dradis-echo.rb
@@ -1,5 +1,3 @@
-require 'ollama-ai'
-
 require 'dradis-plugins'
 
 module Dradis


### PR DESCRIPTION
## Summary

- Remove `ollama-ai` gem dependency from `dradis-echo`
- Add `parse_ndjson_response` to `Provider::HttpStreaming` concern for Ollama's native NDJSON streaming format
- Rewrite `Provider::Ollama` to use `Net::HTTP` directly via the native `/api/chat` endpoint
- Preserve existing `<think>`/`</think>` tag substitution for reasoning models

## How to test

- Configure an Ollama provider and run a prompt — confirm streaming response appears in the browser
- Verify `<think>` tags from reasoning models (e.g. Qwen) are replaced with `{thinking}`/`{/thinking}`

## Affected areas

- Echo provider infrastructure
- `dradis-echo` gemspec