### PR TITLE
reject alignment padding in RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,10 +44,20 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
+Layout/ExtraSpacing:
+  Enabled: true
+  AllowForAlignment: false
+  AllowBeforeTrailingComments: true
+
 Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Layout/HashAlignment:
+  Enabled: true
+  EnforcedColonStyle: key
+  EnforcedHashRocketStyle: key
+
 Style/HashSyntax:
   Enabled: true
   EnforcedShorthandSyntax: never
@@ -76,6 +86,7 @@ Layout/SpaceAroundKeyword:
 
 Layout/SpaceAroundOperators:
   Enabled: true
+  AllowForAlignment: false
 
 Layout/SpaceBeforeFirstArg:
     Enabled: true


### PR DESCRIPTION
## Summary

- Enable `Layout/ExtraSpacing` and `Layout/HashAlignment` cops to catch extra-space padding used to vertically align `=` signs and hash values
- Set `AllowForAlignment: false` on `Layout/SpaceAroundOperators` for the same reason

## Test plan

- [ ] Verify `bin/rubocop-ci` passes on this branch
- [ ] Confirm new code with alignment padding (e.g. `keys   = 1`) is rejected by RuboCop