### PR TITLE
preserve Liquid tags when sanitizing drop field values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@
   - Upgraded gems:
     - addressable, net-imap, nokogiri, rack
   - Bugs fixes:
-    - Drops: preserve Liquid tags when sanitizing issue and evidence field values
+    - Liquid: stop stripping comparison operators from Liquid tags in issue and evidence fields
     - Fields: show a visible border on dropdown fields in the editor
     - [entity]:
       - [future tense verb] [bug fix]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
   - Upgraded gems:
     - addressable, net-imap, nokogiri, rack
   - Bugs fixes:
+    - Drops: preserve Liquid tags when sanitizing issue and evidence field values
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/app/drops/base_drop.rb
+++ b/app/drops/base_drop.rb
@@ -13,31 +13,21 @@ class BaseDrop < Liquid::Drop
     # call below and we want to skip this. Otherwise, proceed as normal.
     return if @wrapping
 
-    # Skip this if we're in the #escape method
-    return if method_name == :escape
-
     @wrapping = true
 
     original_method = instance_method(method_name)
 
     define_method(method_name) do |*args, &block|
       result = original_method.bind(self).call(*args, &block)
-      escape(result)
+      self.class.sanitize(result)
     end
 
     @wrapping = false
   end
 
-  private
+  def self.sanitize(obj)
+    return obj if obj.nil? || !obj.is_a?(String) || obj.empty?
 
-  def escape(obj)
-    if obj.nil? ||
-        !obj.is_a?(String) ||
-        obj.empty?
-
-      return obj
-    end
-
-    HTML::Pipeline::SanitizationFilter.call(obj).to_s
+    HTML::LiquidSafeSanitizer.call(obj)
   end
 end

--- a/app/drops/concerns/escaped_fields.rb
+++ b/app/drops/concerns/escaped_fields.rb
@@ -1,7 +1,7 @@
 module EscapedFields
   def fields
     @record.fields.transform_values do |value|
-      HTML::Pipeline::SanitizationFilter.call(value).to_s
+      BaseDrop.sanitize(value)
     end
   end
 end

--- a/lib/dradis/ce.rb
+++ b/lib/dradis/ce.rb
@@ -13,6 +13,7 @@ module Dradis
 end
 
 require 'html/ignore_liquid_in_textile_block_codes'
+require 'html/liquid_safe_sanitizer'
 require 'html/no_inline_code_textile_formatter'
 
 require 'html/pipeline/dradis/code_highlight_filter'

--- a/lib/html/liquid_safe_sanitizer.rb
+++ b/lib/html/liquid_safe_sanitizer.rb
@@ -1,0 +1,22 @@
+module HTML
+  class LiquidSafeSanitizer
+    LIQUID_PLACEHOLDER_FORMAT = "DRADISSAFE_#{SecureRandom.hex(8)}_%d"
+    LIQUID_TAGS_REGEX = /\{%.*?%\}|\{\{.*?\}\}/m.freeze
+
+    class << self
+      def call(str)
+        stash = []
+        text = str.gsub(LIQUID_TAGS_REGEX) do |match|
+          stash << match
+          format(LIQUID_PLACEHOLDER_FORMAT, stash.size - 1)
+        end
+
+        sanitized = HTML::Pipeline::SanitizationFilter.call(text).to_s
+
+        stash.each_with_index { |tag, i| sanitized.sub!(format(LIQUID_PLACEHOLDER_FORMAT, i), tag) }
+
+        sanitized
+      end
+    end
+  end
+end

--- a/lib/html/liquid_safe_sanitizer.rb
+++ b/lib/html/liquid_safe_sanitizer.rb
@@ -3,6 +3,11 @@ module HTML
     LIQUID_PLACEHOLDER_FORMAT = "DRADISSAFE_#{SecureRandom.hex(8)}_%d"
     LIQUID_TAGS_REGEX = /\{%.*?%\}|\{\{.*?\}\}/m.freeze
 
+    # Note: HTML inside Liquid delimiters (e.g. {% assign x = "<script>..." %}) is stashed
+    # verbatim and not sanitized at this layer. This is fine at the moment since the content reaches the
+    # browser only via the full rendering pipeline (ApplicationHelper#markup), which runs
+    # SanitizationFilter again after Liquid evaluation. Liquid's default auto-escaping also applies to {{ }} output.
+    # BUT do not add raw-output rendering paths without accounting for this otherwise you will introduce XSS vulnerabilities.
     class << self
       def call(str)
         stash = []
@@ -13,7 +18,11 @@ module HTML
 
         sanitized = HTML::Pipeline::SanitizationFilter.call(text).to_s
 
-        stash.each_with_index { |tag, i| sanitized.sub!(format(LIQUID_PLACEHOLDER_FORMAT, i), tag) }
+        # Use block form of sub! so Ruby treats the replacement as a literal string
+        # rather than interpolating backslash sequences (e.g. \1, \&) from the tag content.
+        stash.each_with_index do |tag, i|
+          sanitized.sub!(format(LIQUID_PLACEHOLDER_FORMAT, i)) { tag }
+        end
 
         sanitized
       end

--- a/spec/drops/escaped_drop_spec.rb
+++ b/spec/drops/escaped_drop_spec.rb
@@ -1,28 +1,78 @@
 require 'rails_helper'
 
 describe 'Escaping string from Drops' do
-  let(:issue) { create(:issue, text: "#[Title]#\n<script>test output</script>\n") }
-
   describe BaseDrop do
