### PR TITLE
Initial edit lock implementation

### DIFF
--- a/app/controllers/concerns/editing_lock.rb
+++ b/app/controllers/concerns/editing_lock.rb
@@ -1,0 +1,111 @@
+module EditingLock
+  LOCK_TTL = 120
+
+  def self.included(base)
+    base.before_action :set_editing_lock_record, only: [:lock, :unlock]
+  end
+
+  # Controllers must implement this to return the relevant record.
+  def editing_lock_record
+    raise NotImplementedError, "#{self.class} must implement #editing_lock_record"
+  end
+
+  def lock
+    if renew_lock(@editing_lock_record)
+      head :ok
+    else
+      render json: lock_owner(@editing_lock_record), status: :conflict
+    end
+  end
+
+  def unlock
+    release_lock(@editing_lock_record)
+    head :no_content
+  end
+
+  protected
+
+  # Acquires the lock for the current user.
+  #
+  # Returns true if the lock was acquired (or already held by this user).
+  # Returns false if another user holds the lock.
+  def acquire_lock(record)
+    key = lock_key(record)
+    existing = redis.get(key)
+
+    if existing
+      data = JSON.parse(existing)
+      if data['user_id'] == current_user.id
+        redis.expire(key, LOCK_TTL)
+        return true
+      else
+        return false
+      end
+    end
+
+    set_lock(key)
+    true
+  end
+
+  # Acquires the lock regardless of who currently holds it.
+  # The displaced user will discover the takeover on their next heartbeat.
+  def force_lock(record)
+    set_lock(lock_key(record))
+  end
+
+  # Releases the lock only if the current user holds it.
+  def release_lock(record)
+    key = lock_key(record)
+    existing = redis.get(key)
+    return unless existing
+
+    data = JSON.parse(existing)
+    redis.del(key) if data['user_id'] == current_user.id
+  end
+
+  # Renews the lock TTL if the current user holds it (used by heartbeat).
+  #
+  # Returns true if renewed, false if the lock belongs to another user or is gone.
+  def renew_lock(record)
+    key = lock_key(record)
+    existing = redis.get(key)
+    return false unless existing
+
+    data = JSON.parse(existing)
+    return false unless data['user_id'] == current_user.id
+
+    redis.expire(key, LOCK_TTL)
+    true
+  end
+
+  # Returns { 'user_id' => ..., 'user_name' => ... } or nil.
+  def lock_owner(record)
+    existing = redis.get(lock_key(record))
+    JSON.parse(existing) if existing
+  end
+
+  def locked_by_other?(record)
+    owner = lock_owner(record)
+    owner && owner['user_id'] != current_user.id
+  end
+
+  private
+
+  def set_editing_lock_record
+    @editing_lock_record = editing_lock_record
+  end
+
+  def lock_key(record)
+    model = record.model_name.name.downcase
+    "editing:#{current_project.id}:#{model}:#{record.id}"
+  end
+
+  def set_lock(key)
+    data = { user_id: current_user.id, user_name: current_user.name }.to_json
+    redis.set(key, data, ex: LOCK_TTL)
+  end
+
+  def redis
+    Resque.redis
+  end
+end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -1,6 +1,7 @@
 class EvidenceController < NestedNodeResourceController
   include AttachmentsCopier
   include ConflictResolver
+  include EditingLock
   include EvidenceHelper
   include LiquidEnabledResource
   include Mentioned
@@ -45,6 +46,17 @@ class EvidenceController < NestedNodeResourceController
   end
 
   def edit
+    if locked_by_other?(@evidence)
+      if params[:force]
+        force_lock(@evidence)
+      else
+        @lock_owner = lock_owner(@evidence)
+        return
+      end
+    else
+      acquire_lock(@evidence)
+    end
+
     @form_preview_path = preview_project_node_evidence_path(current_project, @node, @evidence)
   end
 
@@ -58,6 +70,7 @@ class EvidenceController < NestedNodeResourceController
       copy_attachments(@evidence) if @evidence.node_changed?
 
       if @evidence.save
