### PR TITLE
centralize Roslin provisioning

### DIFF
--- a/engines/dradis-echo/app/controllers/dradis/plugins/echo/agents_controller.rb
+++ b/engines/dradis-echo/app/controllers/dradis/plugins/echo/agents_controller.rb
@@ -38,9 +38,7 @@ module Dradis::Plugins::Echo
     end
 
     def set_agent
-      # Avoid params[:id] until we allow :user Agents
-      agent_id = Agents::Roslin.id
-      @agent = Agent.find(agent_id)
+      @agent = Agents::Roslin.instance
     end
 
     def set_providers

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/agent.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/agent.rb
@@ -21,7 +21,7 @@ module Dradis::Plugins::Echo
 
     private
 
-    # System agents (e.g. Roslin) are seeded by migration and must not be deleted.
+    # The engine provisions system agents (e.g. Roslin), and they must not be deleted.
     def prevent_system_deletion
       throw(:abort) if system?
     end

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
@@ -5,14 +5,56 @@ module Dradis::Plugins::Echo
     module Roslin
       extend self
 
-      def instance
-        Agent.find_by!(name: 'Roslin')
+      DEFAULT_ENV = {
+        'LANGUAGETOOL_ADDRESS' => LanguageToolService::DEFAULT_ADDRESS
+      }.freeze
+      NAME = 'Roslin'.freeze
+
+      def exists?
+        Agent.exists?(agent_type: :system, name: NAME)
       end
 
-      delegate :enabled?, :id, :model_override, :provider, to: :instance
+      def instance
+        Agent.find_by!(agent_type: :system, name: NAME)
+      end
+
+      def provision!
+        if exists?
+          clear_legacy_configuration!
+          return instance
+        end
+
+        agent = Agent.find_or_initialize_by(name: NAME)
+
+        if agent.persisted? && !agent.system?
+          agent.errors.add(:agent_type, 'must be system')
+          raise ActiveRecord::RecordInvalid, agent
+        end
+
+        agent.assign_attributes(
+          agent_type: :system,
+          enabled: legacy_enabled,
+          env: DEFAULT_ENV.dup,
+          provider: provision_provider!
+        )
+        agent.save!
+
+        clear_legacy_configuration!
+        agent
+      end
+
+      delegate :id, :model_override, :provider, to: :instance
+
+      def enabled?
+        instance.enabled?
+      rescue ActiveRecord::RecordNotFound
+        false
+      end
 
       def language_tool_configured?
         instance.env['LANGUAGETOOL_ADDRESS'].present?
+      rescue ActiveRecord::RecordNotFound
+        false
       end
 
       def language_tool_reachable?
@@ -21,6 +63,27 @@ module Dradis::Plugins::Echo
         address = instance.env['LANGUAGETOOL_ADDRESS']
         Rails.cache.fetch("echo:languagetool:reachable:#{address}", expires_in: 5.minutes) do
           LanguageToolService.reachable?(address)
+        end
+      end
+
+      private
+
+      def clear_legacy_configuration!
+        Configuration.where('name LIKE ?', 'echo:roslin_%').delete_all
+      end
+
+      def config_value(key)
+        Configuration.find_by(name: "echo:#{key}")&.value
+      end
+
+      def legacy_enabled
+        config_value('roslin_enabled') != 'false'
+      end
+
+      def provision_provider!
+        Provider::Ollama.find_or_create_by!(name: 'Ollama') do |provider|
+          provider.address = config_value('roslin_ollama_address') || Provider::Ollama::DEFAULT_ADDRESS
+          provider.model = config_value('roslin_ollama_model') || Provider::Ollama::DEFAULT_MODEL
         end
       end
     end

--- a/engines/dradis-echo/db/migrate/20260521000001_create_agents.rb
+++ b/engines/dradis-echo/db/migrate/20260521000001_create_agents.rb
@@ -15,42 +15,12 @@ class CreateAgents < ActiveRecord::Migration[8.0]
 
     add_index :dradis_plugins_echo_agents, :name, unique: true
 