-    it 'automatically escapes the string outputs' do
-      class TestDrop < BaseDrop
-        delegate :title, to: :@record
+    class TestDrop < BaseDrop
+      delegate :title, to: :@record
+    end
+
+    context 'with XSS content' do
+      let(:issue) { create(:issue, text: "#[Title]#\n<script>test output</script>\n") }
+
+      it 'strips script tags' do
+        drop = TestDrop.new(issue)
+        expect(drop.title).to eq('')
       end
+    end
 
-      drop = TestDrop.new(issue)
+    context 'with Liquid comparison operators (spaces around operator)' do
+      let(:issue) { create(:issue, text: "#[Title]#\n{% if a > b %}yes{% endif %}\n") }
 
-      expect(drop.title).to eq('')
+      it 'preserves the Liquid tags intact' do
+        drop = TestDrop.new(issue)
+        expect(drop.title).to eq('{% if a > b %}yes{% endif %}')
+      end
+    end
+
+    context 'with Liquid comparison operators (no spaces around operator)' do
+      let(:issue) { create(:issue, text: "#[Title]#\n{% if cvss<7.0 %}Low{% endif %}\n") }
+
+      it 'preserves the Liquid tags intact' do
+        drop = TestDrop.new(issue)
+        expect(drop.title).to eq('{% if cvss<7.0 %}Low{% endif %}')
+      end
+    end
+
+    context 'with Liquid assignment tags' do
+      let(:issue) { create(:issue, text: "#[Title]#\n{% assign label = \"critical\" %}\n") }
+
+      it 'preserves the Liquid tags intact' do
+        drop = TestDrop.new(issue)
+        expect(drop.title).to eq('{% assign label = "critical" %}')
+      end
+    end
+
+    context 'with mixed Liquid tags and XSS content' do
+      let(:issue) { create(:issue, text: "#[Title]#\n{% if x < 10 %}<script>xss</script>{% endif %}\n") }
+
+      it 'preserves Liquid tags and strips XSS content outside them' do
+        drop = TestDrop.new(issue)
+        expect(drop.title).to eq('{% if x < 10 %}{% endif %}')
+      end
     end
   end
 
   describe EscapedFields do
-    it 'automatically escapes the field values' do
-      class TestDrop < BaseDrop
-        include EscapedFields
-      end
+    class TestDrop < BaseDrop
+      include EscapedFields
+    end
 
-      drop = TestDrop.new(issue)
-      expect(drop.fields['Title']).to eq('')
+    context 'with XSS content' do
+      let(:issue) { create(:issue, text: "#[Title]#\n<script>test output</script>\n") }
+
+      it 'strips script tags from field values' do
+        drop = TestDrop.new(issue)
+        expect(drop.fields['Title']).to eq('')
+      end
+    end
+
+    context 'with Liquid comparison operators (no spaces around operator)' do
+      let(:issue) { create(:issue, text: "#[Title]#\n{% if cvss<7.0 %}Low{% endif %}\n") }
+
+      it 'preserves Liquid tags in field values' do
+        drop = TestDrop.new(issue)
+        expect(drop.fields['Title']).to eq('{% if cvss<7.0 %}Low{% endif %}')
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Liquid operators like `<` and `>` inside `{% if %}` blocks were being stripped when issue and evidence content passed through `BaseDrop#escape()`. The HTML sanitizer (`HTML::Pipeline::SanitizationFilter`) parses its input as HTML, so `{% if cvss_score < 7.0 %}` — with `< 7.0` looking like an HTML tag — had the operator stripped, returning broken Liquid syntax to the template engine.

The fix stashes all Liquid tags (`{% %}` and `{{ }}`) behind safe alphanumeric placeholders before running the sanitizer, then restores them afterwards. The sanitizer only ever sees content outside Liquid tags, so operators are never mangled. This is the same protect-process-restore pattern `HTML::IgnoreLiquidInTextileBlockCodes` uses to shield Liquid from Textile processing.

XSS protection is maintained: HTML outside Liquid tags (e.g. `<script>`) is still sanitized normally.

Both `BaseDrop#escape()` (covers delegated methods like `title`, `text`) and `EscapedFields#fields` (covers field hash values on issues, notes, evidence) are updated.

### Testing steps

1. Log in as an admin or author user.
2. Navigate to a project and create a new Issue.
3. In a custom field (e.g. "Description"), enter content that contains a Liquid tag with a `<` operator and no surrounding spaces: `{% if cvss<7.0 %}Low risk{% endif %}`.
4. Save the issue.
5. Navigate to the issue show page and open the content preview (the rendered field output).
6. Assert the Liquid tag `{% if cvss<7.0 %}Low risk{% endif %}` is preserved in the rendered content — it should not be stripped to an empty string.
7. Edit the issue and set a custom field to content containing an XSS payload: `<script>alert(1)</script>`.
8. Save and view the issue.
9. Assert the script tag is stripped from the rendered output and no alert fires.
10. Edit the issue and set a custom field to content mixing Liquid tags and XSS: `{% if x < 10 %}<script>xss</script>{% endif %}`.
11. Save and view the issue.
12. Assert the Liquid tags are preserved (`{% if x < 10 %}{% endif %}`) and the script tag content between them is stripped.
13. Repeat the above steps using an Evidence record in place of an Issue to confirm the same behaviour applies to evidence field values.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.