+        release_lock(@evidence)
         track_updated(@evidence)
         check_for_edit_conflicts(@evidence, updated_at_before_save)
         format.html do
@@ -75,6 +88,7 @@ class EvidenceController < NestedNodeResourceController
   end
 
   def destroy
+    release_lock(@evidence)
     respond_to do |format|
       if @evidence.destroy
         track_destroyed(@evidence)
@@ -104,6 +118,10 @@ class EvidenceController < NestedNodeResourceController
   end
 
   private
+
+  def editing_lock_record
+    @evidence
+  end
 
   def autogenerate_issue
     @evidence.issue = Issue.autogenerate_from(@evidence)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,6 +1,7 @@
 class IssuesController < AuthenticatedController
   include ConflictResolver
   include ContentFromTemplate
+  include EditingLock
   include DynamicFieldNamesCacher
   include EventPublisher
   include IssuesHelper
@@ -73,6 +74,17 @@ class IssuesController < AuthenticatedController
   end
 
   def edit
+    if locked_by_other?(@issue)
+      if params[:force]
+        force_lock(@issue)
+      else
+        @lock_owner = lock_owner(@issue)
+        return
+      end
+    else
+      acquire_lock(@issue)
+    end
+
     @form_preview_path = preview_project_issue_path(current_project, @issue)
   end
 
@@ -82,6 +94,7 @@ class IssuesController < AuthenticatedController
 
       if @issue.update(issue_params)
         @modified = true
+        release_lock(@issue)
         check_for_edit_conflicts(@issue, updated_at_before_save)
         format.html { redirect_to_main_or_qa }
         publish_event('issue.updated', @issue.to_event_payload)
@@ -97,6 +110,7 @@ class IssuesController < AuthenticatedController
   end
 
   def destroy
+    release_lock(@issue)
     respond_to do |format|
       if @issue.destroy
         format.html { redirect_to project_issues_path(current_project), notice: 'Issue deleted.' }
@@ -125,6 +139,10 @@ class IssuesController < AuthenticatedController
   end
 
   private
+
+  def editing_lock_record
+    @issue
+  end
 
   def liquid_resource_assigns
     { 'issue' => IssueDrop.new(@issue) }

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,6 +3,7 @@
 class NotesController < NestedNodeResourceController
   include AttachmentsCopier
   include ConflictResolver
+  include EditingLock
   include LiquidEnabledResource
   include Mentioned
   include MultipleDestroy
@@ -38,6 +39,17 @@ class NotesController < NestedNodeResourceController
   end
 
   def edit
+    if locked_by_other?(@note)
+      if params[:force]
+        force_lock(@note)
+      else
+        @lock_owner = lock_owner(@note)
+        return
+      end
+    else
+      acquire_lock(@note)
+    end
+
     @versions_count = @note.versions.count
     @form_preview_path = preview_project_node_note_path(current_project, @node, @note)
   end
@@ -50,6 +62,7 @@ class NotesController < NestedNodeResourceController
     copy_attachments(@note) if @note.node_changed?
 
     if @note.save
+      release_lock(@note)
       track_updated(@note)
       check_for_edit_conflicts(@note, updated_at_before_save)
       # if the note has just been moved to another node, we must reload
@@ -64,6 +77,7 @@ class NotesController < NestedNodeResourceController
 
   # Remove a Note from the back-end database.
   def destroy
+    release_lock(@note)
     if @note.destroy
       track_destroyed(@note)
       redirect_to project_node_path(current_project, @node), notice: 'Note deleted'
@@ -84,6 +98,10 @@ class NotesController < NestedNodeResourceController
     else
       @note = @node.notes.new
     end
+  end
+
+  def editing_lock_record
+    @note
   end
 
   def liquid_resource_assigns

