### PR TITLE
update dashboard design tokens and dark mode fixes

### DIFF
--- a/app/assets/stylesheets/hera/base.scss
+++ b/app/assets/stylesheets/hera/base.scss
@@ -341,6 +341,16 @@ pre {
 
 .progress {
   --bs-progress-bg: var(--secondary-bg);
+
+  &.empty {
+    background-color: transparent;
+    border: 1px solid var(--border-color);
+
+    .progress-bar {
+      background-color: transparent;
+      width: 100%;
+    }
+  }
 }
 
 .required-input {

--- a/app/assets/stylesheets/hera/base.scss
+++ b/app/assets/stylesheets/hera/base.scss
@@ -339,6 +339,10 @@ pre {
   }
 }
 
+.progress {
+  --bs-progress-bg: var(--secondary-bg);
+}
+
 .required-input {
   color: $red;
 }
@@ -375,7 +379,7 @@ pre {
 }
 
 .text-primary {
-  color: $primary !important;
+  color: var(--text-link) !important;
 }
 
 .text-success {

--- a/app/assets/stylesheets/hera/modules/_active_project.scss
+++ b/app/assets/stylesheets/hera/modules/_active_project.scss
@@ -1,3 +1,10 @@
+:root {
+  /* Colors from d3.js to match board progress bars */
+  --draft-color: #ff99a8;
+  --published-color: #84d784;
+  --review-color: #ffc700;
+}
+
 .active-project {
   .avatars {
     --offset: -0.75rem;
@@ -42,10 +49,6 @@
   }
 
   .donuts {
-    /* Colors from d3.js to match board progress bars */
-    --draft-color: #ff99a8;
-    --published-color: #84d784;
-    --review-color: #ffc700;
     align-items: center;
     display: flex;
     flex-wrap: wrap;

--- a/app/assets/stylesheets/hera/modules/_active_project.scss
+++ b/app/assets/stylesheets/hera/modules/_active_project.scss
@@ -126,16 +126,6 @@
     }
   }
 
-  .progress.empty {
-    background-color: transparent;
-    border: 1px solid var(--border-color);
-
-    .progress-bar {
-      background-color: transparent;
-      width: 100%;
-    }
-  }
-
   .project-card-header {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Summary

CSS groundwork for the dashboard redesign:

- Promote `--draft-color`, `--published-color`, and `--review-color` from `.donuts` scope to `:root` so they are available globally (needed for progress bars in the upcoming widgets)
- Add `--bs-progress-bg` override so progress track uses `--secondary-bg` in both light and dark mode
- Fix `.text-primary` to use `var(--text-link)` instead of `$primary !important`, restoring correct contrast in dark mode

### Testing steps

1. Load Dradis in both light and dark mode
2. Verify `.text-primary` text has correct link colour contrast in dark mode
3. Verify progress bars use the secondary background for their track

### Other Information

Part of the author dashboard redesign. CSS foundations used by the upcoming widgets.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.