-    # Seed data is also in engines/dradis-echo/db/seeds.rb for fresh installs
-    # (db:prepare loads the schema and runs seeds, skipping migration bodies).
-    # This block handles the upgrade path — existing instances running db:migrate
-    # don't run seeds, so Roslin must be created here.
+    # Fresh installs get Roslin through db/seeds.rb. This handles upgrades,
+    # where existing instances run migrations without loading seeds.
     reversible do |dir|
       dir.up do
-        address = config_value('roslin_ollama_address') || Dradis::Plugins::Echo::Provider::Ollama::DEFAULT_ADDRESS
-        model = config_value('roslin_ollama_model') || Dradis::Plugins::Echo::Provider::Ollama::DEFAULT_MODEL
-
-        provider = Dradis::Plugins::Echo::Provider::Ollama.create!(
-          address: address,
-          model: model,
-          name: 'Ollama'
-        )
-
-        next if Dradis::Plugins::Echo::Agent.exists?(name: 'Roslin')
-
-        enabled = config_value('roslin_enabled') != 'false'
-        lt_address = Dradis::Plugins::Echo::LanguageToolService::DEFAULT_ADDRESS
-
-        Dradis::Plugins::Echo::Agent.create!(
-          agent_type: :system,
-          enabled: enabled,
-          env: { 'LANGUAGETOOL_ADDRESS' => lt_address },
-          name: 'Roslin',
-          provider: provider
-        )
-
-        Configuration.where('name LIKE ?', 'echo:roslin_%').delete_all
+        Dradis::Plugins::Echo::Agents::Roslin.provision!
       end
     end
-  end
-
-  private
-
-  def config_value(key)
-    Configuration.find_by(name: "echo:#{key}")&.value
   end
 end

