### PR TITLE
Fix Echo streamed response line breaks and leading blank line

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@ v5.2.0 (July 2026)
   - UI: add dark mode support to the login and setup wizard pages
   - Upgraded gems:
     - concurrent-ruby, crass, faraday, msgpack, net-imap, nokogiri, puma
+  - Bugs fixes:
+    - Echo: preserve line breaks in streamed Ollama responses for models that emit them as standalone tokens
 
 v5.1.0 (May 2026)
   - DataTables: add sticky table toolbar that tracks below the navigation bar when scrolling

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,7 +34,9 @@ v5.2.0 (July 2026)
   - Upgraded gems:
     - concurrent-ruby, crass, faraday, msgpack, net-imap, nokogiri, puma
   - Bugs fixes:
-    - Echo: preserve line breaks in streamed Ollama responses for models that emit them as standalone tokens
+    - Echo:
+      - Preserve line breaks in streamed Ollama responses for models that emit them as standalone tokens
+      - Remove a stray leading blank line from streamed responses
 
 v5.1.0 (May 2026)
   - DataTables: add sticky table toolbar that tracks below the navigation bar when scrolling

--- a/engines/dradis-echo/app/models/dradis/plugins/echo/provider/ollama.rb
+++ b/engines/dradis-echo/app/models/dradis/plugins/echo/provider/ollama.rb
@@ -15,7 +15,7 @@ module Dradis::Plugins::Echo
         next if event['done']
 
         chunk = event['response'].to_s
-        next if chunk.strip.empty?
+        next if chunk.empty?
 
         chunk = chunk.sub('<think>', '{thinking}').sub('</think>', '{/thinking}')
 

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/projects/interactions/_response.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/projects/interactions/_response.html.erb
@@ -20,6 +20,9 @@
         </button>
       </h2>
       <div id="collapseResponse" class="accordion-collapse" aria-labelledby="responseHeading" data-bs-parent="#accordionEcho">
+        <%# Keep the spinner div on the same line as its container: .echo-content uses
+            white-space: break-spaces, so a whitespace text node left behind after the
+            spinner is removed would render as a visible blank line before the response. %>
         <div id="<%= @response_id %>" class="accordion-body echo-content"><div id="<%= "#{@response_id}_spinner" %>"><%= spinner_tag %></div></div>
       </div>
     </div>

--- a/engines/dradis-echo/app/views/dradis/plugins/echo/projects/interactions/_response.html.erb
+++ b/engines/dradis-echo/app/views/dradis/plugins/echo/projects/interactions/_response.html.erb
@@ -20,9 +20,7 @@
         </button>
       </h2>
       <div id="collapseResponse" class="accordion-collapse" aria-labelledby="responseHeading" data-bs-parent="#accordionEcho">
