### PR TITLE
show LanguageTool configuration and reachability in Roslin widget

### DIFF
--- a/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
@@ -14,6 +14,12 @@ module Dradis::Plugins::Echo
       def language_tool_configured?
         instance.env['LANGUAGETOOL_ADDRESS'].present?
       end
+
+      def language_tool_reachable?
+        return false unless language_tool_configured?
+
+        LanguageToolService.reachable?(instance.env['LANGUAGETOOL_ADDRESS'])
+      end
     end
   end
 end

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
@@ -18,7 +18,10 @@ module Dradis::Plugins::Echo
       def language_tool_reachable?
         return false unless language_tool_configured?
 
-        LanguageToolService.reachable?(instance.env['LANGUAGETOOL_ADDRESS'])
+        address = instance.env['LANGUAGETOOL_ADDRESS']
+        Rails.cache.fetch("echo:languagetool:reachable:#{address}", expires_in: 5.minutes) do
+          LanguageToolService.reachable?(address)
+        end
       end
     end
   end

--- a/engines/dradis-echo/app/services/dradis/plugins/echo/language_tool_service.rb
+++ b/engines/dradis-echo/app/services/dradis/plugins/echo/language_tool_service.rb
@@ -4,6 +4,16 @@ module Dradis::Plugins::Echo
 
     DEFAULT_ADDRESS = 'http://localhost:8010'.freeze
 
+    def self.reachable?(address)
+      uri = URI("#{address.strip.chomp('/')}/v2/languages")
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: 2, read_timeout: 2) do |http|
+        http.head(uri.path)
+      end
+      true
+    rescue StandardError
+      false
+    end
+
     def initialize(fields:, address:)
       @fields = fields
       @address = address.strip.chomp('/')

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/agents/_form.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/agents/_form.html.erb
@@ -15,7 +15,7 @@
     Roslin is a writing assistant. When enabled, Roslin provides two capabilities:
   </p>
   <ol>
-    <li>AI-assited writing</li>
+    <li>AI-assisted writing</li>
     <li>Grammar and spell checking</li>
   </ol>
 

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
@@ -1,10 +1,13 @@
-<% roslin_enabled = Dradis::Plugins::Echo::Agents::Roslin.enabled? %>
+<% roslin = Dradis::Plugins::Echo::Agents::Roslin %>
+<% roslin_enabled = roslin.enabled? %>
+<% lt_configured = roslin_enabled && roslin.language_tool_configured? %>
+<% lt_reachable = lt_configured && roslin.language_tool_reachable? %>
 
 <div class="header">
   <div class="header-inner">
     <h5 class="header-name">
       Roslin
-      <% if roslin_enabled %>
+      <% if lt_reachable %>
         <i class="fa-solid fa-check ms-1 d-none" data-behavior="roslin-status-success"></i>
         <i class="fa-solid fa-times ms-1 d-none" data-behavior="roslin-status-error"></i>
       <% else %>
@@ -20,15 +23,28 @@
   </div>
 </div>
 
-<% if roslin_enabled %>
+<% if lt_reachable %>
   <div id="roslin-widget" class="collapse" data-behavior="roslin-widget">
     <p class="mb-0" data-behavior="roslin-issues-summary"></p>
   </div>
-<% else %>
+<% elsif !roslin_enabled %>
   <div id="roslin-widget" class="collapse show">
     <p class="mb-0">
       <%= link_to 'Enable the Roslin agent', echo.agents_path %> to use grammar
       and spell checking.
+    </p>
+  </div>
+<% elsif !lt_configured %>
+  <div id="roslin-widget" class="collapse show">
+    <p class="mb-0">
+      LanguageTool is not configured. <%= link_to 'Update the Roslin agent', echo.agents_path %> to add a LanguageTool address.
+    </p>
+  </div>
+<% else %>
+  <div id="roslin-widget" class="collapse show">
+    <p class="mb-0">
+      LanguageTool server is not reachable. Make sure the server at
+      <%= roslin.instance.env['LANGUAGETOOL_ADDRESS'] %> is running.
     </p>
   </div>
 <% end %>

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
@@ -1,7 +1,6 @@
 <% roslin = Dradis::Plugins::Echo::Agents::Roslin %>
 <% roslin_enabled = roslin.enabled? %>
-<% lt_configured = roslin_enabled && roslin.language_tool_configured? %>
-<% lt_reachable = lt_configured && roslin.language_tool_reachable? %>
+<% lt_reachable = roslin_enabled && roslin.language_tool_reachable? %>
 
 <div class="header">
   <div class="header-inner">
