### PR TITLE
move attachment cleanup to after block to prevent cross-test leakage

### DIFF
--- a/spec/services/nodes/merger_spec.rb
+++ b/spec/services/nodes/merger_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Nodes::Merger do
     let(:source_node) { create(:node, parent_id: root_node, project: root_node.project) }
     let(:target_node) { create(:node, parent_id: root_node, project: root_node.project) }
 
+    after do
+      FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
+    end
+
     it { should eq source_node }
 
     it 'moves notes to target node' do
@@ -69,15 +73,11 @@ RSpec.describe Nodes::Merger do
         conditions: { node_id: target_node.id })
 
       expect(target_attachment).to be_an Attachment
-
-      FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
     end
 
     it 'increases the target node attachment count' do
       create(:attachment, node: source_node)
       expect { merge_nodes }.to change { target_node.attachments.count }.by 1
-
-      FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
     end
 
     describe 'property merges' do
@@ -213,15 +213,11 @@ RSpec.describe Nodes::Merger do
       it 'does not move attachments to target node' do
         create(:attachment, node: source_node)
         expect { merge_nodes }.not_to change { target_node.attachments.count }
-
-        FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
       end
 
       it 'does not change source node attachments count' do
         create(:attachment, node: source_node)
         expect { merge_nodes }.not_to change { source_node.attachments.count }
-
-        FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
       end
     end
   end


### PR DESCRIPTION
### Summary

The `Nodes::Merger` spec has an intermittent CI failure where
`target_node.attachments.count` changes by 5 instead of the expected 1.

**Root cause:** File-backed `Attachment` storage outlives transactional test
rollbacks. When SQLite reuses auto-increment IDs after rollback, newly created
nodes inherit stale attachment files left on disk by earlier tests.

The inline `FileUtils.rm_rf` cleanup was placed after assertions, so it was
skipped whenever an assertion failed — compounding the problem for subsequent
tests.

**Fix:** Move cleanup into an `after` block at the describe level so it always
runs, regardless of assertion outcome.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Commit message has a detailed description of what changed and why.
- [ ] ~~Added a CHANGELOG entry~~ (internal spec change, not user-facing)