### PR TITLE
Add dradis-design Claude Code skill

### DIFF
--- a/.claude/skills/dradis-design/README.md
+++ b/.claude/skills/dradis-design/README.md
@@ -1,0 +1,261 @@
+# Dradis Design System
+
+A design system for **Dradis Framework — Community Edition (CE)**, the open-source
+collaboration framework and penetration-testing report generator built by
+[Security Roots](https://securityroots.com). This system captures the brand,
+visual foundations, and UI vocabulary of the Dradis product so designers and
+agents can produce on-brand interfaces, mockups, and prototypes.
+
+> The Dradis product theme is internally named **"Hera."** Most class names,
+> color scales, and component conventions in this system trace directly to the
+> `hera` stylesheet tree in the codebase.
+
+---
+
+## What is Dradis?
+
+Dradis is an **open-source collaboration framework and penetration testing
+report generator** that helps InfoSec teams streamline reporting workflows. It
+imports data from security tools (Burp Suite, Nessus, Nmap, OpenVAS, Qualys,
+Metasploit, and many more), centralizes findings, and automates the tedious
+parts of security report writing so testers can focus on analysis and
+recommendations.
+
+**Core value proposition:** *Generate consistent, professional pentest reports
+faster — with less manual work.*
+
+### Editions
+- **Community Edition (CE)** — open-source, GPLv2. Single-project, self-hosted.
+  This design system is built from CE.
+- **Professional Edition (Pro)** — commercial. Adds multi-project management,
+  teams, report automation, content blocks, QA workflows, and client
+  collaboration. CE surfaces tasteful "Try Pro" upsells throughout.
+
+### Core domain vocabulary
+Designers should know these product nouns — they appear all over the UI:
+- **Project** — a single security assessment / engagement.
+- **Issue** — a vulnerability or finding (Title, Description, Recommendation,
+  CVEs, etc.). Issues are what end up in the report.
+- **Evidence** — proof attached to an issue, tied to a node.
+- **Node** — a target in scope (host, IP, app component). Shown in a tree sidebar.
+- **Methodology / Board** — a Kanban-style checklist of testing tasks (lists + cards).
+- **Tag** — colored classification on issues (often severity: Critical/High/etc.).
+- **Issue Library** — reusable catalog of findings for consistency across projects.
+- **Remediation Tracker** — tickets for tracking fixes.
+- **QA** — quality-assurance review state for issues (Draft → Ready for review → Published).
+
+---
+
+## Sources
+
+This system was reverse-engineered from the **dradis-ce** codebase (Ruby on
+Rails + Bootstrap 5 + Stimulus/Turbo). Key source locations (paths within the
+attached `dradis-ce/` repo):
+
+| Concern | Source |
+|---|---|
+| Color palette (source of truth) | `app/assets/stylesheets/hera/modules/_colors.scss` |
+| Theme tokens (light/dark) | `app/assets/stylesheets/hera/themes.scss` |
+| Base element styles + fonts | `app/assets/stylesheets/hera/base.scss` |
+| Variables (spacing, sizing) | `app/assets/stylesheets/hera/variables.scss` |
+| Buttons | `app/assets/stylesheets/hera/modules/_buttons.scss` |
+| Navigation (main + sub nav) | `app/assets/stylesheets/hera/modules/navigation/_navigation.scss` |
+| Sidebar | `app/assets/stylesheets/hera/modules/_sidebar.scss` |
+| Boards / Kanban | `app/assets/stylesheets/hera/views/boards.scss` |
+| Layout shell | `app/views/layouts/hera.html.erb` |
+| Logos & fonts | `app/assets/images/`, `app/assets/fonts/` |
+
+- **Public site:** https://dradis.com
+- **GitHub:** https://github.com/dradis/dradis-ce
+- **Icons:** Font Awesome 6.4.0 Free (via `font-awesome-sass` gem)
+- **Type:** Proxima Nova (Light + Regular) — `.otf` files copied into `fonts/`
+
+---
+
+## CONTENT FUNDAMENTALS
+
+How Dradis writes copy. The voice is that of a **practical, no-nonsense tool
+made by security people for security people** — competent, direct, lightly
+encouraging, never marketing-fluffy inside the product.
+
+**Voice & tone**
+- **Direct and instructional.** Copy explains what a thing is *for*, then how to
+  use it. Empty states teach: *"Use issues to represent vulnerabilities or
+  findings. Issues contain general information, such as: Title, Description,
+  Recommendation, CVE's, etc."*
+- **Second person.** Addresses the user as "you/your": *"Centralize security
+  assessments and keep up with the progress of each engagement,"* *"Maintain a
+  library of findings that can be easily accessed."*
+- **Action-oriented page titles.** Big H1s are imperatives: *"Manage your
+  projects," "Build Your Issue Library."* A supporting H2 expands on the benefit.
+- **Confident, not hypey.** No exclamation marks, no superlatives in-product.
+  Benefit statements are concrete ("less manual work", "consistency across all
+  of your projects") rather than aspirational.
+
+**Casing**
+- **Page H1s:** mostly sentence case (*"Manage your projects"*), occasionally
+  title case (*"Build Your Issue Library"*). Lean sentence case for new copy.
+- **Buttons & nav:** Title Case for primary actions (*"New Issue," "New
+  Project," "Add a list…"*), often prefixed with a `+` icon.
+- **Section headers** (`.header-underline`): Sentence case (*"Issues so far,"
+  "Methodology progress," "Recent activity"*).
+- **Table column heads:** Title Case (*Name, Issues, Evidence, Nodes, Affected*).
+
+**Mechanics**
+- **Ellipses for affordances:** "Add a task…", "Add a list…", "Choose any user
+  name you want".
+- **Pluralize honestly:** "1 Issue" / "3 Issues" (the app uses `pluralize`).
+- **Confirmations are blunt and explain consequences:** *"Are you sure?
+  Proceeding will delete this issue and any associated evidence."*
+- **Pro upsells** are framed as helpful tooltips, not nags: *"Dradis Pro: Track
+  project status to manage your team's workload at a glance."*
+
+**Emoji:** **None.** Never used in product. Iconography is carried entirely by
+Font Awesome glyphs. Don't introduce emoji.
+
+---
+
+## VISUAL FOUNDATIONS
+
+Dradis CE is a **dense, utilitarian, Bootstrap-5 application UI** — built for
+information density and long working sessions, not marketing flourish. The
+aesthetic is clean, bordered, and green-forward.
+
+**Color**
+- **Brand green is the identity.** `--brand-500 #1d8749` is *primary*: primary
+  buttons, links, active states, the logo. A full 50→900 brand scale exists.
+- **The navbar is the most recognizable brand surface:** a soft light-green bar
+  (`--brand-200 #a5cfb6`) with dark-green text (`--brand-700 #11512c`) and a
+  `--brand-400` bottom border. Active items get a 5px brand-700 top border.
+- **Semantic colors** map to security/QA meaning: red `#cc293b` (danger/delete),
+  mint green `#85d783` (success), yellow `#e1cd30` (warning), orange `#cc6829`
+  (severity accents). Each has a 100→900 scale.
+- **Lavender** (`#8261d5`) is a special accent — teams, Pro badges, the secondary
+  brand pop.
+- **Greys** are warm-neutral (`#f4f4f4`→`#282828`). Backgrounds are white/near-white;
+  secondary surfaces use `--grey-100`.
+- **Tags drive issue color:** issue severity cards are tinted by user-defined tag
+  colors (inline `style="background: <tag.color>"`), so the issue list is a
+  rainbow of severity bands.
+
+**Theming**
+- **Full light + dark themes**, switched via `data-theme` on `<html>` and driven
+  entirely by CSS custom properties (`--primary-bg`, `--text-default`,
+  `--border-color`, …). Auto-follows OS via `prefers-color-scheme`. Any new
+  component should reference semantic vars, never hard-coded hex, so it themes
+  for free.
+
+**Type**
+- **Proxima Nova** throughout. `ProximaNovaLight` (400) is the body face;
+  `ProximaNovaRegular` (500) is used for **bold text, headings, form labels,
+  table headers, and `<strong>`**. There is no third weight — "bold" = swap to
+  Regular.
+- Body size `0.95rem`. Headings scale h1 `2rem` → h6 `1rem` (slightly smaller
+  below 1200px). Headings are tight (`line-height 1.2`), understated, rarely huge.
+- Monospace only for code blocks (`<pre>`, `<code>`), which get a brand-100 chip
+  background and brand-colored text.
+
+**Spacing & layout**
+- Base spacing unit is **`1.5rem`** (`--margin` / `--padding`).
+- App shell is a CSS grid: sticky top nav (one or two rows), optional left
+  **node sidebar** (14rem), main content, optional right **secondary sidebar**
+  (~17.5rem). Sidebars collapse to a 0.25rem rail.
+- Content lives in **`.content-container`** cards: white bg, `1px` border,
+  **5px radius**, `1.5rem` padding.
+
+**Borders, radii & shadows**
+- **Borders do the heavy lifting**, not shadows. Almost every surface is defined
+  by a `1px solid var(--border-color)` (light grey). This is a *bordered*,
+  low-elevation design.
+- **Radii:** `5px` for content containers/cards, `0.25rem` for buttons & badges,
+  `3px` for Kanban board lists/cards. Pills (`50rem`) only for circular avatars.
+- **Shadows are minimal.** A soft `1px 1px 5px rgba(grey,0.5)` on dropdowns; a
+  pronounced `0 20px 30px rgba(33,55,74,0.2)` *only* on actively-dragged Kanban
+  cards. No ambient drop shadows on resting cards.
+- **Focus ring:** `0 0 0 0.2rem rgba(brand,0.5)` — a green glow on focus-visible.
+
+**Backgrounds**
+- **Flat color only.** No gradients, no hero photography, no textures or
+  patterns in the app UI. Surfaces are white, grey-100, or brand-tinted.
+- The footer is a thin `--brand-100` strip with a `--brand-300` top border.
+
+**Motion & states**
+- **Subtle, fast, functional.** Standard transition is `color/background 0.2s
+  ease-in-out`. No bounces, no large entrance animations, no parallax.
+- **Hover:** links go darker (`--text-link-hover`); buttons darken their fill
+  ~10% (`darken($color, 10%)`); list rows tint to `--primary-bg-subtle`; row
+  action icons fade in from `opacity: 0.25`.
+- **Press/active:** same darkened fill as hover (no shrink/scale transforms).
+- **Drag:** Kanban cards lift with the heavy shadow and `cursor: grabbing`.
+
+**Avatars & imagery**
+- User avatars are **circular** (Gravatar-style, `border-radius: 50%`), shown in
+  overlapping stacks with a "+N" overflow chip. The default `avatar.png` is a
+  flat grey silhouette. There is essentially no decorative photography.
+
+---
+
+## ICONOGRAPHY
+
+- **Primary system: Font Awesome 6.4.0 Free.** This is *the* icon language of
+  Dradis. Used pervasively via `<i class="fa-solid …">`, `fa-regular`, and
+  `fa-brands`. It is **self-hosted** at `assets/fa/all.min.css` (with webfonts in
+  `assets/fa/webfonts/`) — the exact same family and version the product ships,
+  so artifacts render offline. Link it relatively (e.g. `assets/fa/all.min.css`).
+- **Common glyphs** (memorize these — they ARE the product's visual shorthand):
+  - `fa-bug` — Issues / findings (the signature Dradis icon)
+  - `fa-brands fa-trello` — Methodologies / boards
+  - `fa-sitemap` — Nodes
+  - `fa-flag` — Evidence
+  - `fa-cloud-arrow-up` — Upload
+  - `fa-file-export` — Export
+  - `fa-regular fa-handshake` — QA
+  - `fa-regular fa-folder-open` — Project overview
+  - `fa-plus` — New / create (prefixes most primary buttons)
+  - `fa-pencil` / `fa-trash` / `fa-copy` / `fa-box-archive` — row actions
+  - `fa-check` (green) / `fa-times` (red) / `fa-triangle-exclamation` (yellow) — status
+  - `fa-bars`, `fa-chevron-up`, `fa-caret-up`, `fa-grip-vertical` — chrome/controls
+- **Icon coloring:** icons inherit text color by default; semantic icons are
+  tinted (`fa-check` green, `fa-times` red, `fa-info-circle` brand). Issue icons
+  take their tag's color inline.
+- **Brand logos** (in `assets/`):
+  - `logo_small.png` — the standalone "A" mark (interlocking green ribbons +
+    dark band). Used in the navbar.
+  - `logo_full_small.png` — full lockup: the mark + "Dradis" wordmark + "CE".
+  - The mark reads as a stylized **"A"** built from folded green ribbons with a
+    charcoal band woven through it.
+- **No emoji. No custom SVG icon set.** A few tiny legacy "silk" PNG icons
+  (`accept/pencil/stop`) exist for inline table-edit states but are vestigial —
+  prefer Font Awesome equivalents.
+
+---
+
+## Index / Manifest
+
+Root files:
+- **`README.md`** — this file. Brand context, content + visual foundations, iconography.
+- **`colors_and_type.css`** — the complete token layer: raw palette, semantic
+  light/dark theme tokens, font-faces, and base element styles. **Import this
+  first** in any artifact.
+- **`SKILL.md`** — Agent-Skill manifest for using this system in Claude Code.
+- **`fonts/`** — Proxima Nova `.otf` files (Light, Regular).
+- **`assets/`** — logos, favicon, default avatar, loading spinner, check mark,
+  and self-hosted **Font Awesome 6.4** (`assets/fa/`).
+- **`preview/`** — design-system specimen cards (rendered in the Design System tab).
+
+UI kits:
+- **`ui_kits/dradis-app/`** — the Dradis CE web application: shell (nav + sidebar),
+  Projects index, Project Overview dashboard, Issues table, Issue detail, and
+  the Methodologies Kanban board, plus reusable buttons, badges, cards, forms,
+  and a login screen. `index.html` is an interactive click-through.
+
+---
+
+## Caveats / Substitutions
+- **Fonts:** Proxima Nova ships as `.otf` in the repo and is copied into
+  `fonts/`. It is a commercial typeface; if you need a Google-Fonts fallback for
+  portability, the closest free match is **Montserrat** (or system-ui).
+- **Icons** are self-hosted Font Awesome 6.4 (same version as the gem), in `assets/fa/`.
+- This system is derived from **CE**; Pro-only screens (multi-project dashboard,
+  content blocks, full QA workflow) are represented only where CE exposes them
+  as teasers.

--- a/.claude/skills/dradis-design/SKILL.md
+++ b/.claude/skills/dradis-design/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: dradis-design
+description: Use this skill for ANY Dradis CE (Community Edition) UI work — building or changing views, forms, index/show pages, cards, empty states, buttons, tables in the dradis-ce codebase, OR creating CE mocks/slides/prototypes. Carries the design judgment the codebase doesn't state: which button/link/card pattern to use and when, voice/casing, glyph vocabulary, plus a pre-flight checklist to prevent design inconsistencies. Use it whenever a non-designer is implementing UI so the result stays on-brand. For Pro-only screens (dashboard, teams, QA workflow, content blocks, remediation tracker, contributors portal) use the dradis-pro-design skill alongside this one.
+user-invocable: true
+---
+
+Read the `README.md` file within this skill, and explore the other available files.
+
+If creating visual artifacts (slides, mocks, throwaway prototypes, etc), create static HTML files for the user to view. If working on production code, read the rules here to become an expert in designing with this brand.
+
+## ⚠️ Two modes — pick the right one
+
+**Mode A — Throwaway HTML (mocks, slides, prototypes):** import `colors_and_type.css`, use the `var(--token)` names, inline styles are fine. For icons use Font Awesome 6 via CDN (`https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css`). Self-contained and disposable.
+
+**Mode B — Production code in the Dradis repo (the common case):** READ **`production-patterns.md`** FIRST — it is the heart of this skill. It holds the verified decision rules (buttons vs. links vs. destructive actions, cards vs. content-container, page scaffold, forms, tables, empty states), a glyph/voice/casing reference, a **pre-flight checklist**, and an anti-pattern list — all checked against the real source. Then:
+- **Canonical markup = the in-repo Hera Style Guide**, `app/views/styles/index.html.erb` (route `/styles`). Copy real markup from its reveal-code blocks; `production-patterns.md` tells you *which* option to pick and when. Never invent markup the style guide already defines.
+- DO NOT import `colors_and_type.css` and DO NOT copy hex values. The repo already defines every token in `hera/modules/_colors.scss` and `themes.scss`; this skill's CSS is a *mirror for mocks only*. Use existing SASS vars (`$brand-500`) and custom properties (`var(--text-default)`).
+- Follow the repo's `CLAUDE.md` rules: no inline `style`, no ID selectors, no `!important`, `rem` not `px` (px OK for borders), alphabetical sorting, `data-behavior` for JS/CSS hooks, SMACSS file placement.
+- `README.md` is supporting reference for tone and "what good looks like" — translate intent into the repo's Bootstrap 5 + Stimulus + ERB conventions.
+
+If the user invokes this skill without any other guidance, ask them what they want to build or design, ask some questions, and act as an expert designer who outputs HTML artifacts _or_ production code, depending on the need.
+
+## Quick orientation
+- **`production-patterns.md`** — **READ FIRST for any production/codebase UI work.** Verified decision rules (buttons/links/destructive actions, cards vs. content-container, page scaffold, forms, tables, empty states), glyph/voice/casing reference, pre-flight checklist, anti-patterns.
+- **`README.md`** — full brand context: product overview, content fundamentals (voice/tone/casing), visual foundations, and iconography.
+- **`colors_and_type.css`** — import this in any HTML artifact. It defines the raw palette, light/dark semantic theme tokens, the Proxima Nova `@font-face` rules, and base element styles. Reference semantic vars (`var(--brand-500)`, `var(--text-default)`, `var(--border-color)`) — never hard-code hex except for user-defined tag/severity colors.
+
+## The essentials (so you don't have to re-derive them)
+- **Brand color:** CE primary = green `#1d8749` (brand-500), navbar light-green `#a5cfb6` / text `#11512c`. Pro swaps the ramp green→blue — see the `dradis-pro-design` skill.
+- **Type:** Proxima Nova. Body = Light 400 at ~0.95rem; bold/headings = Regular 500. No emoji, ever.
+- **Surfaces:** white/grey-100 backgrounds, `1px` borders (borders > shadows), 5px radius on containers, 0.25rem on buttons, 3px on board cards. Flat colors — no gradients, no hero imagery.
+- **Icons:** Font Awesome 6. Signature glyphs: `fa-bug` (issues), `fa-brands fa-trello` (methodologies), `fa-sitemap` (nodes), `fa-flag` (evidence), `fa-plus` (new).
+- **Voice:** direct, instructional, second-person, confident-not-hypey. Imperative page titles ("Manage your projects"), teaching empty states.
+- **Domain nouns:** project (engagement), issue (finding/vuln), evidence, node (target), methodology/board, tag (severity), Issue Library, QA states (Draft → Ready for review → Published).
+
+## CE upsell pattern
+CE surfaces locked Pro features as disabled links/buttons with `class="js-try-pro"`, `data-term`, and `data-url`. The `try_pro` JS intercepts clicks and shows an upsell modal. This pattern is CE-only — never use it in dradis-pro.
+
+## Pro
+Pro extends CE — the only visual difference is the brand color (green→blue). All CE patterns, components, and voice rules apply to Pro. For Pro-only screens and the brand swap, use the `dradis-pro-design` skill alongside this one.
+
+## When loading assets from HTML
+Place your artifact next to `colors_and_type.css` and import it with a relative path. For Font Awesome, use the CDN: `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css`. For the Proxima Nova font, `colors_and_type.css` includes `@font-face` rules that reference `fonts/proximanova-*.otf` — if those files aren't present, the stack falls back to Montserrat (closest free match) or `system-ui`.

--- a/.claude/skills/dradis-design/colors_and_type.css
+++ b/.claude/skills/dradis-design/colors_and_type.css
@@ -1,0 +1,291 @@
+/* ===================================================================
+   DRADIS DESIGN SYSTEM — Colors & Type
+   Derived from the dradis-ce "Hera" theme
+   (app/assets/stylesheets/hera/modules/_colors.scss, themes.scss, base.scss)
+
+   Two layers:
+   1. RAW PALETTE  — the source-of-truth color scales (compile-time SCSS vars)
+   2. SEMANTIC     — runtime custom properties that components reference,
+                     with light (default) + dark theme values.
+   Plus a TYPE SYSTEM (font families + heading scale).
+   =================================================================== */
+
+/* -------------------------------------------------------------------
+   FONTS  (Proxima Nova — the Dradis product face)
+   ProximaNovaLight is the body default; ProximaNovaRegular is used for
+   bold text, headings, labels, table headers.
+   ------------------------------------------------------------------- */
+@font-face {
+  font-family: 'ProximaNovaLight';
+  src: url('fonts/proximanova-light.otf') format('opentype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'ProximaNovaRegular';
+  src: url('fonts/proximanova-regular.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  /* ============================================================
+     1. RAW PALETTE
+     ============================================================ */
+
+  /* Brand — green. The signature Dradis color. brand-500 is primary. */
+  --brand-50:  #f3f9f6;
+  --brand-100: #d2e7db;
+  --brand-200: #a5cfb6;   /* navbar background */
+  --brand-300: #77b792;
+  --brand-400: #4a9f6d;
+  --brand-500: #1d8749;   /* PRIMARY */
+  --brand-600: #176c3a;
+  --brand-700: #11512c;   /* navbar text */
+  --brand-800: #0c361d;
+  --brand-900: #092916;
+
+  /* Red — danger / destructive */
+  --red-100: #f5d4d8;
+  --red-200: #eba9b1;
+  --red-300: #e07f89;
+  --red-400: #d65462;
+  --red-500: #cc293b;     /* $red */
+  --red-600: #a3212f;
+  --red-700: #7a1923;
+  --red-800: #521018;
+  --red-900: #29080c;
+
+  /* Green — success / mint (lighter, distinct from brand) */
+  --green-100: #e7f7e6;
+  --green-200: #ceefcd;
+  --green-300: #b6e7b5;
+  --green-400: #9ddf9c;
+  --green-500: #85d783;   /* $green / success */
+  --green-600: #6aac69;
+  --green-700: #50814f;
+  --green-800: #355634;
+  --green-900: #1b2b1a;
+
+  /* Yellow — warning */
+  --yellow-100: #f9f5d6;
+  --yellow-200: #f3ebac;
+  --yellow-300: #ede183;
+  --yellow-400: #e7d759;
+  --yellow-500: #e1cd30;  /* $yellow / warning */
+  --yellow-600: #b4a426;
+  --yellow-700: #877b1d;
+  --yellow-800: #5a5213;
+  --yellow-900: #2d290a;
+
+  /* Orange — secondary accent (severity, etc.) */
+  --orange-100: #f5e1d4;
+  --orange-200: #ebc3a9;
+  --orange-300: #e0a47f;
+  --orange-400: #d68654;
+  --orange-500: #cc6829;
+  --orange-600: #a35321;
+  --orange-700: #7a3e19;
+  --orange-800: #522a10;
+  --orange-900: #291508;
+
+  /* Grey — neutrals */
+  --grey-100: #f4f4f4;
+  --grey-200: #e8e8e8;
+  --grey-300: #dddddd;
+  --grey-400: #d1d1d1;
+  --grey-500: #c6c6c6;
+  --grey-600: #9e9e9e;
+  --grey-700: #636363;
+  --grey-800: #4f4f4f;
+  --grey-900: #282828;
+
+  --black: #141414;
+  --white: #ffffff;
+
+  /* Lavender — special accent (teams, badges, Pro features) */
+  --lavender-dark:  #8261d5;
+  --lavender-light: #ac92ec;
+
+  /* Theme shortcuts (from variables.scss) */
+  --light:   var(--brand-200);
+  --primary: var(--brand-500);
+  --dark:    var(--brand-900);
+
+  /* ============================================================
+     2. SEMANTIC TOKENS — LIGHT THEME (default)
+     ============================================================ */
+
+  /* Backgrounds */
+  --brand-bg: var(--brand-500);
+  --nav-active-bg: var(--brand-500);
+  --primary-bg: var(--white);
+  --primary-bg-subtle: #f7f7f7;        /* darken(white, 3%) */
+  --secondary-bg: var(--grey-100);
+  --secondary-bg-strong: #dbdbdb;      /* darken(grey-100, 10%) */
+  --secondary-bg-subtle: #e7e7e7;      /* darken(grey-100, 5%) */
+
+  /* Borders */
+  --border-color: var(--grey-200);
+  --border-color-dark: var(--grey-900);
+
+  /* Text */
+  --text-default: var(--grey-900);
+  --text-muted: var(--grey-700);
+  --text-link: var(--brand-500);
+  --text-link-hover: #0b341c;          /* darken(brand-500, 20%) */
+  --text-error: var(--red-500);
+  --text-error-hover: var(--red-600);
+  --text-success: #3f6b3e;             /* darken(green-700, 10%) */
+  --text-warning: #6d6416;             /* darken(yellow-600, 15%) */
+  --pre-code-color: var(--brand-700);
+  --untagged-color: var(--grey-700);
+  --untagged-text: var(--white);
+
+  /* Tables / misc */
+  --table-stripe-bg: rgba(0, 0, 0, 0.05);
+  --icon-disabled: var(--grey-600);
+
+  /* Radii (Bootstrap $border-radius = 0.375rem; Dradis containers use 5px) */
+  --radius-sm: 0.25rem;    /* buttons, badges, board cards */
+  --radius:    0.375rem;   /* default bootstrap */
+  --radius-lg: 5px;        /* content-container, cards */
+  --radius-pill: 50rem;
+
+  /* Spacing (from variables.scss) */
+  --margin: 1.5rem;
+  --padding: 1.5rem;
+
+  /* Chrome dimensions */
+  --navbar-height: calc(3.2rem - 1px); /* @kind spacing */
+  --sidebar-width: 14rem;
+
+  /* Focus ring */
+  --focus-shadow: 0 0 0 0.2rem rgba(29, 135, 73, 0.5);
+
+  /* Shadows (light) — Dradis is shadow-light; mostly borders, soft drops */
+  --shadow-sm: 1px 1px 5px 0 rgba(232, 232, 232, 0.5);
+  --shadow-drag: 0 20px 30px 0 rgba(33, 55, 74, 0.2);
+
+  /* ============================================================
+     3. TYPE SYSTEM
+     ============================================================ */
+  --font-body: 'ProximaNovaLight', system-ui, -apple-system, sans-serif;
+  --font-strong: 'ProximaNovaRegular', system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --text-base: 0.95rem;    /* body default */
+  --text-small: 0.9rem;
+
+  /* Heading scale (≥1200px breakpoint from base.scss) */
+  --h1: 2rem;
+  --h2: 1.5rem;
+  --h3: 1.3rem;
+  --h4: 1.2rem;
+  --h5: 1.1rem;
+  --h6: 1rem;
+
+  color-scheme: light;
+}
+
+/* ============================================================
+   DARK THEME  — [data-theme='dark'] (and prefers-color-scheme)
+   ============================================================ */
+[data-theme='dark'] {
+  --brand-bg: var(--brand-600);
+  --nav-active-bg: var(--brand-600);
+  --primary-bg: var(--grey-900);
+  --primary-bg-subtle: var(--grey-800);
+  --secondary-bg: #232323;             /* darken(grey-900, 3%) */
+  --secondary-bg-strong: #3a3a3a;
+  --secondary-bg-subtle: #454545;
+
+  --border-color: var(--grey-700);
+  --border-color-dark: var(--grey-300);
+
+  --text-default: var(--grey-100);
+  --text-muted: var(--grey-400);
+  --text-link: var(--brand-300);
+  --text-link-hover: var(--brand-200);
+  --text-error: var(--red-300);
+  --text-error-hover: var(--red-200);
+  --text-success: var(--green-400);
+  --text-warning: var(--yellow-400);
+  --pre-code-color: var(--brand-300);
+  --untagged-color: var(--grey-400);
+  --untagged-text: var(--grey-900);
+
+  --table-stripe-bg: rgba(255, 255, 255, 0.05);
+  --icon-disabled: var(--grey-500);
+
+  color-scheme: dark;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT STYLES
+   Map raw tokens onto real HTML elements. Import this file and
+   these defaults apply; components can still override.
+   ============================================================ */
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  color: var(--text-default);
+  background-color: var(--primary-bg);
+  text-wrap: pretty;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-strong);
+  font-weight: 500;
+  color: var(--text-default);
+  line-height: 1.2;
+  margin: 0 0 0.5rem;
+}
+h1 { font-size: var(--h1); }
+h2 { font-size: var(--h2); }
+h3 { font-size: var(--h3); }
+h4 { font-size: var(--h4); }
+h5 { font-size: var(--h5); }
+h6 { font-size: var(--h6); }
+
+b, strong, th, .form-label { font-family: var(--font-strong); }
+
+a {
+  color: var(--text-link);
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+}
+a:hover { color: var(--text-link-hover); }
+
+code {
+  font-family: var(--font-mono);
+  background-color: var(--brand-100);
+  color: var(--primary);
+  border-radius: var(--radius);
+  padding: 0.15rem 0.5rem;
+  font-size: 0.9em;
+}
+
+pre {
+  background-color: var(--secondary-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+pre code { background: none; color: var(--pre-code-color); padding: 0; }
+
+blockquote {
+  border-left: 3px solid var(--primary);
+  padding-left: 1rem;
+  margin-left: 0;
+}
+
+::selection { background: var(--light); color: var(--text-default); }

--- a/.claude/skills/dradis-design/production-patterns.md
+++ b/.claude/skills/dradis-design/production-patterns.md
@@ -1,0 +1,247 @@
+# Dradis (Hera) — Production UI Patterns
+
+Decision rules for building UI **in the `dradis-ce` codebase**. The repo already
+holds the styles and markup; this file holds the **judgment** the codebase
+doesn't state — *which* pattern is correct and *when*. Every rule here is verified
+against the actual source (file references included).
+
+> **Canonical markup lives in the repo, not here.** Before building any component,
+> open the in-repo **Hera Style Guide** — `app/views/styles/index.html.erb` (route:
+> `/styles`) — and copy the real markup from its reveal-code blocks. This file tells
+> you which option to pick; the style guide tells you the exact tags/classes. Never
+> invent markup a component in the style guide already defines.
+
+---
+
+## 0. Editions & white-labeling (CE vs Pro) — color rules
+
+Pro extends CE; the **only design difference is the brand color**. Structure,
+components, and every rule below are identical across editions.
+
+- **Never hardcode a brand hex** (green *or* blue). Use `$brand-*` / `var(--brand-*)`
+  and the semantic tokens. CE compiles the green ramp; Pro's `_colors.scss`
+  `@import 'pro_colors'` swaps `$brand-100`–`900` to blue (`#1570cb` primary), and
+  because `themes.scss` references `$brand-*`, the whole UI recolors automatically.
+- **White-labeling (Pro):** a customer can override the brand on key chrome via
+  `--white-label-bg` / `--white-label-text` (body gets `.white-labeled`). So any
+  brand-colored chrome (navbar, primary surfaces) **must** use `.bg-primary` /
+  `.white-label-bg` / `.white-label-text` — never a literal brand color — or
+  white-labeling silently breaks. Verified against `hera/modules/_white_label.scss`.
+- **Edition branching in server code:** use `defined?(Dradis::Pro)` (the existing
+  codebase convention).
+
+---
+
+## 1. Page scaffold (index / show pages)
+
+Verified against `app/views/issues/index.html.erb`.
+
+- Wrap each page section in **`<div class="content-container">`** (white surface, grey
+  border, radius, uniform padding). This is the **default** page wrapper.
+- Page title is **`<h4 class="header-underline">`**, with the page-level action(s) in a
+  **`<span class="actions">`** *inside* the heading.
+- Breadcrumbs go through `content_for :breadcrumbs` as `<ol class="breadcrumb">`.
+- Sidebar (when present) goes through `content_for :sidebar`.
+- Page title text via `content_for :title`.
+- **Show pages** may lead with a tab bar (`<ul class="tabs-container nav nav-tabs main-tabs">`,
+  each tab a `nav-link` with a `fa-*` glyph), then a single `content-container` holding the
+  `tab-content`. The dots menu for page-level actions sits as the last `<li>` in the tab bar.
+  Verified against `nodes/show.html.erb`.
+
+```erb
+<% content_for :title, 'Issues summary' %>
+<div class="content-container">
+  <h4 class="header-underline">Issues
+    <span class="actions pt-1">
+      <div class="action"><!-- primary action, see §2 --></div>
+    </span>
+  </h4>
+  <!-- table (§5) or empty state (§6) -->
+</div>
+```
+
+---
+
+## 2. Buttons vs. links vs. actions (the #1 drift source)
+
+The split is **by context, not by "navigate vs. act."** Verified against
+`issues/_table.html.erb`, `issues/_actions.erb`, `issues/index.html.erb`,
+`hera/modules/_buttons.scss`.
+
+**A. Form & emphasis actions → real buttons.**
+- `btn btn-primary` for the single main action of a form/view (submit, save).
+- `btn btn-secondary` / `btn btn-outline-*` for lower emphasis.
+- `btn btn-danger` **only** for a destructive action presented as a button (rare; the
+  usual destructive affordance is a link — see D).
+- **One `btn-primary` per view.** Sentence case, verb-first label ("Save changes").
+
+**B. Page-header "New {Record}" action → an anchor, not a button.**
+On index pages the primary "New X" is a **`link_to` anchor** with a `fa-plus` icon,
+placed in the header `.actions` span — frequently a templates dropdown. It is **not**
+a `btn-primary`.
+```erb
+<span class="actions pt-1">
+  <div class="action">
+    <div class="dropdown">
+      <%= link_to 'javascript:void(0)', class: 'dropdown-toggle', data: { bs_toggle: 'dropdown' } do %>
+        <i class="fa-solid fa-plus me-1"></i>New Issue
+      <% end %>
+      <!-- templates dropdown -->
+    </div>
+  </div>
+</span>
+```
+
+**C. Row / table-cell / dots-menu item actions → anchors with icon + label.**
+Edit, View History, Send to, etc. are **`link_to` anchors**, each with a `fa-* fa-fw`
+icon and a label — **not** buttons.
+```erb
+<%= link_to edit_project_issue_path(current_project, issue) do %>
+  <i class="fa-solid fa-pencil"></i> Edit
+<% end %>
+```
+
+**D. Destructive actions → styled as error text (`text-error-hover`), never a button.**
+The **invariant**: destructive actions use `class: 'text-error-hover'` (or
+`'dropdown-item text-error-hover'` in a menu), a `fa-trash` icon, and the label
+"Delete" — and are **never** `button_to` or `<button>`. There are **two sanctioned
+mechanisms**, pick by how much confirmation the action needs:
+
+*D1 — Inline confirm link* (Issues, Evidence). A `method: :delete` anchor with a
+`data-confirm` that **spells out the consequence**:
+```erb
+<%= link_to [current_project, issue],
+    method: :delete,
+    data: { confirm: "Are you sure?\n\nProceeding will delete this issue and any associated evidence." },
+    class: 'text-error-hover' do %>
+  <i class="fa-solid fa-trash"></i> Delete
+<% end %>
+```
+
+*D2 — Modal trigger* (Nodes). When the delete needs a richer confirmation dialog,
+the trigger opens a modal instead:
+```erb
+<a href="#modal_delete_node" class="dropdown-item text-error-hover" tabindex="-1" data-bs-toggle="modal">
+  <i class="fa-solid fa-trash fa-fw"></i> Delete
+</a>
+```
+
+Verified against `issues/_table.html.erb`, `issues/_actions.erb`,
+`evidence/_actions.html.erb` (D1) and `nodes/show.html.erb` (D2).
+
+**D-modals. Non-destructive menu actions that open a modal** (Add subnode, Rename,
+Move, Merge) follow the same trigger shape — an anchor with `data-bs-toggle="modal"`,
+a `fa-* fa-fw` icon, and a label — just without `text-error-hover`:
+```erb
+<a href="#modal_rename_node" class="dropdown-item" tabindex="-1" data-bs-toggle="modal">
+  <i class="fa-solid fa-pencil fa-fw"></i> Rename
+</a>
+```
+
+**E. `btn-link` (button that looks like a plain text link).**
+Defined in `_buttons.scss` but **currently unused** in the app. Treat as a rare,
+sanctioned exception. **Never** hand-roll a link-looking button with ad-hoc CSS or
+utility classes — if you truly need one, use `.btn.btn-link` and nothing else.
+
+---
+
+## 3. Cards vs. content-container
+
+Verified against `app/views/styles/index.html.erb` (Cards & Content Container).
+
+- **`content-container`** = the default wrapper for **each section of a page**. Use it
+  unless the content is specifically a set of like items. Optional `header-underline` heading.
+- **`card`** = **multiple items of the same category** (e.g. the three "add issues"
+  methods). Variations: `card-header bg-primary` (emphasis) or `bg-default`; or a
+  header-less card. Separate in-card actions with an `<hr>`.
+- **Decision:** repeated peers of one category → cards. Anything else → content-container.
+- **Don't** nest `content-container`s inside cards, and don't use a card as a one-off
+  page section.
+
+---
+
+## 4. Forms
+
+Verified against `app/views/styles/index.html.erb` (Form Elements) and `issues/_form.html.erb`.
+
+- Field group: `<div class="mb-3">` wrapping `<label class="form-label">` + control.
+- Controls: `form-control` (text/textarea), `form-select` (selects; combobox via
+  `data-combobox-config`).
+- Validation states: `is-valid` / `is-invalid` on the control.
+- Submit: `btn btn-primary` (one per form). `disabled` for disabled inputs.
+- Labels are sentence case.
+
+---
+
+## 5. Tables (index data)
+
+Verified against `issues/_table.html.erb`.
+
+- `tag.table class: 'table table-striped mb-0'` with `data-behavior="dradis-datatable"`.
+- First column = `select-checkbox`; last column = `column-actions` holding the row's
+  Edit (anchor) + Delete (delete-link, §2D).
+- Hidden utility columns use `data-column-visible="false"`.
+- Select via `data` attributes (`data-behavior`), never classes/IDs (repo JS convention).
+
+---
+
+## 6. Empty states
+
+Verified against `app/views/styles/index.html.erb` (Empty States), `issues/index.html.erb`,
+`issues/_empty_state_actions.html.erb`.
+
+- Render the shared partial: `render 'shared/empty_state', name:, docs_link:, text:, actions_partial:`.
+- Anatomy: SVG icon (`empty-state-icon`) → title **"You don't have any {record} yet"** →
+  one-line `{record}` description → optional CTA / `empty-state-docs-link` ("More about {record}").
+- The `text:` teaches what the record is *for* (instructional voice), it doesn't just say "no data".
+- Multi-method empty states (like Issues) use a row of `card add-issues` cards, one per method.
+
+---
+
+## 7. Voice, casing, glyphs
+
+- **Voice:** direct, instructional, second-person, confident-not-hypey. Page/section
+  titles are imperative or plain nouns ("Issues", "Manage your projects"). Empty states teach.
+- **Casing:** sentence case for buttons, labels, menu items, titles. Not Title Case, not ALL CAPS.
+- **No emoji** in product UI.
+- **Glyphs (Font Awesome 6):** `fa-bug` = issues, `fa-brands fa-trello` = methodologies,
+  `fa-sitemap` = nodes, `fa-flag` = evidence, `fa-plus` = new, `fa-pencil` = edit,
+  `fa-trash` = delete, `fa-history` = history, `fa-ellipsis-h` = dots menu. Use `fa-fw`
+  for fixed-width alignment in menus.
+- **Domain nouns:** project (engagement), issue (finding/vuln), evidence (uncountable —
+  never "evidences"), node (target), methodology/board, tag (severity), Issue Library,
+  QA states (Draft → Ready for review → Published).
+
+---
+
+## 8. Pre-flight checklist (run before finishing any UI change)
+
+Self-check these — they catch the drift that actually happens:
+
+1. **Markup copied from the Hera Style Guide** (`/styles`), not invented?
+2. **One `btn-primary`** in the view, and is it the genuine main action?
+3. **Right action affordance for context** — form action = button; page-header "New X" =
+   header anchor; row/menu actions = `link_to` anchors with icon+label?
+4. **Destructive action** = `text-error-hover` + `fa-trash` + "Delete", via either a
+   `method: :delete` confirm-link or a modal trigger — never `button_to`/`<button>`?
+5. **Container choice correct** — `content-container` for a page section, `card` only for
+   repeated like items?
+6. **Styling via existing SASS vars / classes** — no inline `style`, no ID selectors, no
+   ad-hoc hex (no literal brand green/blue — use `$brand-*`), no `!important`, and
+   brand-colored chrome uses `.bg-primary`/`.white-label-*` so white-labeling survives?
+7. **Copy** in sentence case, instructional voice, correct domain nouns, no emoji?
+8. **JS/CSS hooks via `data-behavior`**, not classes or IDs?
+
+---
+
+## 9. Anti-patterns (don't)
+
+- ❌ A bare `<button>`/`<a>` styled to look like a text link via custom CSS (use `btn-link` if ever needed).
+- ❌ `btn-primary` on more than one action in a view.
+- ❌ A `btn-primary` for the index-page "New X" action (it's a header anchor).
+- ❌ `button_to` / `<button>` for Delete (the convention is a `text-error-hover` `method: :delete` link **or** a modal trigger).
+- ❌ A `card` used as a generic one-off page section (use `content-container`).
+- ❌ Title Case or ALL CAPS labels; emoji in UI; "evidences".
+- ❌ Hardcoded hex (except user-defined tag/severity colors) or inline styles. A literal
+  brand green/blue is always wrong — use `$brand-*`; it breaks the other edition and white-labeling.
+- ❌ Selecting elements by class/ID in JS instead of `data-behavior`.


### PR DESCRIPTION
### Summary

Adds the Dradis CE design system as a `/dradis-design` Claude Code skill under `.claude/skills/dradis-design/`. The skill was generated with Claude Design and captures the brand, visual foundations, component vocabulary, and voice rules for Dradis CE so agents can produce on-brand UI without a designer in the loop.

The skill operates in two modes:
- **Throwaway HTML** (mocks, slides, prototypes) — uses `colors_and_type.css` for tokens and the Font Awesome CDN for icons
- **Production code** — reads `production-patterns.md` for verified decision rules (buttons vs. links, card patterns, page scaffold, forms, tables, empty states), then defers to the in-repo Hera Style Guide for canonical markup

Key files included:
- `SKILL.md` — agent-facing manifest and usage instructions
- `README.md` — full brand context (voice/tone, visual foundations, iconography)
- `production-patterns.md` — verified decision rules and pre-flight checklist for production UI work
- `colors_and_type.css` — token layer for HTML artifacts (mirrors the repo's SASS vars; mocks only)

### Other Information

The companion `dradis-pro-design` skill (Pro-only screens and the green→blue brand swap) is synced to Pro in secroots/dradis-pro#2826 + secroots/dradis-pro#2827.

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Commit message has a detailed description of what changed and why.