### PR TITLE
upgrade msgpack to 1.8.3 to address CVE-2026-54522

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - concurrent-ruby, crass, faraday, net-imap, nokogiri, puma
+    - concurrent-ruby, crass, faraday, msgpack, net-imap, nokogiri, puma
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     mono_logger (1.1.1)
-    msgpack (1.5.2)
+    msgpack (1.8.3)
     multi_json (1.19.1)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)


### PR DESCRIPTION
## Summary

- Upgrades msgpack from 1.5.2 to 1.8.3 to address [CVE-2026-54522](https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54522) (Use-After-Free in MessagePack::Buffer#clear enables cross-buffer disclosure)
- msgpack is a transitive dependency of bootsnap