### PR TITLE
Bump sqlite3 and websocket-driver

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,34 @@
+[v#.#.#] ([month] [YYYY])
+  - [entity]:
+    - [future tense verb] [feature]
+  - Upgraded gems:
+    - sqlite3, websocket-driver
+  - Bugs fixes:
+    - [entity]:
+      - [future tense verb] [bug fix]
+    - Bug tracker items:
+      - [item]
+  - Echo enhancements:
+    - [Echo entity]:
+      - [future tense verb] [Echo enhancement]
+  - New integrations:
+    - [integration]
+  - Integration enhancements:
+    - [integration]:
+      - [future tense verb] [integration enhancement]
+      - [integration bug fixes]:
+        - [future tense verb] [integration bug fix]
+  - Reporting enhancements:
+    - [report type]:
+      - [future tense verb] [reporting enhancement]
+  - REST/JSON API enhancements:
+    - [API entity]:
+      - [future tense verb] [API enhancement]
+  - Security Fixes:
+    - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+
 v5.2.0 (July 2026)
   - UI: add dark mode support to the login and setup wizard pages
   - Upgraded gems:

--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ gem 'rinku'
 gem 'sanitize', '6.0.2'
 
 # SQLite3 DB driver
-gem 'sqlite3'
+gem 'sqlite3', '~> 2.9.5'
 # gem 'pg'
 
 # --------------------------------------------------------- Dradis Professional

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -545,11 +545,11 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (2.7.2)
+    sqlite3 (2.9.5)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (2.7.2-arm64-darwin)
-    sqlite3 (2.7.2-x86_64-darwin)
-    sqlite3 (2.7.2-x86_64-linux-gnu)
+    sqlite3 (2.9.5-arm64-darwin)
+    sqlite3 (2.9.5-x86_64-darwin)
+    sqlite3 (2.9.5-x86_64-linux-gnu)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -588,7 +588,7 @@ GEM
       railties (>= 6.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -695,7 +695,7 @@ DEPENDENCIES
   simple_form
   spring
   sprockets-rails (>= 3.0.0)
-  sqlite3
+  sqlite3 (~> 2.9.5)
   stimulus-rails
   terser (~> 1.1)
   thor (~> 1.4.0)


### PR DESCRIPTION
### Summary

Bump
- `sqlite3` to 2.9.5
-  `websocket-driver` to 0.8.2

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