-        <div id="<%= @response_id %>" class="accordion-body echo-content">
-          <div id="<%= "#{@response_id}_spinner" %>"><%= spinner_tag %></div>
-        </div>
+        <div id="<%= @response_id %>" class="accordion-body echo-content"><div id="<%= "#{@response_id}_spinner" %>"><%= spinner_tag %></div></div>
       </div>
     </div>
   </div>

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/ollama_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/ollama_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require File.expand_path('../../../../../factories/providers', __dir__)
+
+describe Dradis::Plugins::Echo::Provider::Ollama do
+  subject(:provider) { build(:provider) }
+
+  let(:client) { instance_double(::Ollama::Controllers::Client) }
+
+  before do
+    allow(provider).to receive(:client).and_return(client)
+  end
+
+  def stub_events(*events)
+    allow(client).to receive(:generate) do |_payload, &block|
+      events.each { |event| block.call(event, nil) }
+    end
+  end
+
+  describe '#generate' do
+    it 'concatenates response chunks into the buffer' do
+      stub_events(
+        { 'response' => 'Hello ', 'done' => false },
+        { 'response' => 'world', 'done' => false },
+        { 'response' => '', 'done' => true }
+      )
+
+      expect(provider.generate(prompt: 'hi')).to eq('Hello world')
+    end
+
+    it 'preserves whitespace-only chunks, such as standalone line breaks' do
+      stub_events(
+        { 'response' => '1. First item.', 'done' => false },
+        { 'response' => "  \n", 'done' => false },
+        { 'response' => '2. Second item.', 'done' => false },
+        { 'response' => '', 'done' => true }
+      )
+
+      expect(provider.generate(prompt: 'hi')).to eq("1. First item.  \n2. Second item.")
+    end
+
+    it 'skips events with an empty response, such as thinking-only chunks' do
+      stub_events(
+        { 'response' => '', 'thinking' => 'Reasoning...', 'done' => false },
+        { 'response' => 'Answer', 'done' => false },
+        { 'response' => '', 'done' => true }
+      )
+
+      expect(provider.generate(prompt: 'hi')).to eq('Answer')
+    end
+
+    it 'replaces think tags embedded in the response text' do
+      stub_events(
+        { 'response' => '<think>', 'done' => false },
+        { 'response' => 'reasoning', 'done' => false },
+        { 'response' => '</think>', 'done' => false },
+        { 'response' => 'Answer', 'done' => false },
+        { 'response' => '', 'done' => true }
+      )
+
+      expect(provider.generate(prompt: 'hi')).to eq('{thinking}reasoning{/thinking}Answer')
+    end
+
+    it 'yields each chunk to the given block instead of buffering' do
+      stub_events(
+        { 'response' => 'Hello ', 'done' => false },
+        { 'response' => 'world', 'done' => false },
+        { 'response' => '', 'done' => true }
+      )
+
+      chunks = []
+      provider.generate(prompt: 'hi') { |chunk| chunks << chunk }
+
+      expect(chunks).to eq(['Hello ', 'world'])
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Echo: fix line breaks and stray blank line in streamed responses.

Before:
<img width="660" height="460" alt="image" src="https://github.com/user-attachments/assets/25ab743c-37c8-4f4f-8523-780d5b1eb6ec" />

After:
<img width="660" height="460" alt="image" src="https://github.com/user-attachments/assets/8e199470-3ad3-4ed4-b454-50cecb5a6e79" />

(Extra whitespace line and indentation also fixed but not captured in the screenshots)

### Testing steps

1. Log in as an admin user.
2. Navigate to **Admin → Configuration → Echo → Agents**, and edit the Roslin agent.
3. Set the provider to Ollama, with an address pointing at an Ollama instance that has a reasoning-capable model available (e.g. `qwen3:0.6b` or larger), and enable the agent.
4. Save the configuration. Assert the agent shows as enabled.
5. Navigate to any project and open an existing issue (or create one).
6. Click the **Echo** tab on the issue.
7. Select or write a prompt that asks for a multi-item, multi-line answer, for example: "Write a short numbered list (5 items) of common web vulnerabilities, one per line, with a one-sentence description each."
8. Click **Start with this prompt**.
9. Wait for the response to finish streaming (the "Done." line appears at the bottom).
10. Assert each numbered item (1–5) appears on its own line inside the "Echo Response" panel, not run together into a single paragraph.
11. Assert the first line of the response ("1. ...") starts flush with the left edge of the panel, with no blank line or indentation above it.
12. Repeat steps 7–11 using a non-reasoning model (e.g. `qwen2.5:7b`) as the agent's provider model. Assert the response still renders correctly with line breaks preserved and no leading blank line, confirming the fix didn't regress the existing behavior.
13. Repeat steps 7–11 once more with the same reasoning model as step 3, to confirm the fix is consistent across multiple interactions (not just a single lucky run).

### Other Information

Root cause 1 (line breaks): some models (e.g. qwen3) tokenize a markdown line break as its own standalone streamed chunk. The Ollama provider's whitespace-only guard dropped those chunks along with genuinely empty ones, collapsing multi-line responses into a single run-on paragraph.

Root cause 2 (stray blank line): the spinner placeholder sat on its own line inside the response container in the erb template. Removing the spinner once streaming started left behind the surrounding whitespace text node, which rendered as a visible blank line before the first chunk of every response (independent of the first bug, and present regardless of model).

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.