@@ -34,7 +33,7 @@
       and spell checking.
     </p>
   </div>
-<% elsif !lt_configured %>
+<% elsif !roslin.language_tool_configured? %>
   <div id="roslin-widget" class="collapse show">
     <p class="mb-0">
       LanguageTool is not configured. <%= link_to 'Update the Roslin agent',

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
@@ -37,14 +37,17 @@
 <% elsif !lt_configured %>
   <div id="roslin-widget" class="collapse show">
     <p class="mb-0">
-    The Language Tool is not configured. <%= link_to 'Update the Roslin agent', echo.edit_agent_path(Dradis::Plugins::Echo::Agents::Roslin) %> to add a <code>LANGUAGETOOL_ADDRESS</code>.
+      LanguageTool is not configured. <%= link_to 'Update the Roslin agent',
+      echo.edit_agent_path(Dradis::Plugins::Echo::Agents::Roslin) %> to enable
+      grammar and spell checking.
     </p>
   </div>
 <% else %>
   <div id="roslin-widget" class="collapse show">
+    <p>LanguageTool server is not reachable.</p>
     <p class="mb-0">
-      LanguageTool server is not reachable. Make sure the server at
-      <strong><%= roslin.instance.env['LANGUAGETOOL_ADDRESS'] %></strong> is running.
+      Make sure the server address
+      is <%= link_to 'properly configured', echo.edit_agent_path(Dradis::Plugins::Echo::Agents::Roslin) %>.
     </p>
   </div>
 <% end %>

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/issues/_widget.html.erb
@@ -37,14 +37,14 @@
 <% elsif !lt_configured %>
   <div id="roslin-widget" class="collapse show">
     <p class="mb-0">
-      LanguageTool is not configured. <%= link_to 'Update the Roslin agent', echo.agents_path %> to add a LanguageTool address.
+    The Language Tool is not configured. <%= link_to 'Update the Roslin agent', echo.edit_agent_path(Dradis::Plugins::Echo::Agents::Roslin) %> to add a <code>LANGUAGETOOL_ADDRESS</code>.
     </p>
   </div>
 <% else %>
   <div id="roslin-widget" class="collapse show">
     <p class="mb-0">
       LanguageTool server is not reachable. Make sure the server at
-      <%= roslin.instance.env['LANGUAGETOOL_ADDRESS'] %> is running.
+      <strong><%= roslin.instance.env['LANGUAGETOOL_ADDRESS'] %></strong> is running.
     </p>
   </div>
 <% end %>

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/projects/interactions/index.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/projects/interactions/index.html.erb
@@ -56,7 +56,7 @@
   </div>
   <p>
     Think of Roslin as an editor or writing companion. It allows you to interact
-    with different LLM providers to help enhance your findings's readability
+    with different LLM providers to help enhance your findings' readability
     or adapt them to your audience.
   </p>
 <% end %>

--- a/engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/issues/widget_spec.rb
+++ b/engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/issues/widget_spec.rb
@@ -10,6 +10,8 @@ describe 'Roslin widget' do
       before do
         roslin_agent = instance_double(Dradis::Plugins::Echo::Agent, enabled?: true)
         allow(Dradis::Plugins::Echo::Agents::Roslin).to receive(:instance).and_return(roslin_agent)
+        allow(Dradis::Plugins::Echo::Agents::Roslin).to receive(:language_tool_configured?).and_return(true)
+        allow(Dradis::Plugins::Echo::Agents::Roslin).to receive(:language_tool_reachable?).and_return(true)
       end
 
       it 'renders the status icons and collapsed widget body' do


### PR DESCRIPTION
### Summary

Show the connection status for the languagetool in the roslin widget

If the language tool is not configured:
<img width="261" height="140" alt="Screenshot 2026-05-28 at 5 43 51 PM" src="https://github.com/user-attachments/assets/9f881b4f-82f7-4ca6-8fd4-8afb745aa42b" />


If the address is unreachable:
<img width="278" height="147" alt="Screenshot 2026-05-28 at 5 39 15 PM" src="https://github.com/user-attachments/assets/d4fa1af9-9392-46e5-aa5b-66be7b7bbdf5" />


### Check List

- [ ] Added a CHANGELOG entry
- [ ] Commit message has a detailed description of what changed and why.
