### PR TITLE
Guard against nil env in Roslin#language_tool_configured?

### DIFF
--- a/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/agents/roslin.rb
@@ -52,7 +52,7 @@ module Dradis::Plugins::Echo
       end
 
       def language_tool_configured?
-        instance.env['LANGUAGETOOL_ADDRESS'].present?
+        instance.env && instance.env['LANGUAGETOOL_ADDRESS'].present?
       rescue ActiveRecord::RecordNotFound
         false
       end


### PR DESCRIPTION
### Summary

The \`env\` column on \`dradis_plugins_echo_agents\` can be nil if a Roslin agent record was created before the column existed. \`Roslin#language_tool_configured?\` calls \`env['LANGUAGETOOL_ADDRESS']\` which raises \`NoMethodError\` when \`env\` is nil.

Add a nil guard so the method returns false instead of crashing.

### Testing steps

N/A — not user-facing.

### Other Information

N/A

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.