### PR TITLE
upgrade faraday to 2.14.2 to address CVE-2026-33637

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@
     - Node-level Methodologies
     - Projects
   - Upgraded gems:
-    - addressable, net-imap, nokogiri, rack
+    - addressable, faraday, net-imap, nokogiri, rack
   - Bugs fixes:
     - Fields: show a visible border on dropdown fields in the editor
     - [entity]:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
### Summary

Upgrades faraday from 2.14.1 to 2.14.2 to address CVE-2026-33637 (GHSA-5rv5-xj5j-3484): protocol-relative URI objects bypassing host scoping — an incomplete fix for the previous GHSA-33mh-2634-fwr2.

### Testing steps

N/A — dependency upgrade only.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.