### PR TITLE
Harden Echo AI provider request and error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 v5.2.0 (July 2026)
   - UI: add dark mode support to the login and setup wizard pages
+  - Bugs fixes:
+    - Echo: stop broadcasting AI provider error responses to the browser
+    - Echo: restrict Anthropic provider requests to the fixed messages endpoint
   - Upgraded gems:
     - concurrent-ruby, crass, faraday, msgpack, net-imap, nokogiri, puma
 

--- a/engines/dradis-echo/app/jobs/dradis/plugins/echo/interaction_job.rb
+++ b/engines/dradis-echo/app/jobs/dradis/plugins/echo/interaction_job.rb
@@ -23,10 +23,10 @@ module Dradis::Plugins::Echo
 
       Turbo::StreamsChannel.broadcast_append_to [interaction_id, 'prompts'], target: 'messages', html: '<p>Done.</p>'
     rescue => e
-      msg = '<div class="alert alert-danger m-0">'
-      msg << ERB::Util.html_escape(e.message)
-      msg << '</div>'
-      Turbo::StreamsChannel.broadcast_update_to [interaction_id, 'prompts'], target: response_id, html: msg
+      Rails.logger.error("[Echo] interaction #{interaction_id} failed: #{e.message}")
+
+      html = '<div class="alert alert-danger m-0">Something went wrong.</div>'
+      Turbo::StreamsChannel.broadcast_update_to [interaction_id, 'prompts'], target: response_id, html: html
     end
   end
 end

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/provider/anthropic.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/provider/anthropic.rb
@@ -21,7 +21,7 @@ module Dradis::Plugins::Echo
     def build_headers
       {
         'anthropic-version' => API_VERSION,
-        'x-api-key'         => api_key
+        'x-api-key' => api_key
       }
     end
 

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/provider/anthropic.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/provider/anthropic.rb
@@ -3,7 +3,7 @@ module Dradis::Plugins::Echo
     include Provider::HttpStreaming
 
     API_VERSION = '2023-06-01'.freeze
-    DEFAULT_ADDRESS = 'https://api.anthropic.com/v1/messages'.freeze
+    DEFAULT_ADDRESS = 'https://api.anthropic.com/v1'.freeze
     DEFAULT_MAX_TOKENS = 4096
     DEFAULT_MODEL = 'claude-sonnet-4-6'.freeze
 
@@ -26,7 +26,7 @@ module Dradis::Plugins::Echo
     end
 
     def build_uri(_model)
-      URI(address)
+      URI("#{address}/messages")
     end
 
     # Anthropic sends several SSE event types; only content_block_delta carries text:

--- a/engines/dradis-echo/spec/factories/providers.rb
+++ b/engines/dradis-echo/spec/factories/providers.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     model { 'qwen2.5:14b' }
 
     factory :anthropic_provider, class: 'Dradis::Plugins::Echo::Provider::Anthropic' do
-      address { 'https://api.anthropic.com/v1/messages' }
+      address { 'https://api.anthropic.com/v1' }
       api_key { 'sk-ant-test' }
       model { 'claude-sonnet-4-6' }
     end

--- a/engines/dradis-echo/spec/jobs/dradis/plugins/echo/interaction_job_spec.rb
+++ b/engines/dradis-echo/spec/jobs/dradis/plugins/echo/interaction_job_spec.rb
@@ -4,9 +4,9 @@ require File.expand_path('../../../../factories/providers', __dir__)
 
 describe Dradis::Plugins::Echo::InteractionJob do
   let(:interaction_id) { 'project-1' }