--- a/engines/dradis-echo/db/seeds.rb
+++ b/engines/dradis-echo/db/seeds.rb
@@ -1,14 +1,1 @@
-unless Dradis::Plugins::Echo::Agent.exists?(name: 'Roslin')
-  provider = Dradis::Plugins::Echo::Provider::Ollama.find_or_create_by!(name: 'Ollama') do |p|
-    p.address = Dradis::Plugins::Echo::Provider::Ollama::DEFAULT_ADDRESS
-    p.model = Dradis::Plugins::Echo::Provider::Ollama::DEFAULT_MODEL
-  end
-
-  Dradis::Plugins::Echo::Agent.create!(
-    agent_type: :system,
-    enabled: true,
-    env: { 'LANGUAGETOOL_ADDRESS' => Dradis::Plugins::Echo::LanguageToolService::DEFAULT_ADDRESS },
-    name: 'Roslin',
-    provider: provider
-  )
-end
+Dradis::Plugins::Echo::Agents::Roslin.provision!

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/agents/roslin_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/agents/roslin_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+require File.expand_path('../../../../../factories/agents', __dir__)
+require File.expand_path('../../../../../factories/providers', __dir__)
+
+describe Dradis::Plugins::Echo::Agents::Roslin do
+  before do
+    Dradis::Plugins::Echo::Agent.delete_all
+    Dradis::Plugins::Echo::Provider.delete_all
+    Configuration.where('name LIKE ?', 'echo:roslin_%').delete_all
+  end
+
+  describe '.exists?' do
+    it 'ignores non-system agents named Roslin' do
+      create(:agent, name: described_class::NAME)
+
+      expect(described_class.exists?).to be false
+    end
+  end
+
+  describe '.enabled?' do
+    it 'returns false when Roslin is not provisioned' do
+      expect(described_class.enabled?).to be false
+    end
+  end
+
+  describe '.instance' do
+    it 'finds the system agent named Roslin' do
+      agent = create(:system_agent, name: described_class::NAME)
+
+      expect(described_class.instance).to eq(agent)
+    end
+
+    it 'does not find non-system agents named Roslin' do
+      create(:agent, name: described_class::NAME)
+
+      expect { described_class.instance }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe '.provision!' do
+    it 'creates Roslin with defaults' do
+      agent = described_class.provision!
+
+      expect(agent).to be_system
+      expect(agent).to be_enabled
+      expect(agent.env).to eq(described_class::DEFAULT_ENV)
+      expect(agent.name).to eq(described_class::NAME)
+      expect(agent.provider).to have_attributes(
+        address: Dradis::Plugins::Echo::Provider::Ollama::DEFAULT_ADDRESS,
+        model: Dradis::Plugins::Echo::Provider::Ollama::DEFAULT_MODEL,
+        name: 'Ollama'
+      )
+    end
+
+    it 'uses legacy configuration values when present' do
+      create(:configuration, name: 'echo:roslin_enabled', value: 'false')
+      create(:configuration, name: 'echo:roslin_ollama_address', value: 'http://ollama.example.test:11434')
+      create(:configuration, name: 'echo:roslin_ollama_model', value: 'llama3.3')
+
+      agent = described_class.provision!
+
+      expect(agent).not_to be_enabled
+      expect(agent.provider.address).to eq('http://ollama.example.test:11434')
+      expect(agent.provider.model).to eq('llama3.3')
+      expect(Configuration.where('name LIKE ?', 'echo:roslin_%')).to be_empty
+    end
+
+    it 'returns the existing system Roslin without changing admin-managed fields' do
+      provider = create(:provider, address: 'http://existing.example.test:11434', model: 'existing-model')
+      agent = create(
+        :system_agent,
+        enabled: false,
+        env: { 'CUSTOM' => 'value' },
+        name: described_class::NAME,
+        provider: provider
+      )
+      create(:configuration, name: 'echo:roslin_enabled', value: 'true')
+
+      expect(described_class.provision!).to eq(agent)
+      expect(agent.reload).not_to be_enabled
+      expect(agent.env).to eq('CUSTOM' => 'value')
+      expect(agent.provider).to eq(provider)
+      expect(Configuration.where('name LIKE ?', 'echo:roslin_%')).to be_empty
+    end
+
+    it 'raises when a non-system agent is already named Roslin' do
+      create(:agent, name: described_class::NAME)
+
+      expect { described_class.provision! }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(Dradis::Plugins::Echo::Provider.exists?(name: 'Ollama')).to be false
+    end
+  end
+end

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/agents/roslin_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/agents/roslin_spec.rb
@@ -23,6 +23,12 @@ describe Dradis::Plugins::Echo::Agents::Roslin do
     end
   end
 
+  describe '.language_tool_configured?' do
+    it 'returns false when Roslin is not provisioned' do
+      expect(described_class.language_tool_configured?).to be false
+    end
+  end
+
   describe '.instance' do
     it 'finds the system agent named Roslin' do
       agent = create(:system_agent, name: described_class::NAME)

--- a/engines/dradis-echo/spec/support/setup.rb
+++ b/engines/dradis-echo/spec/support/setup.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
-    # The migration creates Roslin enabled; disable it so grammar checks don't
-    # run across all views during specs unless a test explicitly enables it.
+    # Roslin is enabled by default; keep existing test data disabled so grammar
+    # checks don't run across all views unless a test explicitly enables it.
     agent = Dradis::Plugins::Echo::Agents::Roslin
     agent.instance.update!(enabled: false) if agent.enabled?
   end


### PR DESCRIPTION
### Summary

Centralizes Roslin identity, lookup, and provisioning in `Agents::Roslin` so fresh installs and upgrades share the same idempotent path. The migration and seeds now call `Roslin.provision!` instead of duplicating the system-agent shape, legacy `echo:roslin_*` settings are consumed in one place, and controller lookup goes through `Roslin.instance` directly.

### Testing steps

