### PR TITLE
style dropdown fields consistently with other form controls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
   - Upgraded gems:
     - addressable, net-imap, nokogiri, rack
   - Bugs fixes:
+    - Fields: show a visible border on dropdown fields in the editor
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/app/assets/stylesheets/hera/modules/_inline_editable.scss
+++ b/app/assets/stylesheets/hera/modules/_inline_editable.scss
@@ -44,6 +44,13 @@
 
   select {
     background-color: var(--primary-bg);
-    margin: 0 1.5rem 2.25rem 1.5rem;
+    border-color: var(--border-color);
+    border-radius: $border-radius;
+    margin: 0 1.5rem 1rem 1rem;
+
+    &:focus,
+    &:hover {
+      border-color: var(--border-color);
+    }
   }
 }

--- a/app/views/fields/_field.html.erb
+++ b/app/views/fields/_field.html.erb
@@ -22,7 +22,7 @@
     <div class="edit-hover">
       <% if render_dropdown?(value) %>
         <% options = value.split(' | ') %>
-        <%= select :item_form, "field_value_#{index}", options, {}, { class: 'form-control', data: { behavior: 'preview-enabled' }, tabindex: index + 1 } %>
+        <%= select :item_form, "field_value_#{index}", options, {}, { class: 'form-select', data: { behavior: 'preview-enabled' }, tabindex: index + 1 } %>
       <% else %>
         <%= label_tag "item_form[field_value_#{index}]", 'Field Value', class: 'visually-hidden' %>
         <%= text_area_tag "item_form[field_value_#{index}]", value, rows: 1,


### PR DESCRIPTION
### Summary

Pipe-separated dropdown fields in the inline editor were rendering without a visible border, making them visually indistinguishable from plain text fields. This fixes the styling by using the correct Bootstrap 5 `form-select` class and adding explicit border, border-radius, and margin rules to the `.inline-editable select` styles.

### Testing steps

1. Login to Dradis
2. Navigate to a project and go to the Issues list
3. Click **New Issue** and select the issue template
4. Switch to the **Fields** view in the editor
5. Assert the **Type** field renders as a dropdown (not a textarea) with a visible border
6. Hover over the dropdown — assert the border remains visible on hover
7. Select an option from the dropdown — assert the selection is applied
8. Save the issue, then edit it again
9. Assert the dropdown field still renders correctly on edit
10. Repeat steps 3–9 for a new **Evidence** record using the evidence template, verifying the **Status** dropdown behaves the same way

### Other Information

Affects all record types that use the inline field editor: Issues, Evidence, Notes, and Cards.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.