### PR TITLE
Update author dashboard

### DIFF
--- a/app/assets/stylesheets/hera/base.scss
+++ b/app/assets/stylesheets/hera/base.scss
@@ -339,6 +339,10 @@ pre {
   }
 }
 
+.progress {
+  --bs-progress-bg: var(--secondary-bg);
+}
+
 .required-input {
   color: $red;
 }
@@ -375,7 +379,7 @@ pre {
 }
 
 .text-primary {
-  color: $primary !important;
+  color: var(--text-link) !important;
 }
 
 .text-success {

--- a/app/assets/stylesheets/hera/modules/_active_project.scss
+++ b/app/assets/stylesheets/hera/modules/_active_project.scss
@@ -1,3 +1,10 @@
+:root {
+  /* Colors from d3.js to match board progress bars */
+  --draft-color: #ff99a8;
+  --published-color: #84d784;
+  --review-color: #ffc700;
+}
+
 .active-project {
   .avatars {
     --offset: -0.75rem;
@@ -42,10 +49,6 @@
   }
 
   .donuts {
-    /* Colors from d3.js to match board progress bars */
-    --draft-color: #ff99a8;
-    --published-color: #84d784;
-    --review-color: #ffc700;
     align-items: center;
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
### Summary

- Promotes `--draft-color`, `--review-color`, `--published-color` from `.donuts` scope to `:root` in `_active_project.scss` so they can be reused across components.
- Overrides `.progress` track colour to `var(--secondary-bg)` for dark mode consistency.
- Fixes `.text-primary` contrast in dark mode — `$primary` (`#1d8749`) fails the 3:1 threshold on dark backgrounds; switches to `var(--text-link)`.

### Testing steps

1. Toggle dark mode and confirm links/text marked `.text-primary` are legible.
2. Confirm existing donut charts on active project cards still render the correct colours.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.