--- a/app/javascript/controllers/editing_lock_controller.js
+++ b/app/javascript/controllers/editing_lock_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus"
+
+const HEARTBEAT_INTERVAL = 60000
+
+export default class extends Controller {
+  static values = { lockUrl: String, unlockUrl: String }
+
+  connect() {
+    this.heartbeatTimer = setInterval(() => this.sendHeartbeat(), HEARTBEAT_INTERVAL)
+  }
+
+  disconnect() {
+    clearInterval(this.heartbeatTimer)
+    this.releaseLock()
+  }
+
+  sendHeartbeat() {
+    fetch(this.lockUrlValue, {
+      method: 'PATCH',
+      headers: { 'X-CSRF-Token': this.csrfToken },
+    }).then(response => {
+      if (response.status === 409) {
+        response.json().then(({ user_name: userName }) => {
+          clearInterval(this.heartbeatTimer)
+          this.showLockTakenWarning(userName)
+        })
+      }
+    })
+  }
+
+  showLockTakenWarning(userName) {
+    const submitBtn = this.element.nextElementSibling?.querySelector('[type=submit]') ||
+                      document.querySelector('form [type=submit]')
+    if (submitBtn) submitBtn.disabled = true
+
+    const alert = document.createElement('div')
+    alert.className = 'alert alert-danger'
+    alert.textContent = `${userName} has taken over this edit. Your changes cannot be saved.`
+    this.element.after(alert)
+  }
+
+  releaseLock() {
+    fetch(this.unlockUrlValue, {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': this.csrfToken },
+      keepalive: true,
+    })
+  }
+
+  get csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content ?? ''
+  }
+}

--- a/app/views/evidence/edit.html.erb
+++ b/app/views/evidence/edit.html.erb
@@ -9,6 +9,17 @@
 <div class="content-container">
   <h4 class="header-underline">Edit evidence</h4>
   <div class="note-text-inner">
-    <%= render 'form' %>
+    <% if @lock_owner %>
+      <%= render 'shared/editing_locked',
+            lock_owner: @lock_owner,
+            record: @evidence,
+            force_path: edit_project_node_evidence_path(current_project, @node, @evidence) %>
+    <% else %>
+      <div data-controller="editing-lock"
+           data-editing-lock-lock-url-value="<%= lock_project_node_evidence_path(current_project, @node, @evidence) %>"
+           data-editing-lock-unlock-url-value="<%= unlock_project_node_evidence_path(current_project, @node, @evidence) %>">
+      </div>
+      <%= render 'form' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -17,6 +17,17 @@
     <h4 class="header-underline">Edit issue (<%= @issue.state.humanize %>)</h4>
     <!-- This div is needed to allow correct tabbing order in Chrome with page is loaded with turbolinks -->
     <div class="autofocus" autofocus="true" tabindex="1"></div>
-    <%= render 'form' %>
+    <% if @lock_owner %>
+      <%= render 'shared/editing_locked',
+            lock_owner: @lock_owner,
+            record: @issue,
+            force_path: edit_project_issue_path(current_project, @issue) %>
+    <% else %>
+      <div data-controller="editing-lock"
+           data-editing-lock-lock-url-value="<%= lock_project_issue_path(current_project, @issue) %>"
+           data-editing-lock-unlock-url-value="<%= unlock_project_issue_path(current_project, @issue) %>">
+      </div>
+      <%= render 'form' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -9,6 +9,17 @@
 <div class="content-container">
   <h4 class="header-underline">Edit note</h4>
   <div class="note-text-inner">
