### PR TITLE
Clean up leaked attachment files to prevent cross-spec pollution

### DIFF
--- a/spec/features/evidence_moving_spec.rb
+++ b/spec/features/evidence_moving_spec.rb
@@ -29,6 +29,10 @@ describe 'moving an evidence', js: true do
     click_move_evidence
   end
 
+  after do
+    FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
+  end
+
   let(:content) { "#[Description]#\nTest Evidence\n" }
   let(:current_evidence) { @evidence = create(:evidence, content: content, node: @node_5) }
 

--- a/spec/features/node_merging_spec.rb
+++ b/spec/features/node_merging_spec.rb
@@ -21,6 +21,10 @@ describe 'merging a node', js: true do
     click_link 'Merge'
   end
 
+  after do
+    FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
+  end
+
   it 'redirects to the target node' do
     within_merge_node_modal do
       click_link(target_node.label)

--- a/spec/features/note_moving_spec.rb
+++ b/spec/features/note_moving_spec.rb
@@ -30,6 +30,10 @@ describe 'moving a note', js: true do
     click_move_note
   end
 
+  after do
+    FileUtils.rm_rf(Dir.glob(Attachment.pwd + '*'))
+  end
+
   let(:text) { "#[Description]#\nTest Note\n" }
   let(:current_note) { @note = create(:note, text: text, node: @node_5) }
 


### PR DESCRIPTION
### Summary

Fixes a family of flaky spec failures caused by cross-spec attachment file pollution (most recently the `Nodes::Merger` failure in [this CI run](https://github.com/dradis/dradis-ce/actions/runs/29410722288/job/87337092814): `expected target_node.attachments.count to have changed by 1, but was changed by 5`).

Attachments are plain files under `tmp/storage/attachments/<node_id>/`, which transactional rollback/truncation never cleans, and SQLite reuses low auto-increment node IDs across examples. So files leaked by one spec show up as phantom attachments on a later spec's node whenever the random seed lines the IDs up.

54249ca6c addressed the same root cause but patched the victim's after-side (`merger_spec`), which can't stop upstream pollution. This PR plugs the three remaining specs that create attachment files without cleaning them up:

- `spec/features/evidence_moving_spec.rb`
- `spec/features/note_moving_spec.rb`
- `spec/features/node_merging_spec.rb`

Each gets the same `after` cleanup already used by `attachment_spec` and `merger_spec`.

### Other Information

Spec-only change, no CHANGELOG entry needed.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry (n/a — spec-only)
- [x] Commit message has a detailed description of what changed and why.