### PR TITLE
Style unauthenticated pages for dark mode support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [v#.#.#] ([month] [YYYY])
+  - UI: add dark mode support to the login and setup wizard pages
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:

--- a/app/assets/stylesheets/application/easter_eggs/december.scss
+++ b/app/assets/stylesheets/application/easter_eggs/december.scss
@@ -1,5 +1,5 @@
 body.unauthenticated:not(.contributors).december {
-  @include easter-egg-theme(#c30f16);
+  @include easter-egg-theme(#ec2029);
 
   &::after,
   &::before {

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -18,7 +18,7 @@ body.unauthenticated {
   min-height: 100vh;
 
   a {
-    color: var(--primary);
+    color: var(--text-link);
     transition: color 0.2s ease-in-out;
 
     &:hover {
@@ -48,13 +48,17 @@ body.unauthenticated {
     }
 
     &.btn-primary {
-      border: 0px none;
       background: var(--primary);
-      font-weight: 300;
+      border-color: var(--primary);
+      color: $white;
 
       &:hover,
+      &:focus,
+      &:focus-visible,
+      &:active,
       &:not(:disabled):not(.disabled):active {
         background: var(--dark);
+        border-color: var(--dark);
       }
     }
   }

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -60,7 +60,7 @@ body.unauthenticated {
   }
 
   .error-text {
-    color: red;
+    color: var(--text-error);
     font-size: 80%;
   }
 

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -64,7 +64,7 @@ body.unauthenticated {
 
     &.btn-primary {
       background: var(--primary);
-      border-color: var(--primary);
+      border: none;
       color: $white;
 
       &:hover,
@@ -73,7 +73,6 @@ body.unauthenticated {
       &:active,
       &:not(:disabled):not(.disabled):active {
         background: var(--dark);
-        border-color: var(--dark);
       }
     }
   }

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -174,14 +174,24 @@ body.unauthenticated {
     }
   }
 
-  @media (prefers-color-scheme: dark) {
+}
+
+@mixin unauthenticated-dark {
+  body.unauthenticated {
+    color: var(--text-revert);
+
+    a {
+      color: var(--primary);
+    }
+
     .form-container {
-      --bs-card-bg: #{$brand-100};
+      background-color: $brand-100;
     }
 
     .form-control {
       background-color: transparent;
-      border-color: var(--text-default);
+      border-color: var(--text-revert);
+      color: var(--text-revert);
 
       &:focus {
         background-color: transparent;
@@ -189,7 +199,17 @@ body.unauthenticated {
     }
 
     .mission-container span {
-      color: rgba(255, 255, 255, 0.8);
+      color: $brand-100;
     }
   }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    @include unauthenticated-dark;
+  }
+}
+
+[data-theme='dark'] {
+  @include unauthenticated-dark;
 }

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -22,7 +22,7 @@ body.unauthenticated {
     transition: color 0.2s ease-in-out;
 
     &:hover {
-      color: var(--dark);
+      color: var(--text-link-hover);
       text-decoration: none;
     }
   }

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -175,6 +175,10 @@ body.unauthenticated {
   }
 
   @media (prefers-color-scheme: dark) {
+    .form-container {
+      --bs-card-bg: #{$brand-100};
+    }
+
     .form-control {
       background-color: transparent;
       border-color: var(--text-default);
@@ -182,10 +186,6 @@ body.unauthenticated {
       &:focus {
         background-color: transparent;
       }
-    }
-
-    .form-container {
-      --bs-card-bg: rgba(255, 255, 255, 0.8);
     }
 
     .mission-container span {

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -173,33 +173,20 @@ body.unauthenticated {
       line-height: 4rem;
     }
   }
-
 }
 
 @mixin unauthenticated-dark {
   body.unauthenticated {
-    color: var(--text-revert);
-
-    a {
-      color: var(--primary);
-    }
-
     .form-container {
-      background-color: $brand-100;
+      background-color: var(--primary-bg-subtle);
     }
 
     .form-control {
       background-color: transparent;
-      border-color: var(--text-revert);
-      color: var(--text-revert);
 
       &:focus {
         background-color: transparent;
       }
-    }
-
-    .mission-container span {
-      color: $brand-100;
     }
   }
 }

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -47,6 +47,21 @@ body.unauthenticated {
       width: 100%;
     }
 
+    &.btn-outline-primary {
+      background-color: transparent;
+      border: 1px solid var(--text-link);
+      color: var(--text-link);
+
+      &:hover,
+      &:focus,
+      &:active,
+      &:not(:disabled):not(.disabled):active {
+        background: var(--text-link);
+        border-color: var(--text-link);
+        color: $white;
+      }
+    }
+
     &.btn-primary {
       background: var(--primary);
       border-color: var(--primary);

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -175,6 +175,15 @@ body.unauthenticated {
   }
 
   @media (prefers-color-scheme: dark) {
+    .form-control {
+      background-color: transparent;
+      border-color: var(--text-default);
+
+      &:focus {
+        background-color: transparent;
+      }
+    }
+
     .form-container {
       --bs-card-bg: rgba(255, 255, 255, 0.8);
     }

--- a/app/assets/stylesheets/application/sessions.scss
+++ b/app/assets/stylesheets/application/sessions.scss
@@ -169,4 +169,14 @@ body.unauthenticated {
       line-height: 4rem;
     }
   }
+
+  @media (prefers-color-scheme: dark) {
+    .form-container {
+      --bs-card-bg: rgba(255, 255, 255, 0.8);
+    }
+
+    .mission-container span {
+      color: rgba(255, 255, 255, 0.8);
+    }
+  }
 }

--- a/app/assets/stylesheets/hera/modules/_buttons.scss
+++ b/app/assets/stylesheets/hera/modules/_buttons.scss
@@ -121,19 +121,14 @@
       color: inherit;
     }
 
+    &:hover,
     &:focus,
     &:focus-visible,
     &:active,
     &:not(:disabled):not(.disabled):active {
-      border-color: $primary;
-      background: $primary;
-      color: $white;
-    }
-
-    &:hover {
-      background: $light;
-      border-color: $dark;
-      color: $dark;
+      background: var(--text-link);
+      border-color: var(--text-link);
+      color: var(--text-inverted);
     }
   }
 

--- a/app/assets/stylesheets/hera/modules/_divider.scss
+++ b/app/assets/stylesheets/hera/modules/_divider.scss
@@ -1,18 +1,19 @@
 .divider {
-  border-top: 1px solid var(--border-color);
-  height: 0;
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
   margin: 0.25rem 0;
-  position: relative;
+
+  &::before,
+  &::after {
+    border-top: 1px solid var(--border-color);
+    content: '';
+    flex: 1;
+  }
 
   .divider-label {
-    background-color: var(--primary-bg);
     color: var(--text-default);
     font-size: $text-small;
-    left: 50%;
-    padding: 0 0.5rem;
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
 
     &.lead {
       font-size: 1.25rem;

--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -43,6 +43,12 @@
     }
   }
 
+  // Card overrides
+  .card {
+    --bs-card-bg: #{$grey-900};
+    --bs-card-cap-bg: #{$grey-800};
+  }
+
   // Forms
   --form-select-caret: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23d1d1d1' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
   --form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba(255, 255, 255, 0.25)'/%3e%3c/svg%3e");

--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -69,6 +69,7 @@
   --text-default: #{$grey-100};
   --text-error: #{$red-300};
   --text-error-hover: #{$red-200};
+  --text-inverted: #{$grey-900};
   --text-link: #{$brand-300};
   --text-link-hover: #{$brand-200};
   --text-muted: #{$grey-400};
@@ -142,6 +143,7 @@
   --text-default: #{$grey-900};
   --text-error: #{$red-500};
   --text-error-hover: #{$red-600};
+  --text-inverted: #{$grey-100};
   --text-link: #{$brand-500};
   --text-link-hover: #{darken($brand-500, 20%)};
   --text-muted: #{$grey-700};

--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -71,9 +71,8 @@
   --text-error-hover: #{$red-200};
   --text-inverted: #{$grey-900};
   --text-link: #{$brand-200};
-  --text-link-hover: #{$brand-200};
+  --text-link-hover: #{$brand-300};
   --text-muted: #{$grey-400};
-  --text-revert: #{$grey-900};
   --text-success: #{$green-400};
   --text-warning: #{$yellow-400};
   --untagged-color: #{$grey-400};
@@ -148,7 +147,6 @@
   --text-link: #{$brand-500};
   --text-link-hover: #{darken($brand-500, 20%)};
   --text-muted: #{$grey-700};
-  --text-revert: #{$grey-100};
   --text-success: #{darken($green-700, 10%)};
   --text-warning: #{darken($yellow-600, 15%)};
   --untagged-color: #{$grey-700};

--- a/app/assets/stylesheets/hera/themes.scss
+++ b/app/assets/stylesheets/hera/themes.scss
@@ -6,7 +6,7 @@
 
 @mixin dark-theme {
   // Backgrounds
-  --brand-bg: #{$brand-600};
+  --brand-bg: #{$brand-500};
   --nav-active-bg: #{$brand-600};
   --primary-bg: #{$grey-900};
   --primary-bg-subtle: #{$grey-800};
@@ -70,9 +70,10 @@
   --text-error: #{$red-300};
   --text-error-hover: #{$red-200};
   --text-inverted: #{$grey-900};
-  --text-link: #{$brand-300};
+  --text-link: #{$brand-200};
   --text-link-hover: #{$brand-200};
   --text-muted: #{$grey-400};
+  --text-revert: #{$grey-900};
   --text-success: #{$green-400};
   --text-warning: #{$yellow-400};
   --untagged-color: #{$grey-400};
@@ -107,7 +108,7 @@
   --brand-bg: #{$brand-500};
   --nav-active-bg: #{$brand-500};
   --primary-bg: #{$white};
-  --primary-bg-subtle: #{darken($white, 3%)}; // darken($primary-bg, 3%)
+  --primary-bg-subtle: #{darken($white, 1%)}; // darken($primary-bg, 1%)
   --secondary-bg: #{$grey-100};
   --secondary-bg-strong: #{darken($grey-100, 10%)}; // darken($secondary-bg, 10%)
   --secondary-bg-subtle: #{darken($grey-100, 5%)}; // darken($secondary-bg, 5%)
@@ -147,6 +148,7 @@
   --text-link: #{$brand-500};
   --text-link-hover: #{darken($brand-500, 20%)};
   --text-muted: #{$grey-700};
+  --text-revert: #{$grey-100};
   --text-success: #{darken($green-700, 10%)};
   --text-warning: #{darken($yellow-600, 15%)};
   --untagged-color: #{$grey-700};

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -38,8 +38,9 @@ a {
 }
 
 .btn-experience {
-  border: 1.5px solid $border-color;
+  border: 1.5px solid var(--border-color);
   border-radius: 5px;
+  color: var(--text-default);
   box-shadow: 0px 0px 0px 0px rgba(62, 66, 66, 0.1);
   height: 100%;
   padding: 1.375rem 1.85rem;
@@ -49,12 +50,12 @@ a {
 
   &:focus,
   &:hover {
-    border-color: $primary;
+    border-color: var(--brand-bg);
     box-shadow: 0px 0px 50px 0px rgba(62, 66, 66, 0.1);
   }
 
   p {
-    color: $primary;
+    color: var(--brand-bg);
     font-weight: bold;
   }
 
@@ -66,7 +67,7 @@ a {
 
     i {
       bottom: 0;
-      color: $primary;
+      color: var(--brand-bg);
       font-size: 1rem;
       position: absolute;
       right: 0;
@@ -83,9 +84,30 @@ a {
   }
 }
 
+.btn-outline-primary {
+  border-color: var(--text-link);
+  color: var(--text-link);
+
+  &:focus,
+  &:focus-visible,
+  &:active,
+  &:not(:disabled):not(.disabled):active {
+    background: $primary;
+    border-color: $primary;
+    color: $white;
+  }
+
+  &:hover {
+    background: $light;
+    border-color: $dark;
+    color: $dark;
+  }
+}
+
 .btn-primary {
-  background-color: $primary;
-  border-color: $primary;
+  background-color: var(--brand-bg);
+  border-color: var(--brand-bg);
+  color: $white;
 
   &:hover,
   &:focus,
@@ -93,22 +115,6 @@ a {
   &:active,
   &:not(:disabled):not(.disabled):active {
     background-color: darken($primary, 10);
-    border-color: darken($primary, 10);
-  }
-}
-
-.btn-outline-primary {
-  border-color: $primary;
-  color: $primary;
-
-  &:hover,
-  &:focus,
-  &:focus-visible,
-  &:active,
-  &:not(:disabled):not(.disabled):active {
-    border-color: $primary;
-    background: $primary;
-    color: $white;
   }
 }
 
@@ -124,14 +130,31 @@ a {
   width: 100%;
 }
 
+.form-control,
+.form-select {
+  background-color: var(--primary-bg);
+  border-color: var(--border-color);
+  color: var(--text-default);
+
+  &:focus {
+    background-color: var(--primary-bg);
+    border-color: var(--border-color);
+    color: var(--text-default);
+  }
+}
+
+.form-label {
+  color: var(--text-default);
+}
+
 .h-100vh {
   height: 100vh;
 }
 
 h1 {
-  text-align: center;
   font-size: 1.3rem;
   margin: 3rem 0 2rem;
+  text-align: center;
 }
 
 label {
@@ -149,15 +172,15 @@ label {
   width: 66%;
 
   &:after {
-    border-top: 1.5px solid $primary;
+    border-top: 1.5px solid var(--brand-bg);
     content: '';
     display: block;
   }
 
   &-indicator {
     align-items: center;
-    background-color: $white;
-    border: 1.5px solid $primary;
+    background-color: var(--primary-bg);
+    border: 1.5px solid var(--brand-bg);
     border-radius: 50%;
     display: flex;
     font-size: 0.8rem;
@@ -169,7 +192,7 @@ label {
     width: 1.3rem;
 
     &.active {
-      background-color: $primary;
+      background-color: var(--brand-bg);
     }
 
     &:first-of-type {

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -40,8 +40,8 @@ a {
 .btn-experience {
   border: 1.5px solid var(--border-color);
   border-radius: 5px;
-  color: var(--text-default);
   box-shadow: 0px 0px 0px 0px rgba(62, 66, 66, 0.1);
+  color: var(--text-default);
   height: 100%;
   padding: 1.375rem 1.85rem;
   text-align: left;
@@ -50,12 +50,12 @@ a {
 
   &:focus,
   &:hover {
-    border-color: var(--brand-bg);
+    border-color: var(--text-link);
     box-shadow: 0px 0px 50px 0px rgba(62, 66, 66, 0.1);
   }
 
   p {
-    color: var(--brand-bg);
+    color: var(--text-link);
     font-weight: bold;
   }
 
@@ -67,7 +67,7 @@ a {
 
     i {
       bottom: 0;
-      color: var(--brand-bg);
+      color: var(--text-link);
       font-size: 1rem;
       position: absolute;
       right: 0;
@@ -88,19 +88,14 @@ a {
   border-color: var(--text-link);
   color: var(--text-link);
 
+  &:hover,
   &:focus,
   &:focus-visible,
   &:active,
   &:not(:disabled):not(.disabled):active {
-    background: $primary;
-    border-color: $primary;
-    color: $white;
-  }
-
-  &:hover {
-    background: $light;
-    border-color: $dark;
-    color: $dark;
+    background: var(--text-link);
+    border-color: var(--text-link);
+    color: var(--text-inverted);
   }
 }
 
@@ -115,6 +110,8 @@ a {
   &:active,
   &:not(:disabled):not(.disabled):active {
     background-color: darken($primary, 10);
+    border-color: darken($primary, 10);
+    color: $white;
   }
 }
 

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -16,11 +16,11 @@ body {
 
 a {
   color: var(--text-link);
+  text-decoration: none;
   transition: color 0.2s ease-in-out;
 
   &:hover {
     color: var(--text-link-hover);
-    text-decoration: none;
   }
 }
 
@@ -136,7 +136,8 @@ a {
   &:focus {
     background: transparent;
     border-color: var(--brand-bg);
-    box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--brand-bg) 50%, transparent);
+    box-shadow: 0 0 0 0.2rem
+      color-mix(in srgb, var(--brand-bg) 50%, transparent);
     color: var(--text-default);
     outline: 0;
   }

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -140,6 +140,20 @@ a {
   }
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    .form-control,
+    .form-select {
+      background-color: transparent;
+      border-color: var(--text-default);
+
+      &:focus {
+        background-color: transparent;
+      }
+    }
+  }
+}
+
 .form-label {
   color: var(--text-default);
 }

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -38,10 +38,9 @@ a {
 }
 
 .btn-experience {
-  border: 1.5px solid var(--border-color);
+  border: 1.5px solid $border-color;
   border-radius: 5px;
   box-shadow: 0px 0px 0px 0px rgba(62, 66, 66, 0.1);
-  color: var(--text-default);
   height: 100%;
   padding: 1.375rem 1.85rem;
   text-align: left;
@@ -50,12 +49,12 @@ a {
 
   &:focus,
   &:hover {
-    border-color: var(--text-link);
+    border-color: $primary;
     box-shadow: 0px 0px 50px 0px rgba(62, 66, 66, 0.1);
   }
 
   p {
-    color: var(--text-link);
+    color: $primary;
     font-weight: bold;
   }
 
@@ -67,7 +66,7 @@ a {
 
     i {
       bottom: 0;
-      color: var(--text-link);
+      color: $primary;
       font-size: 1rem;
       position: absolute;
       right: 0;
@@ -84,25 +83,9 @@ a {
   }
 }
 
-.btn-outline-primary {
-  border-color: var(--text-link);
-  color: var(--text-link);
-
-  &:hover,
-  &:focus,
-  &:focus-visible,
-  &:active,
-  &:not(:disabled):not(.disabled):active {
-    background: var(--text-link);
-    border-color: var(--text-link);
-    color: var(--text-inverted);
-  }
-}
-
 .btn-primary {
-  background-color: var(--brand-bg);
-  border-color: var(--brand-bg);
-  color: $white;
+  background-color: $primary;
+  border-color: $primary;
 
   &:hover,
   &:focus,
@@ -111,6 +94,20 @@ a {
   &:not(:disabled):not(.disabled):active {
     background-color: darken($primary, 10);
     border-color: darken($primary, 10);
+  }
+}
+
+.btn-outline-primary {
+  border-color: $primary;
+  color: $primary;
+
+  &:hover,
+  &:focus,
+  &:focus-visible,
+  &:active,
+  &:not(:disabled):not(.disabled):active {
+    border-color: $primary;
+    background: $primary;
     color: $white;
   }
 }
@@ -127,45 +124,14 @@ a {
   width: 100%;
 }
 
-.form-control,
-.form-select {
-  background-color: var(--primary-bg);
-  border-color: var(--border-color);
-  color: var(--text-default);
-
-  &:focus {
-    background-color: var(--primary-bg);
-    border-color: var(--border-color);
-    color: var(--text-default);
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']) {
-    .form-control,
-    .form-select {
-      background-color: transparent;
-      border-color: var(--text-default);
-
-      &:focus {
-        background-color: transparent;
-      }
-    }
-  }
-}
-
-.form-label {
-  color: var(--text-default);
-}
-
 .h-100vh {
   height: 100vh;
 }
 
 h1 {
+  text-align: center;
   font-size: 1.3rem;
   margin: 3rem 0 2rem;
-  text-align: center;
 }
 
 label {
@@ -183,15 +149,15 @@ label {
   width: 66%;
 
   &:after {
-    border-top: 1.5px solid var(--brand-bg);
+    border-top: 1.5px solid $primary;
     content: '';
     display: block;
   }
 
   &-indicator {
     align-items: center;
-    background-color: var(--primary-bg);
-    border: 1.5px solid var(--brand-bg);
+    background-color: $white;
+    border: 1.5px solid $primary;
     border-radius: 50%;
     display: flex;
     font-size: 0.8rem;
@@ -203,7 +169,7 @@ label {
     width: 1.3rem;
 
     &.active {
-      background-color: var(--brand-bg);
+      background-color: $primary;
     }
 
     &:first-of-type {

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -38,27 +38,33 @@ a {
 }
 
 .btn-experience {
-  border: 1.5px solid $border-color;
+  border: 1.5px solid var(--text-link);
   border-radius: 5px;
   box-shadow: 0px 0px 0px 0px rgba(62, 66, 66, 0.1);
+  color: var(--text-link);
   height: 100%;
   padding: 1.375rem 1.85rem;
   text-align: left;
-  transition: box-shadow 0.2s ease-in-out, border-color 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, color 0.2s ease-in-out;
   width: 100%;
 
   &:focus,
-  &:hover {
-    border-color: $primary;
+  &:hover,
+  &:active,
+  &:not(:disabled):not(.disabled):active {
+    background: var(--text-link);
+    border-color: var(--text-link);
     box-shadow: 0px 0px 50px 0px rgba(62, 66, 66, 0.1);
+    color: var(--text-inverted);
   }
 
   p {
-    color: $primary;
+    color: inherit;
     font-weight: bold;
   }
 
   span {
+    color: inherit;
     display: block;
     font-size: 0.8rem;
     position: relative;
@@ -66,7 +72,7 @@ a {
 
     i {
       bottom: 0;
-      color: $primary;
+      color: inherit;
       font-size: 1rem;
       position: absolute;
       right: 0;
@@ -84,8 +90,9 @@ a {
 }
 
 .btn-primary {
-  background-color: $primary;
-  border-color: $primary;
+  background-color: var(--brand-bg);
+  border-color: var(--brand-bg);
+  color: $white;
 
   &:hover,
   &:focus,
@@ -94,27 +101,22 @@ a {
   &:not(:disabled):not(.disabled):active {
     background-color: darken($primary, 10);
     border-color: darken($primary, 10);
+    color: $white;
   }
 }
 
 .btn-outline-primary {
-  border-color: $primary;
-  color: $primary;
+  border-color: var(--text-link);
+  color: var(--text-link);
 
   &:hover,
   &:focus,
   &:focus-visible,
   &:active,
   &:not(:disabled):not(.disabled):active {
-    border-color: $primary;
-    background: $primary;
-    color: $white;
-  }
-}
-
-.container {
-  &.narrow {
-    max-width: 500px;
+    background: var(--text-link);
+    border-color: var(--text-link);
+    color: var(--text-inverted);
   }
 }
 
@@ -124,8 +126,23 @@ a {
   width: 100%;
 }
 
+.form-control,
+.form-select {
+  background-color: var(--primary-bg-subtle);
+  border-color: var(--border-color);
+  color: var(--text-default);
+
+  &:focus {
+    background-color: var(--primary-bg-subtle);
+    border-color: var(--brand-bg);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px var(--brand-bg);
+    color: var(--text-default);
+    outline: 0;
+  }
+}
+
 .h-100vh {
-  height: 100vh;
+  min-height: 100vh;
 }
 
 h1 {
@@ -143,21 +160,28 @@ label {
   max-width: 150px;
 }
 
+.setup-wrapper {
+  background: var(--primary-bg-subtle);
+  border: 1px solid var(--border-color);
+  border-radius: 0.25rem;
+  max-width: 600px;
+}
+
 .setup-progress {
   margin: 3rem auto 0;
   position: relative;
   width: 66%;
 
   &:after {
-    border-top: 1.5px solid $primary;
+    border-top: 1.5px solid var(--brand-bg);
     content: '';
     display: block;
   }
 
   &-indicator {
     align-items: center;
-    background-color: $white;
-    border: 1.5px solid $primary;
+    background-color: var(--primary-bg-subtle);
+    border: 1.5px solid var(--brand-bg);
     border-radius: 50%;
     display: flex;
     font-size: 0.8rem;
@@ -169,7 +193,7 @@ label {
     width: 1.3rem;
 
     &.active {
-      background-color: $primary;
+      background-color: var(--brand-bg);
     }
 
     &:first-of-type {

--- a/app/assets/stylesheets/setup/setup.scss
+++ b/app/assets/stylesheets/setup/setup.scss
@@ -45,7 +45,8 @@ a {
   height: 100%;
   padding: 1.375rem 1.85rem;
   text-align: left;
-  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, color 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out, color 0.2s ease-in-out;
   width: 100%;
 
   &:focus,
@@ -128,14 +129,14 @@ a {
 
 .form-control,
 .form-select {
-  background-color: var(--primary-bg-subtle);
+  background-color: transparent;
   border-color: var(--border-color);
   color: var(--text-default);
 
   &:focus {
-    background-color: var(--primary-bg-subtle);
+    background: transparent;
     border-color: var(--brand-bg);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px var(--brand-bg);
+    box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--brand-bg) 50%, transparent);
     color: var(--text-default);
     outline: 0;
   }

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -29,6 +29,7 @@ export default class extends Controller {
   }
 
   persist(theme) {
+    localStorage.setItem('dradis-theme', theme)
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
     fetch(this.preferencesPathValue, {
       method: "PATCH",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="auto">
   <head>
     <title><%= [content_for(:title), 'Dradis Community Edition'].compact.join(' | ') %></title>
+    <script>(() => { const t = localStorage.getItem('dradis-theme'); if (t) document.documentElement.dataset.theme = t; })();</script>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track' => true %>
     <%= javascript_include_tag 'legacy.application', 'data-turbo-track' => true %>
     <%= favicon_link_tag %>

--- a/app/views/layouts/setup.html.erb
+++ b/app/views/layouts/setup.html.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="auto">
   <head>
     <title><%= content_for?(:title) ? yield(:title) : 'Dradis Community Edition' %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
@@ -13,9 +13,9 @@
 
   <body class="<%= controller_name %> <%= action_name %>">
     <%= render 'layouts/hera/noscript' %>
-    <div class="container narrow">
-      <div class="row h-100vh">
-        <div class="col-12 d-flex flex-column justify-content-between">
+    <div class="container">
+      <div class="row h-100vh justify-content-center">
+        <div class="col d-flex flex-column justify-content-between my-4 setup-wrapper">
           <div class="logo">
             <%= image_tag 'logo_full_small.png', class: 'img-fluid' %>
           </div>

--- a/app/views/layouts/setup.html.erb
+++ b/app/views/layouts/setup.html.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="auto">
   <head>
     <title><%= content_for?(:title) ? yield(:title) : 'Dradis Community Edition' %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">

--- a/app/views/layouts/setup.html.erb
+++ b/app/views/layouts/setup.html.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="auto">
+<html lang="en" data-theme="light">
   <head>
     <title><%= content_for?(:title) ? yield(:title) : 'Dradis Community Edition' %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">

--- a/app/views/setup/analytics/new.html.erb
+++ b/app/views/setup/analytics/new.html.erb
@@ -4,8 +4,8 @@
 
 <%= form_tag(setup_analytics_path) do -%>
   <h1>Making Dradis better, together!</h1>
-  <p class="small">We need your help to make Dradis better.</p>
-  <p class="small">
+  <p>We need your help to make Dradis better.</p>
+  <p>
     <a
       href="https://dradis.com/why-dradis.html?utm_source=ce&utm_medium=app&utm_campaign=analytics#privacy"
       target="_blank">Privacy and data sovereignty</a>
@@ -13,18 +13,18 @@
     track individual users, or project data, only aggregated anonymous
     feature usage. We use an open-source and privacy-friendly solution.
   </p>
-  <p class="small mb-0">Would you help us improve?</p>
+  <p class="mb-0">Would you help us improve?</p>
 
-  <div class="d-flex">
-    <%= button_tag name: 'analytics', value: '0', class: 'btn btn-outline-primary' do %>
+  <div class="d-flex justify-content-center gap-4 my-5">
+    <%= button_tag name: 'analytics', value: '0', class: 'btn btn-outline-primary m-0' do %>
       No thanks. <i class="fa-solid fa-long-arrow-right"></i>
     <% end %>
-    <%= button_tag name: 'analytics', value: '1', class: 'btn btn-primary' do %>
+    <%= button_tag name: 'analytics', value: '1', class: 'btn btn-primary m-0' do %>
       Yes, I'd like to help! <i class="fa-solid fa-long-arrow-right"></i>
     <% end %>
   </div>
 
-  <p class="small">
+  <p class="small text-center">
     Read the <a
       href="https://dradis.com/ce/privacy.html?utm_source=ce&utm_medium=app&utm_campaign=analytics"
       target="_blank">Privacy FAQ</a> or <a


### PR DESCRIPTION
### Summary

Adds dark mode support to the login and setup wizard pages, which previously had `data-theme=\"light\"` hardcoded and were unaffected by the user's theme preference.

**Login page**
- Switches `data-theme` from `\"light\"` to `\"auto\"` so the page follows the system preference by default
- Adds a small inline script in `<head>` that reads `localStorage` and applies any stored theme preference before first paint, so returning users see their chosen theme immediately on the login screen
- The theme controller now writes to `localStorage` on every theme change, keeping the login view in sync going forward
- Dark mode styles use a dedicated SCSS mixin (`unauthenticated-dark`) applied to both the `@media (prefers-color-scheme: dark)` and `[data-theme='dark']` selectors, matching the pattern in `themes.scss`
- In dark mode: the form container uses `var(--primary-bg-subtle)` as its background; form controls are set to transparent so they inherit the dark theme correctly

**Setup pages**
- Switches `data-theme` from `\"light\"` to `\"auto\"`
- Replaces all hardcoded SASS colour values with CSS custom properties throughout `setup.scss` — buttons, form controls, progress indicators, and the new `.setup-wrapper` container all respond to the active theme
- Layout is centred via a `.setup-wrapper` card-like container rather than a fixed-width `.narrow` class

**Shared**
- Adds `--text-inverted` to `themes.scss` for both light and dark themes
- Adds `.card` background overrides (`--bs-card-bg`, `--bs-card-cap-bg`) to the dark theme mixin
- Refactors `.divider` to use flexbox, removing the dependency on the page background colour for the label

### Testing steps

- Visit the login page with the system set to **light mode** — verify the page looks correct (green gradient, dark text in card)
- Visit the login page with the system set to **dark mode** — verify the card has a grey background, light text, and the typewriter text on the right is readable
- Log in, switch theme to **Dark** via the navbar toggle, then log out — verify the login page loads in dark mode without a flash
- Log in, switch theme to **Light**, then log out — verify the login page loads in light mode
- Log in, switch theme to **Auto**, then log out — verify the login page follows the system preference
- Step through the setup wizard (password → analytics → kit) in both light and dark system mode — verify all pages render correctly with readable text, visible buttons, and correct form control styles
- Verify the divider on the kit selection page renders correctly (label centred between two lines)

### Other Information

The inline `<script>` tag in `application.html.erb` is a deliberate exception to the no-inline-scripts convention. It must execute synchronously before the browser applies stylesheets to prevent a flash of the wrong theme — an external file or a `turbo:load` handler would be too late.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.