### PR TITLE
Upgrade concurrent-ruby to 1.3.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - faraday, net-imap, nokogiri, puma
+    - concurrent-ruby, faraday, net-imap, nokogiri, puma
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)


### PR DESCRIPTION
### Summary

Upgrades `concurrent-ruby` from 1.3.6 to 1.3.7 to address three CVEs flagged by `bundler-audit`:

- **CVE-2026-54904** — `AtomicReference#update` livelocks when the stored value is `Float::NAN`
- **CVE-2026-54905** — `ReentrantReadWriteLock` read-count overflow grants a write lock without exclusivity
- **CVE-2026-54906** — `ReadWriteLock` allows wrong-thread write release and stray read-release counter corruption

### Testing steps

- Run `bundle exec rake` / CI passes

### Other Information

Only `Gemfile.lock` changed — no `Gemfile` constraint update needed as the existing `>= 1.0` range already resolves to 1.3.7.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.