### PR TITLE
Bump rails-html-sanitizer to 1.7.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - sqlite3, websocket-driver
+    - rails-html-sanitizer, sqlite3, websocket-driver
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'nokogiri', '>= 1.19.4'
 # before 1.0.4, so make sure we're using 1.0.4+:
 # see https://github.com/rails/rails-html-sanitizer/commit/f3ba1a839a
 # and https://github.com/flavorjones/loofah/issues/144
-gem 'rails-html-sanitizer', '~> 1.6.1'
+gem 'rails-html-sanitizer', '~> 1.7.1'
 
 # Textile markup
 gem 'RedCloth', '~> 4.3.4', require: 'redcloth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     local_time (2.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.2.4)
@@ -416,8 +416,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails_autolink (1.1.8)
       actionview (> 3.1)
@@ -678,7 +678,7 @@ DEPENDENCIES
   puma (~> 7.2.1)
   rack-mini-profiler (~> 2.0)
   rails (~> 8.0.5)
-  rails-html-sanitizer (~> 1.6.1)
+  rails-html-sanitizer (~> 1.7.1)
   record_tag_helper
   rerun
   resque


### PR DESCRIPTION
### Summary

Bump rails-html-sanitizer to 1.7.1

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