-    <%= render "form" %>
+    <% if @lock_owner %>
+      <%= render 'shared/editing_locked',
+            lock_owner: @lock_owner,
+            record: @note,
+            force_path: edit_project_node_note_path(current_project, @node, @note) %>
+    <% else %>
+      <div data-controller="editing-lock"
+           data-editing-lock-lock-url-value="<%= lock_project_node_note_path(current_project, @node, @note) %>"
+           data-editing-lock-unlock-url-value="<%= unlock_project_node_note_path(current_project, @node, @note) %>">
+      </div>
+      <%= render "form" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_editing_locked.html.erb
+++ b/app/views/shared/_editing_locked.html.erb
@@ -1,0 +1,13 @@
+<div class="alert alert-warning">
+  <p>
+    <strong><%= lock_owner['user_name'] %></strong> is currently editing this
+    <%= record.model_name.human.downcase %>. Editing at the same time may cause
+    conflicts.
+  </p>
+  <p>
+    You can wait for them to finish, or take over the edit. If you take over,
+    <%= lock_owner['user_name'] %> will be notified on their next auto-save
+    heartbeat and their save will be blocked.
+  </p>
+  <%= link_to 'Take over edit', "#{force_path}?force=true", class: 'btn btn-sm btn-warning', data: { turbo: false } %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,13 @@ Rails.application.routes.draw do
     end
   end
 
+  concern :editing_lockable do
+    member do
+      patch :lock
+      delete :unlock
+    end
+  end
+
   concern :previewable do
     member do
       post :preview
@@ -70,7 +77,7 @@ Rails.application.routes.draw do
 
     post :create_multiple_evidence, to: 'issues/evidence#create_multiple'
 
-    resources :issues, concerns: [:multiple_destroy, :previewable] do
+    resources :issues, concerns: [:editing_lockable, :multiple_destroy, :previewable] do
       collection do
         post :import
         resources :merge, only: [:new, :create], controller: 'issues/merge'
@@ -101,11 +108,11 @@ Rails.application.routes.draw do
 
       resource :merge, only: [:create], controller: 'nodes/merge'
 
-      resources :notes, concerns: [:multiple_destroy, :previewable] do
+      resources :notes, concerns: [:editing_lockable, :multiple_destroy, :previewable] do
         resources :revisions, only: [:index, :show]
       end
 
-      resources :evidence, except: :index, concerns: [:multiple_destroy, :previewable] do
+      resources :evidence, except: :index, concerns: [:editing_lockable, :multiple_destroy, :previewable] do
         resources :revisions, only: [:index, :show]
       end
 

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe EvidenceController, type: :controller do
+  let(:current_user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:node) { create(:node, project: @project) }
+  let(:evidence) { create(:evidence, node: node) }
+
+  let(:edit_params)   { { project_id: @project.id, node_id: node.id, id: evidence.id } }
+  let(:lock_params)   { { project_id: @project.id, node_id: node.id, id: evidence.id } }
+  let(:unlock_params) { { project_id: @project.id, node_id: node.id, id: evidence.id } }
+  let(:record) { evidence }
+
+  before do
+    @project = create(:project)
+    login_as_user(current_user)
+  end
+
+  it_behaves_like 'editing lock behavior'
+end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe IssuesController, type: :controller do
+  let(:current_user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:issue) { create(:issue, project: @project) }
+
+  let(:edit_params)   { { project_id: @project.id, id: issue.id } }
+  let(:lock_params)   { { project_id: @project.id, id: issue.id } }
+  let(:unlock_params) { { project_id: @project.id, id: issue.id } }
+  let(:record) { issue }
+
+  before do
+    @project = create(:project)
+    login_as_user(current_user)
+  end
+
+  it_behaves_like 'editing lock behavior'
+end

--- a/spec/controllers/notes_controller_spec.rb
+++ b/spec/controllers/notes_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe NotesController, type: :controller do
+  let(:current_user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:node) { create(:node, project: @project) }
+  let(:note) { create(:note, node: node) }
+
+  let(:edit_params)   { { project_id: @project.id, node_id: node.id, id: note.id } }
+  let(:lock_params)   { { project_id: @project.id, node_id: node.id, id: note.id } }
+  let(:unlock_params) { { project_id: @project.id, node_id: node.id, id: note.id } }
+  let(:record) { note }
+
+  before do
+    @project = create(:project)
+    login_as_user(current_user)
+  end
+
+  it_behaves_like 'editing lock behavior'
+end

