### PR TITLE
update crass to 1.0.7 to address security advisories

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - concurrent-ruby, faraday, net-imap, nokogiri, puma
+    - concurrent-ruby, crass, faraday, net-imap, nokogiri, puma
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     csv (3.3.5)
     date (3.5.1)
     diff-lcs (1.5.0)


### PR DESCRIPTION
## Summary

- Updates `crass` from 1.0.6 to 1.0.7 to resolve four security advisories: GHSA-6jxj-px6v-747w, GHSA-6wmf-3r64-vcwv, GHSA-8vfg-2r28-hvhj, GHSA-wwpr-jff3-395c
- All advisories relate to denial-of-service conditions (stack overflow, CPU/memory exhaustion) triggered by malformed CSS input