-  let(:response_id)    { 'response-1' }
-  let(:prompt)         { 'Summarise this issue.' }
-  let(:agent)          { create(:system_agent) }
+  let(:response_id) { 'response-1' }
+  let(:prompt) { 'Summarise this issue.' }
+  let(:agent) { create(:system_agent) }
 
   def perform
     described_class.perform_now(

--- a/engines/dradis-echo/spec/jobs/dradis/plugins/echo/interaction_job_spec.rb
+++ b/engines/dradis-echo/spec/jobs/dradis/plugins/echo/interaction_job_spec.rb
@@ -26,24 +26,34 @@ describe Dradis::Plugins::Echo::InteractionJob do
   describe 'when agent is not enabled' do
     before { agent.update!(enabled: false) }
 
-    it 'broadcasts a user-friendly error' do
+    it 'broadcasts a generic error without leaking details' do
       perform
       expect(Turbo::StreamsChannel).to have_received(:broadcast_update_to) do |_, **kwargs|
-        expect(kwargs[:html]).to include('is not enabled')
+        expect(kwargs[:html]).to include('Something went wrong')
+        expect(kwargs[:html]).not_to include('is not enabled')
       end
     end
   end
 
-  describe 'error message sanitisation' do
-    it 'HTML-escapes the error message before broadcasting' do
+  describe 'error message handling' do
+    it 'does not reflect the underlying error message to the browser' do
       allow_any_instance_of(Dradis::Plugins::Echo::Provider::Ollama)
-        .to receive(:generate).and_raise('<script>alert(1)</script>')
+        .to receive(:generate).and_raise('<script>alert(1)</script> upstream-secret')
 
       perform
       expect(Turbo::StreamsChannel).to have_received(:broadcast_update_to) do |_, **kwargs|
-        expect(kwargs[:html]).to include('&lt;script&gt;')
-        expect(kwargs[:html]).not_to include('<script>')
+        expect(kwargs[:html]).to include('Something went wrong')
+        expect(kwargs[:html]).not_to include('script')
+        expect(kwargs[:html]).not_to include('upstream-secret')
       end
+    end
+
+    it 'logs the full error message for operators' do
+      allow_any_instance_of(Dradis::Plugins::Echo::Provider::Ollama)
+        .to receive(:generate).and_raise('upstream-secret')
+
+      expect(Rails.logger).to receive(:error).with(/upstream-secret/)
+      perform
     end
   end
 

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/anthropic_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/anthropic_spec.rb
@@ -47,7 +47,7 @@ describe Dradis::Plugins::Echo::Provider::Anthropic do
   describe '#extract_text' do
     it 'extracts text from content_block_delta events' do
       payload = {
-        'type'  => 'content_block_delta',
+        'type' => 'content_block_delta',
         'delta' => { 'type' => 'text_delta', 'text' => 'Hello' }
       }
       expect(provider.send(:extract_text, payload)).to eq('Hello')

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/anthropic_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/anthropic_spec.rb
@@ -12,12 +12,13 @@ describe Dradis::Plugins::Echo::Provider::Anthropic do
   end
 
   describe '#build_uri' do
-    it 'returns the configured address' do
-      expect(provider.send(:build_uri, 'claude-sonnet-4-6').to_s).to eq(described_class::DEFAULT_ADDRESS)
+    it 'appends messages to the address' do
+      expect(provider.send(:build_uri, 'claude-sonnet-4-6').to_s)
+        .to eq("#{described_class::DEFAULT_ADDRESS}/messages")
     end
 
-    it 'uses a custom address when set' do
-      provider.address = 'https://anthropic.proxy.example.com/v1/messages'
+    it 'appends messages to a custom address, preventing full-path control' do
+      provider.address = 'https://anthropic.proxy.example.com/v1'
       expect(provider.send(:build_uri, 'claude-sonnet-4-6').to_s)
         .to eq('https://anthropic.proxy.example.com/v1/messages')
     end

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/http_streaming_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/http_streaming_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Dradis::Plugins::Echo::Provider::HttpStreaming do
   let(:provider) do
     Dradis::Plugins::Echo::Provider::Anthropic.new(
-      address: 'https://api.anthropic.com/v1/messages',
+      address: 'https://api.anthropic.com/v1',
       api_key: 'sk-ant-test',
       model: 'claude-sonnet-4-6',
       name: 'Test'

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider_spec.rb
@@ -59,7 +59,7 @@ describe Dradis::Plugins::Echo::Provider do
     it 'returns the default for each subclass' do
       expect(described_class::Ollama.default_address).to eq('http://localhost:11434')
       expect(described_class::OpenAI.default_address).to eq('https://api.openai.com/v1')
-      expect(described_class::Anthropic.default_address).to eq('https://api.anthropic.com/v1/messages')
+      expect(described_class::Anthropic.default_address).to eq('https://api.anthropic.com/v1')
       expect(described_class::Gemini.default_address).to include('generativelanguage.googleapis.com')
     end
   end


### PR DESCRIPTION
### Summary

Improves how the Dradis Echo AI provider integration handles requests and errors (relates to #1641).

- **Generic error messaging.** `InteractionJob` previously broadcast the upstream provider's raw response/error to the browser. It now logs the detail server-side and shows the user a generic "Something went wrong." message.
- **Consistent Anthropic endpoint.** `Provider::Anthropic` now treats `address` as a base URL and appends `/messages`, matching how the OpenAI and Gemini providers build their request URLs. `delete_suffix('/messages')` keeps existing providers (and full-URL entries) working.

### Testing steps

1. Configure a provider whose address points at an endpoint that returns an error (any non-2xx).
2. Run a Dradis Echo interaction on a project.
3. **Expected:** the browser shows a generic "Something went wrong." message; the full error appears in the server log.
4. Confirm Anthropic requests resolve to `.../v1/messages` whether the address is set to the base URL or the full endpoint.

### Other Information

Full `dradis-echo` suite passes (101 examples), rubocop clean.

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