--- a/spec/support/editing_lock_shared_examples.rb
+++ b/spec/support/editing_lock_shared_examples.rb
@@ -1,0 +1,124 @@
+# Shared examples for controllers that include EditingLock.
+#
+# Required let variables:
+#   - record          : the model instance (note, issue, or evidence)
+#   - edit_params     : params hash for GET #edit
+#   - lock_params     : params hash for PATCH #lock
+#   - unlock_params   : params hash for DELETE #unlock
+#   - current_user    : the signed-in user
+#   - other_user      : a second user (for locked-by-other scenarios)
+
+shared_examples 'editing lock behavior' do
+  let(:redis_double) { double('Redis::Namespace') }
+
+  before do
+    allow(Resque).to receive(:redis).and_return(redis_double)
+  end
+
+  describe '#edit' do
+    context 'when the content is not locked' do
+      before { allow(redis_double).to receive(:get).and_return(nil) }
+
+      it 'acquires the lock and renders the edit form' do
+        allow(redis_double).to receive(:set)
+
+        get :edit, params: edit_params
+
+        expect(redis_double).to have_received(:set)
+        expect(assigns(:lock_owner)).to be_nil
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context 'when the content is locked by the current user' do
+      before do
+        allow(redis_double).to receive(:get).and_return(
+          { user_id: current_user.id, user_name: current_user.name }.to_json
+        )
+        allow(redis_double).to receive(:expire)
+      end
+
+      it 'renews the TTL and renders the edit form' do
+        get :edit, params: edit_params
+
+        expect(redis_double).to have_received(:expire)
+        expect(assigns(:lock_owner)).to be_nil
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context 'when the content is locked by another user' do
+      before do
+        allow(redis_double).to receive(:get).and_return(
+          { user_id: other_user.id, user_name: other_user.name }.to_json
+        )
+      end
+
+      it 'exposes @lock_owner and renders the edit template (showing interstitial)' do
+        get :edit, params: edit_params
+
+        expect(assigns(:lock_owner)).to include('user_id' => other_user.id, 'user_name' => other_user.name)
+        expect(response).to render_template(:edit)
+      end
+
+      context 'with force=true' do
+        it 'force-acquires the lock and renders the edit form' do
+          allow(redis_double).to receive(:set)
+
+          get :edit, params: edit_params.merge(force: 'true')
+
+          expect(redis_double).to have_received(:set)
+          expect(assigns(:lock_owner)).to be_nil
+          expect(response).to render_template(:edit)
+        end
+      end
+    end
+  end
+
+  describe '#lock' do
+    context 'when the current user holds the lock' do
+      before do
+        allow(redis_double).to receive(:get).and_return(
+          { user_id: current_user.id, user_name: current_user.name }.to_json
+        )
+        allow(redis_double).to receive(:expire).and_return(1)
+      end
+
+      it 'returns 200 OK' do
+        patch :lock, params: lock_params
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the lock has been taken by another user' do
+      before do
+        allow(redis_double).to receive(:get).and_return(
+          { user_id: other_user.id, user_name: other_user.name }.to_json
+        )
+      end
+
+      it 'returns 409 Conflict with the new owner details' do
+        patch :lock, params: lock_params
+
+        expect(response).to have_http_status(:conflict)
+        body = JSON.parse(response.body)
+        expect(body).to include('user_id' => other_user.id, 'user_name' => other_user.name)
+      end
+    end
+  end
+
+  describe '#unlock' do
+    it 'releases the lock and returns 204' do
+      allow(redis_double).to receive(:get).and_return(
+        { user_id: current_user.id, user_name: current_user.name }.to_json
+      )
+      allow(redis_double).to receive(:del)
+
+      delete :unlock, params: unlock_params
+
+      expect(redis_double).to have_received(:del)
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
### Spec
Currently, the conflict resolver shows an alert when you have updated a content but a different user has updated it too when you were editing it. Showing the warning on save, is too late since the content has already been overwritten. This requires the user to manually go through the history and resolve the merge.

**Proposed solution**
Prevent the edit of a content if a user is currently editing it.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
