### PR TITLE
Add changelog template

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,34 @@
+[v#.#.#] ([month] [YYYY])
+  - [entity]:
+    - [future tense verb] [feature]
+  - Upgraded gems:
+    - puma
+  - Bugs fixes:
+    - [entity]:
+      - [future tense verb] [bug fix]
+    - Bug tracker items:
+      - [item]
+  - Echo enhancements:
+    - [Echo entity]:
+      - [future tense verb] [Echo enhancement]
+  - New integrations:
+    - [integration]
+  - Integration enhancements:
+    - [integration]:
+      - [future tense verb] [integration enhancement]
+      - [integration bug fixes]:
+        - [future tense verb] [integration bug fix]
+  - Reporting enhancements:
+    - [report type]:
+      - [future tense verb] [reporting enhancement]
+  - REST/JSON API enhancements:
+    - [API entity]:
+      - [future tense verb] [API enhancement]
+  - Security Fixes:
+    - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+
 v5.1.0 (May 2026)
   - DataTables: add sticky table toolbar that tracks below the navigation bar when scrolling
   - Mail: add support for SMTP configuration via environment variables for Docker deployments; smtp.yml remains supported for VM deployments during the deprecation transition


### PR DESCRIPTION
### Summary

- Add changelog template
- Add `puma` as the upgraded gem from the latest release commit