1. Log in as an administrator.
2. Confirm the AI Copilot (Echo) addon is enabled (Configuration → Integrations) and that the application has at least one project containing an issue.
3. From the top navigation, open the AI Copilot section and click the **Agents** sub-nav item (robot icon) to navigate to the Agents page (`/agents`).
4. Assert that an agent named **Roslin** is listed.
5. Assert that Roslin's provider is **Ollama** with the default address (`http://localhost:11434`) and default model (`qwen2.5:14b`).
6. Assert that Roslin shows as **enabled**.
7. Assert that the Roslin row has **no delete control** (system agents cannot be deleted).
8. Click **Edit** on the Roslin agent, change the model override (e.g. `qwen2.5:32b`), and save.
9. Assert the flash message reads "Roslin updated." and the new model override is shown on the Agents page.
10. Edit Roslin again, clear the `LANGUAGETOOL_ADDRESS` env value, and save.
11. Navigate to a project, open an issue, and click to edit its content.
12. Assert the Roslin grammar widget shows the "LanguageTool is not configured" message with a link to update the Roslin agent.
13. Edit Roslin, set `LANGUAGETOOL_ADDRESS` back to a reachable LanguageTool URL, ensure Roslin is enabled, and save.
14. Reload the issue edit view and assert the Roslin grammar widget is now active (grammar suggestions/corrections available).
15. Edit Roslin, set it to **disabled**, and save.
16. Reload the issue edit view and assert the widget shows the "Enable the Roslin agent" message instead of the active widget.
17. Open the project's **Interactions** page for Roslin; with Roslin disabled, assert it shows "The Roslin agent is not enabled."
18. Re-enable Roslin and assert the Interactions page lets you select text and interact with Roslin.
19. (Upgrade path — run in `bundle exec rails console`) Simulate a pre-migration state: create the legacy settings `Configuration.create!(name: 'echo:roslin_enabled', value: 'false')`, `Configuration.create!(name: 'echo:roslin_ollama_address', value: 'http://ollama.example.test:11434')`, `Configuration.create!(name: 'echo:roslin_ollama_model', value: 'llama3.3')`, then delete the existing Roslin agent and its Ollama provider.
20. Run `Dradis::Plugins::Echo::Agents::Roslin.provision!` in the console.
21. Assert the returned agent is a system agent named "Roslin", is **disabled** (from `echo:roslin_enabled=false`), and its provider address is `http://ollama.example.test:11434` and model `llama3.3`.
22. Assert `Configuration.where("name LIKE 'echo:roslin_%'")` returns an empty set (legacy settings were consumed and removed).
23. Run `Dradis::Plugins::Echo::Agents::Roslin.provision!` a second time and assert it returns the same agent without creating a duplicate Agent or Ollama provider.
24. On a clean state, create a non-system agent named "Roslin" (`FactoryBot.create(:agent, name: 'Roslin')` or equivalent) and call `Dradis::Plugins::Echo::Agents::Roslin.provision!`; assert it raises `ActiveRecord::RecordInvalid` and that no Ollama provider was created.

### Other Information

CI / automated verification run locally:

- `bundle exec bundler-audit --update --ignore CVE-2024-21510 CVE-2025-61921`
- `bundle exec ruby-audit update && bundle exec ruby-audit check --ignore CVE-2025-61594 CVE-2025-58767 CVE-2026-41316`
- `bundle exec brakeman -q -w2`
- `bin/rubocop-ci develop false`
- `RAILS_ENV=test bundle exec rspec engines/dradis-echo/spec/models/dradis/plugins/echo/agents/roslin_spec.rb engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/issues/widget_spec.rb engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/grammar_corrections_spec.rb engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/grammar_suggestions_spec.rb`

A full local `RAILS_ENV=test bundle exec rspec spec engines -p` run still showed unrelated feature failures around stale Issue lookups in browser-driven specs. The focused Echo/Roslin coverage passes locally; GitHub CI will provide the clean environment signal.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
