### PR TITLE
Remove unnecessary alignment spacing in model initializers

### DIFF
--- a/app/models/diffed_revision.rb
+++ b/app/models/diffed_revision.rb
@@ -4,7 +4,7 @@ class DiffedRevision
   def initialize(revision, record)
     raise 'undiffable revision' unless revision.event == 'update'
     @revision = revision
-    @record   = record
+    @record = record
   end
 
   def diff

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,9 +5,9 @@ class Search
   attr_reader :page, :project, :query, :scope
 
   def initialize(query:, scope: :all, page: 1, project:)
-    @query   = query
-    @scope   = scope
-    @page    = page
+    @query = query
+    @scope = scope
+    @page = page
     @project = project
   end
 

--- a/engines/dradis-echo/spec/services/dradis/plugins/echo/language_tool_service_spec.rb
+++ b/engines/dradis-echo/spec/services/dradis/plugins/echo/language_tool_service_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 describe Dradis::Plugins::Echo::LanguageToolService do
   let(:service) do
     described_class.new(
-      fields:  { 'Description' => 'This are a mistake.' },
+      fields: { 'Description' => 'This are a mistake.' },
       address: 'http://languagetool.local:8081'
     )
   end
 
   def stub_http(body:)
     response = instance_double(Net::HTTPResponse, body: body)
-    http     = instance_double(Net::HTTP)
+    http = instance_double(Net::HTTP)
     allow(http).to receive(:post).and_return(response)
     allow(Net::HTTP).to receive(:start).and_yield(http)
   end
@@ -21,9 +21,9 @@ describe Dradis::Plugins::Echo::LanguageToolService do
         {
           'matches' => [
             {
-              'offset'       => 5,
-              'length'       => 3,
-              'message'      => 'Possible agreement error',
+              'offset' => 5,
+              'length' => 3,
+              'message' => 'Possible agreement error',
               'replacements' => [{ 'value' => 'is' }, { 'value' => 'was' }]
             }
           ]
@@ -50,9 +50,9 @@ describe Dradis::Plugins::Echo::LanguageToolService do
         many_body = {
           'matches' => [
             {
-              'offset'       => 0,
-              'length'       => 4,
-              'message'      => 'Error',
+              'offset' => 0,
+              'length' => 4,
+              'message' => 'Error',
               'replacements' => [1, 2, 3, 4].map { |n| { 'value' => "r#{n}" } }
             }
           ]


### PR DESCRIPTION
### Summary

Resolves `Layout/ExtraSpacing` RuboCop offenses in two models by removing
the vertical alignment whitespace in their initializers:

- `app/models/diffed_revision.rb`
- `app/models/search.rb`

No behavioural change — whitespace only.

### Testing steps

N/A — whitespace-only refactor. Covered by existing specs (`spec/models/search_spec.rb`).

### Other Information

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry (not required — internal lint refactor, no user-facing change)
- [x] Commit message has a detailed description of what changed and why.