### PR TITLE
Bump net-imap to 0.6.4.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - puma
+    - net-imap, puma
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ gem 'whenever', require: false
 
 gem 'net-smtp'
 gem 'net-pop'
-gem 'net-imap', '>= 0.6.4'
+gem 'net-imap', '>= 0.6.4.1'
 
 gem 'puma', '~> 7.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -669,7 +669,7 @@ DEPENDENCIES
   local_time (>= 2.0.0)
   matrix
   mini_racer
-  net-imap (>= 0.6.4)
+  net-imap (>= 0.6.4.1)
   net-pop
   net-smtp
   nokogiri (>= 1.19.3)


### PR DESCRIPTION
### Summary

Bump net-imap to 0.6.4.1

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
