### PR TITLE
enforce do...end for multi-line blocks via Style/BlockDelimiters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,10 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
+# Use { } for single-line blocks and do...end for multi-line blocks.
+Style/BlockDelimiters:
+  Enabled: true
+
 # Do not use braces for hash literals when they are the last argument of a
 # method call.
 Style/HashAsLastArrayItem:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -297,23 +297,6 @@ Style/BlockComments:
   Exclude:
     - 'app/models/attachment.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, ProceduralMethods, FunctionalMethods, IgnoredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# IgnoredMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'app/controllers/attachments_controller.rb'
-    - 'app/controllers/evidence_controller.rb'
-    - 'app/controllers/issues/merge_controller.rb'
-    - 'engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb'
-    - 'engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb'
-    - 'spec/factories/attachments.rb'
-    - 'spec/features/issues_spec.rb'
-
 # Offense count: 19
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -35,7 +35,7 @@ class AttachmentsController < AuthenticatedController
   def show
     filename = params[:filename]
 
-    @attachment  = Attachment.find(filename, conditions: { node_id: @node.id })
+    @attachment = Attachment.find(filename, conditions: { node_id: @node.id })
     send_options = { filename: @attachment.filename }
 
     # Figure out the best way of displaying the file (by default send it as
@@ -93,10 +93,10 @@ class AttachmentsController < AuthenticatedController
   # new jQuery uploader
   def build_attachment_json
     json = {
-      name:        @attachment.filename,
-      size:        File.size(@attachment.fullpath),
-      url:         project_node_attachment_path(current_project, @node, @attachment.filename),
-      delete_url:  project_node_attachment_path(current_project, @node, @attachment.filename),
+      name: @attachment.filename,
+      size: File.size(@attachment.fullpath),
+      url: project_node_attachment_path(current_project, @node, @attachment.filename),
+      delete_url: project_node_attachment_path(current_project, @node, @attachment.filename),
       delete_type: 'DELETE'
     }
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -8,7 +8,7 @@ class AttachmentsController < AuthenticatedController
   # Retrieve all the associated attachments for a given :node_id
   def index
     @attachments = Node.find(params[:node_id]).attachments
-    @attachments.each do |a| a.close end
+    @attachments.each { |a| a.close }
   end
 
   # Create a new attachment for a given :node_id using a file that has been

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -136,7 +136,7 @@ class EvidenceController < NestedNodeResourceController
   end
 
   def set_auto_save_key
-    @auto_save_key =  if @evidence&.persisted?
+    @auto_save_key = if @evidence&.persisted?
       "evidence-#{@evidence.id}"
     elsif params[:template]
       "node-#{@node.id}-evidence-#{params[:template]}"

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -30,15 +30,15 @@ class EvidenceController < NestedNodeResourceController
     respond_to do |format|
       if @evidence.save
         track_created(@evidence)
-        format.html {
+        format.html do
           redirect_to [current_project, @evidence.node, @evidence],
             notice: "Evidence added for node #{@evidence.node.label}."
-        }
+        end
       else
-        format.html {
+        format.html do
           initialize_nodes_sidebar
           render 'new'
-        }
+        end
       end
       format.js
     end
@@ -65,10 +65,10 @@ class EvidenceController < NestedNodeResourceController
         end
 
       else
-        format.html {
+        format.html do
           initialize_nodes_sidebar
           render 'edit'
-        }
+        end
       end
       format.js
     end
@@ -78,7 +78,7 @@ class EvidenceController < NestedNodeResourceController
     respond_to do |format|
       if @evidence.destroy
         track_destroyed(@evidence)
-        format.html {
+        format.html do
           notice = "Successfully deleted evidence for '#{@evidence.issue.title}.'"
           # Evidence can be deleted from 3 places:
           # 1. from the issue evidence tab
@@ -91,13 +91,13 @@ class EvidenceController < NestedNodeResourceController
           else
             redirect_back fallback_location: project_node_path(current_project, @node), notice: notice
           end
-        }
+        end
         format.js
       else
-        format.html {
+        format.html do
           redirect_to [current_project, @node, @evidence],
             notice: "Error while deleting evidence: #{@evidence.errors}"
-        }
+        end
         format.js
       end
     end

--- a/app/controllers/issues/merge_controller.rb
+++ b/app/controllers/issues/merge_controller.rb
@@ -34,13 +34,13 @@ class Issues::MergeController < IssuesController
     end
 
     respond_to do |format|
-      format.html {
+      format.html do
         if count > 0
           redirect_to [current_project, @issue], notice: "#{count} #{'issue'.pluralize(count)} merged into #{@issue.title}."
         else
           redirect_to project_issues_path(current_project), alert: "Issues couldn't be merged."
         end
-      }
+      end
       format.json
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -52,7 +52,7 @@ class Comment < ApplicationRecord
     case action.to_s
     when 'create'
       subscribe_mentioned()
-      create_notifications(action: :mention, actor: actor,  recipients: mentions)
+      create_notifications(action: :mention, actor: actor, recipients: mentions)
 
       # We're finding subscribers that have not been mention here
       # using ActiveRecord because create_notifications expect recipients

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -86,9 +86,9 @@ class Comment < ApplicationRecord
     elsif resource.respond_to?(:project)
       scope.merge(resource.project.testers_for_mentions)
     else
-      ids = scope.select { |user|
+      ids = scope.select do |user|
         Ability.new(user).can?(:read, resource)
-      }.map(&:id)
+      end.map(&:id)
 
       # Ensure we return an ActiveRecord::Relation object
       scope.where(id: ids)

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/attachments_spec.rb
@@ -113,13 +113,13 @@ describe 'Attachments API' do
     end
 
     describe 'POST /api/nodes/:node_id/attachments' do
-      let(:post_attachment) {
+      let(:post_attachment) do
         file = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/rails.png'))
         params = { files: [file] }
         url = "/api/nodes/#{node.id}/attachments"
 
         post url , params: params, env: @env
-      }
+      end
 
       it 'returns 201 when file saved' do
         post_attachment

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb
@@ -153,17 +153,17 @@ describe 'Issues API' do
 
       it 'throws 422 if issue is invalid' do
         params = { issue: { text: 'A' * (65535 + 1) } }
-        expect {
+        expect do
           post '/api/issues', params: params.to_json, env: @env.merge('CONTENT_TYPE' => 'application/json')
-        }.not_to change { current_project.issues.count }
+        end.not_to change { current_project.issues.count }
         expect(response.status).to eq(422)
       end
 
       it 'throws 422 if state is invalid' do
         params = { issue: { text: "#[Title]#\nIssue test\n", state: 'fakestate' } }
-        expect {
+        expect do
           post '/api/issues', params: params.to_json, env: @env.merge('CONTENT_TYPE' => 'application/json')
-        }.not_to change { current_project.issues.count }
+        end.not_to change { current_project.issues.count }
         expect(response.status).to eq(422)
       end
     end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v1/issues_spec.rb
@@ -128,7 +128,7 @@ describe 'Issues API' do
         expect(response.status).to eq(201)
 
         retrieved_issue = JSON.parse(response.body)
-        database_issue  = current_project.issues.find(retrieved_issue['id'])
+        database_issue = current_project.issues.find(retrieved_issue['id'])
 
         expect(database_issue.tag_list).to eq(tag_name)
       end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/attachments_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/attachments_spec.rb
@@ -122,13 +122,13 @@ describe 'Attachments API' do
     end
 
     describe 'POST /api/nodes/:node_id/attachments' do
-      let(:post_attachment) {
+      let(:post_attachment) do
         file = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/rails.png'))
         params = { files: [file] }
         url = "/api/nodes/#{node.id}/attachments"
 
         post url , params: params, env: @env
-      }
+      end
 
       it 'returns 201 when file saved' do
         post_attachment

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/issues_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/issues_spec.rb
@@ -167,17 +167,17 @@ describe 'Issues API' do
 
       it 'throws 422 if issue is invalid' do
         params = { issue: { text: 'A' * (65535 + 1) } }
-        expect {
+        expect do
           post '/api/issues', params: params.to_json, env: @env.merge('CONTENT_TYPE' => 'application/json')
-        }.not_to change { current_project.issues.count }
+        end.not_to change { current_project.issues.count }
         expect(response.status).to eq(422)
       end
 
       it 'throws 422 if state is invalid' do
         params = { issue: { text: "#[Title]#\nIssue test\n", state: 'fakestate' } }
-        expect {
+        expect do
           post '/api/issues', params: params.to_json, env: @env.merge('CONTENT_TYPE' => 'application/json')
-        }.not_to change { current_project.issues.count }
+        end.not_to change { current_project.issues.count }
         expect(response.status).to eq(422)
       end
     end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/issues_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/issues_spec.rb
@@ -142,7 +142,7 @@ describe 'Issues API' do
         expect(response.status).to eq(201)
 
         retrieved_issue = JSON.parse(response.body)
-        database_issue  = current_project.issues.find(retrieved_issue['id'])
+        database_issue = current_project.issues.find(retrieved_issue['id'])
 
         expect(database_issue.tag_list).to eq(tag_name)
       end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/upload_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/upload_spec.rb
@@ -58,9 +58,9 @@ describe 'Upload API' do
       let(:file_fixture) { file_fixture_upload(file_path, 'plain/text') }
       let(:uploader) { 'Dradis::Plugins::Projects::Upload::Package' }
 
-      let(:params) {
+      let(:params) do
         { file: file_fixture, uploader: uploader, state: 'draft' }
-      }
+      end
 
       it 'calls the relevant importer' do
         expect(Dradis::Plugins::Projects::Upload::Package::Importer).to(

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/http_streaming_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider/http_streaming_spec.rb
@@ -27,12 +27,12 @@ describe Dradis::Plugins::Echo::Provider::HttpStreaming do
   describe '#parse_sse_response' do
     it 'raises an error for non-2xx responses' do
       stub_http(body: 'Unauthorized', code: '401')
-      expect {
+      expect do
         provider.send(:parse_sse_response,
                       URI('https://api.anthropic.com/v1/messages'),
                       headers: {},
                       body: {})
-      }.to raise_error(RuntimeError, /API error \(401\)/)
+      end.to raise_error(RuntimeError, /API error \(401\)/)
     end
 
     it 'parses SSE lines and yields text chunks' do
@@ -66,12 +66,12 @@ describe Dradis::Plugins::Echo::Provider::HttpStreaming do
       sse_body = "data: not-valid-json\ndata: {\"type\":\"message_start\"}\n\n"
       stub_http(body: sse_body)
 
-      expect {
+      expect do
         provider.send(:parse_sse_response,
                       URI('https://api.anthropic.com/v1/messages'),
                       headers: {},
                       body: {}) { |_chunk| }
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 

--- a/engines/dradis-echo/spec/models/dradis/plugins/echo/provider_spec.rb
+++ b/engines/dradis-echo/spec/models/dradis/plugins/echo/provider_spec.rb
@@ -93,9 +93,9 @@ describe Dradis::Plugins::Echo::Provider do
     it 'raises NotImplementedError on the base class' do
       provider = build(:provider)
       # Ollama overrides #generate, so test the base class directly
-      expect {
+      expect do
         Dradis::Plugins::Echo::Provider.new.generate(prompt: 'test')
-      }.to raise_error(NotImplementedError)
+      end.to raise_error(NotImplementedError)
     end
   end
 

--- a/engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/grammar_corrections_spec.rb
+++ b/engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/grammar_corrections_spec.rb
@@ -148,7 +148,7 @@ describe 'Grammar corrections' do
     it 'returns 404 for an issue outside the current project scope' do
       other_issue = create(:issue, node: create(:node))
 
-      expect {
+      expect do
         post "/addons/echo/projects/#{@project.id}/grammar_corrections", params: {
           commentable_type: 'Issue',
           commentable_id: other_issue.id,
@@ -157,7 +157,7 @@ describe 'Grammar corrections' do
           length: 4,
           replacement: 'test'
         }
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'returns 422 for an invalid commentable_type' do

--- a/engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/grammar_suggestions_spec.rb
+++ b/engines/dradis-echo/spec/requests/dradis/plugins/echo/projects/grammar_suggestions_spec.rb
@@ -90,12 +90,12 @@ describe 'Grammar suggestions' do
     it 'returns 404 for an issue outside the current project scope' do
       other_issue = create(:issue, node: create(:node))
 
-      expect {
+      expect do
         post "/addons/echo/projects/#{@project.id}/grammar_suggestions", params: {
           commentable_type: 'Issue',
           commentable_id: other_issue.id
         }
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'returns 422 for an invalid commentable_type' do

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -7,9 +7,9 @@ FactoryBot.define do
 
     initialize_with do
       FileUtils.mkdir_p Attachment.pwd.join(node.id.to_s).to_s
-      FileUtils.cp Rails.root.join("spec/fixtures/files/rails.png").to_s,
+      FileUtils.cp Rails.root.join('spec/fixtures/files/rails.png').to_s,
                    Attachment.pwd.join(node.id.to_s, filename).to_s
-      Attachment.find(filename, conditions: { node_id: node.id } )
+      Attachment.find(filename, conditions: { node_id: node.id })
     end
   end
 end

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     sequence(:filename) { |n| "image#{n}.png" }
     node
 
-    initialize_with {
+    initialize_with do
       FileUtils.mkdir_p Attachment.pwd.join(node.id.to_s).to_s
       FileUtils.cp Rails.root.join("spec/fixtures/files/rails.png").to_s,
                    Attachment.pwd.join(node.id.to_s, filename).to_s
       Attachment.find(filename, conditions: { node_id: node.id } )
-    }
+    end
   end
 end

--- a/spec/factories/evidence.rb
+++ b/spec/factories/evidence.rb
@@ -11,9 +11,9 @@ FactoryBot.define do
     end
 
     trait :with_liquid do
-      content {
+      content do
         "#[Title]#\nFoo\n\n#[Description]#\nLiquid: {{evidence.title}}\n\nProject: {{project.name}}"
-      }
+      end
     end
   end
 end

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -13,9 +13,9 @@ FactoryBot.define do
     end
 
     trait :with_liquid do
-      text {
+      text do
         "#[Title]#\nFoo\n\n#[Description]#\nLiquid: {{issue.title}}\n\nProject: {{project.name}}"
-      }
+      end
     end
   end
 end

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     trait :with_properties do
-      properties {
+      properties do
         {
           'network': 'blue',
           'ip': [
@@ -38,7 +38,7 @@ FactoryBot.define do
             ]
           }
         }
-      }
+      end
     end
   end
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
   end
 
   trait :with_liquid do
-    content {
+    content do
       "#[Title]#\nFoo\n\n#[Description]#\nLiquid: {{note.title}}\n\nProject: {{project.name}}"
-    }
+    end
   end
 end

--- a/spec/features/board_pages/board_pages_spec.rb
+++ b/spec/features/board_pages/board_pages_spec.rb
@@ -46,14 +46,14 @@ describe 'Board pages:' do
           board
           visit project_boards_path(current_project)
 
-          expect {
+          expect do
             click_link 'New Methodology'
 
             find('#modal-board-new', visible: true)
             find('#board_new_board_template ~ .combobox').click
             find('.combobox-option', text: 'Methodology Template v3').click
             click_button 'Add methodology'
-          }.to change { Board.count }.by(1)
+          end.to change { Board.count }.by(1)
         end
       end
     end

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -294,9 +294,9 @@ describe 'Card pages:' do
           new_list = create(:list)
           @card.update(list: new_list)
 
-          expect {
+          expect do
             visit project_board_list_card_path(current_project, @board, @list, @card)
-          }.to raise_error ActiveRecord::RecordNotFound
+          end.to raise_error ActiveRecord::RecordNotFound
         end
       end
     end

--- a/spec/features/card_pages/card_pages_spec.rb
+++ b/spec/features/card_pages/card_pages_spec.rb
@@ -13,14 +13,14 @@ describe 'Card pages:' do
 
   context 'as authenticated user' do
     let(:add_users) do
-      @first_user  = create(:user)
+      @first_user = create(:user)
       @second_user = create(:user)
     end
 
     before do
       login_to_project_as_user
       @board = create(:board, project: current_project, node: current_project.methodology_library)
-      @list  = create(:list, board: @board)
+      @list = create(:list, board: @board)
     end
 
     describe 'when in new page', js: true do
@@ -246,7 +246,7 @@ describe 'Card pages:' do
 
       describe "clicking 'delete'" do
         before { PaperTrail.enabled = true }
-        after  { PaperTrail.enabled = false }
+        after { PaperTrail.enabled = false }
 
         let(:submit_form) do
           within('.actions', match: :first) do

--- a/spec/features/export/v3/template_spec.rb
+++ b/spec/features/export/v3/template_spec.rb
@@ -11,9 +11,9 @@ require 'rails_helper'
 describe 'Pro export template', skip: true do
   before { login_to_project_as_user }
 
-  let(:export_options) {
+  let(:export_options) do
     { plugin: Dradis::Plugins::Projects, project_id: current_project.id }
-  }
+  end
 
   context 'exporting boards' do
     before do

--- a/spec/features/issue_pages/merge_spec.rb
+++ b/spec/features/issue_pages/merge_spec.rb
@@ -64,9 +64,9 @@ describe 'issue pages' do
         expect(Issue.last.reload.tag_list).to eq(tag_name)
       end
 
-      let(:submit_form) {
+      let(:submit_form) do
         submit_and_wait
-      }
+      end
       include_examples 'deleted item is listed in Trash', :issue
     end
   end

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -60,19 +60,19 @@ describe 'node pages' do
           .and change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(3)
 
         expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h|
+          ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h|
             h[:job]
-          }.last(3)
+          end.last(3)
         ).to include *Array.new(3, ActivityTrackingJob)
         expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+          ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h1|
             h1[:args].map { |h2| h2['action'] }
-          }.flatten.last(3)
+          end.flatten.last(3)
         ).to include *Array.new(3, 'create')
         expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+          ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h1|
             h1[:args].map { |h2| h2['trackable_type'] }
-          }.flatten.last(3)
+          end.flatten.last(3)
         ).to include *Array.new(3, 'Node')
 
         expect(current_project.nodes.last(3).map(&:label)).to match_array([
@@ -147,19 +147,19 @@ describe 'node pages' do
         .and change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(3)
 
         expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h|
+          ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h|
             h[:job]
-          }.last(3)
+          end.last(3)
         ).to eq Array.new(3, ActivityTrackingJob)
         expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+          ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h1|
             h1[:args].map { |h2| h2['action'] }
-          }.flatten.last(3)
+          end.flatten.last(3)
         ).to eq Array.new(3, 'create')
         expect(
-          ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+          ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h1|
             h1[:args].map { |h2| h2['trackable_type'] }
-          }.flatten.last(3)
+          end.flatten.last(3)
         ).to eq Array.new(3, 'Node')
 
         expect(node.children.pluck(:label)).to match_array([

--- a/spec/features/node_pages_spec.rb
+++ b/spec/features/node_pages_spec.rb
@@ -273,9 +273,9 @@ describe 'node pages' do
       include ActivityMacros
 
       let(:extra_setup) do
-        @note       = create(:note, node: @node)
-        @issue      = create(:issue, node: current_project.issue_library)
-        @evidence   = create(:evidence, issue: @issue, node: @node)
+        @note = create(:note, node: @node)
+        @issue = create(:issue, node: current_project.issue_library)
+        @evidence = create(:evidence, issue: @issue, node: @node)
         @other_node = create(:node, project: current_project)
         @activities = [@node, @note, @evidence].flat_map do |model|
           [
@@ -305,11 +305,11 @@ describe 'node pages' do
 
     context 'when the node has nested notes or evidence' do
       let(:extra_setup) do
-        @note           = create(:note, node: @node, text: "#[Title]#\nMy note")
-        @issue          = create(:issue, node: current_project.issue_library)
-        @evidence       = create(:evidence, issue: @issue, node: @node)
-        other_node      = create(:node, project: current_project)
-        @other_note     = create(:note,     node: other_node)
+        @note = create(:note, node: @node, text: "#[Title]#\nMy note")
+        @issue = create(:issue, node: current_project.issue_library)
+        @evidence = create(:evidence, issue: @issue, node: @node)
+        other_node = create(:node, project: current_project)
+        @other_note = create(:note, node: other_node)
         @other_evidence = create(:evidence, node: other_node)
       end
 
@@ -326,7 +326,7 @@ describe 'node pages' do
     it "shows the node's properties" do
       @properties.each do |key, value|
         should have_selector 'h4', text: key.to_s.capitalize
-        should have_selector 'p',  text: value
+        should have_selector 'p', text: value
       end
     end
   end

--- a/spec/features/upload/v2/template_spec.rb
+++ b/spec/features/upload/v2/template_spec.rb
@@ -20,9 +20,9 @@ describe 'Dradis::Plugins::Projects::Upload::V2::Template::Importer', skip: true
   end
 
   let(:importer_class) { Dradis::Plugins::Projects::Upload::Template }
-  let(:with_comments) {
+  let(:with_comments) do
     Rails.root.join('spec', 'fixtures', 'files', 'templates', 'with_comments.xml')
-  }
+  end
 
   context 'uploading a template with comments' do
     it 'imports the comments' do

--- a/spec/features/upload/v3/template_spec.rb
+++ b/spec/features/upload/v3/template_spec.rb
@@ -20,12 +20,12 @@ describe 'Dradis::Plugins::Projects::Upload::V3::Template::Importer', skip: true
   end
 
   let(:importer_class) { Dradis::Plugins::Projects::Upload::Template }
-  let(:with_node_boards) {
+  let(:with_node_boards) do
     Rails.root.join('spec', 'fixtures', 'files', 'templates', 'with_node_boards.xml')
-  }
-  let(:without_node_id) {
+  end
+  let(:without_node_id) do
     Rails.root.join('spec', 'fixtures', 'files', 'templates', 'without_node_id.xml')
-  }
+  end
 
   context 'uploading a template with boards' do
     before { @importer.import(file: with_node_boards) }

--- a/spec/jobs/activity_tracking_job_spec.rb
+++ b/spec/jobs/activity_tracking_job_spec.rb
@@ -27,7 +27,7 @@ describe ActivityTrackingJob do #, type: :job do
           trackable = model
           trackable.destroy if action == :destroy
 
-          expect {
+          expect do
             described_class.new.perform(
               action: action.to_s,
               project_id: project.id,
@@ -35,7 +35,7 @@ describe ActivityTrackingJob do #, type: :job do
               trackable_type: trackable.class.to_s,
               user_id: user.id
             )
-          }.to change { Activity.count }.by(1)
+          end.to change { Activity.count }.by(1)
 
           activity = Activity.last
 

--- a/spec/jobs/activity_tracking_job_spec.rb
+++ b/spec/jobs/activity_tracking_job_spec.rb
@@ -8,19 +8,19 @@ describe ActivityTrackingJob do #, type: :job do
 
   describe '#perform' do
     it 'creates activities' do
-      project   = create(:project)
-      parent_node  = create(:node, project: project)
+      project = create(:project)
+      parent_node = create(:node, project: project)
       parent_issue = create(:issue, node: project.issue_library)
 
-      node      = create(:node, project: project)
-      issue     = create(:issue, node: project.issue_library)
-      note      = create(:note, node: parent_node)
-      evidence  = create(:evidence, issue: parent_issue, node: parent_node)
-      comment   = create(:comment, commentable: parent_issue)
+      node = create(:node, project: project)
+      issue = create(:issue, node: project.issue_library)
+      note = create(:note, node: parent_node)
+      evidence = create(:evidence, issue: parent_issue, node: parent_node)
+      comment = create(:comment, commentable: parent_issue)
 
-      models  = [node, issue, note, evidence, comment]
+      models = [node, issue, note, evidence, comment]
       actions = [:create, :update, :destroy]
-      user    = create(:user)
+      user = create(:user)
 
       models.each do |model|
         actions.each do |action|

--- a/spec/jobs/notifications_reader_job_spec.rb
+++ b/spec/jobs/notifications_reader_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe NotificationsReaderJob  do #, type: :job do
+describe NotificationsReaderJob do #, type: :job do
   it 'uses correct queue' do
     expect(described_class.new.queue_name).to eq('dradis_project')
   end
@@ -20,7 +20,7 @@ describe NotificationsReaderJob  do #, type: :job do
               notifiable_id: project.id,
               user_id: user.id
             )
-          end.to change{ Notification.unread.count }.by(-1)
+          end.to change { Notification.unread.count }.by(-1)
         end
       end
     end
@@ -40,7 +40,7 @@ describe NotificationsReaderJob  do #, type: :job do
             notifiable_id: commentable.id,
             user_id: user.id
           )
-        end.to change{ Notification.unread.count }.by(-1)
+        end.to change { Notification.unread.count }.by(-1)
       end
     end
   end

--- a/spec/jobs/notifications_reader_job_spec.rb
+++ b/spec/jobs/notifications_reader_job_spec.rb
@@ -14,13 +14,13 @@ describe NotificationsReaderJob  do #, type: :job do
 
           create(:notification, notifiable: project, action: :assign, actor: create(:user), recipient: user)
 
-          expect {
+          expect do
             described_class.new.perform(
               notifiable_type: project.class.to_s,
               notifiable_id: project.id,
               user_id: user.id
             )
-          }.to change{ Notification.unread.count }.by(-1)
+          end.to change{ Notification.unread.count }.by(-1)
         end
       end
     end
@@ -34,13 +34,13 @@ describe NotificationsReaderJob  do #, type: :job do
 
         create(:notification, notifiable: comment, action: :create, actor: create(:user), recipient: user)
 
-        expect {
+        expect do
           described_class.new.perform(
             notifiable_type: commentable.class.to_s,
             notifiable_id: commentable.id,
             user_id: user.id
           )
-        }.to change{ Notification.unread.count }.by(-1)
+        end.to change{ Notification.unread.count }.by(-1)
       end
     end
   end

--- a/spec/lib/html/pipeline/dradis/sanitize_spec.rb
+++ b/spec/lib/html/pipeline/dradis/sanitize_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe HTML::Pipeline::Dradis::Sanitize do
-  let(:context) {
+  let(:context) do
     { whitelist: HTML::Pipeline::Dradis::Sanitize::ALLOWLIST }
-  }
+  end
   let(:pipeline_filters) { [HTML::Pipeline::SanitizationFilter] }
   let(:pipeline) { HTML::Pipeline.new(pipeline_filters, context) }
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -39,9 +39,9 @@ describe Comment do
       subscriptions = create_list(:subscription, 2, subscribable: commentable)
       comment = create(:comment, commentable: commentable)
 
-      expect {
+      expect do
         comment.notify(action: 'create', actor: comment.user, recipients: [])
-      }.to change { Notification.count }.by(2)
+      end.to change { Notification.count }.by(2)
     end
 
     it 'creates notifications when a comment has mentions' do
@@ -56,9 +56,9 @@ describe Comment do
         content: "Hello @#{mentioned.email} and @#{issue_owner.email}"
       )
 
-      expect {
+      expect do
         comment.notify(action: 'create', actor: comment.user, recipients: [])
-      }.to change { Notification.count }.by(3) \
+      end.to change { Notification.count }.by(3) \
       .and change { Subscription.count }.by(1)
 
       expect(Notification.where(action: 'mention').count).to eq(2)
@@ -73,9 +73,9 @@ describe Comment do
 
       allow_any_instance_of(Ability).to receive(:can?).with(:read, comment).and_return(false)
 
-      expect {
+      expect do
         comment.notify(action: 'create', actor: comment.user, recipients: [])
-      }.to change { Notification.count }.by(0)
+      end.to change { Notification.count }.by(0)
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,7 +8,7 @@ describe Comment do
   it { should validate_presence_of :content }
 
   it 'subscribes the comment author to the commentable' do
-    user  = create(:user)
+    user = create(:user)
     issue = create(:issue)
     expect do
       Comment.create(commentable: issue, content: 'rspec content', user: user)
@@ -17,16 +17,16 @@ describe Comment do
 
   describe '#mentions' do
     it 'detects mentions' do
-      user1   = create(:user, email: 'foo@dradis.test')
-      user2   = create(:user, email: 'bar@dradis.test')
+      user1 = create(:user, email: 'foo@dradis.test')
+      user2 = create(:user, email: 'bar@dradis.test')
       comment = create(:comment, content: 'Hello @foo@dradis.test and hello @bar@dradis.test')
 
       expect(comment.mentions).to match_array [user1, user2]
     end
 
     it 'detects admins in mentions' do
-      user1   = create(:user, :admin, email: 'admin@dradis.test')
-      user2   = create(:user, email: 'foo@dradis.test')
+      user1 = create(:user, :admin, email: 'admin@dradis.test')
+      user2 = create(:user, email: 'foo@dradis.test')
       comment = create(:comment, content: 'Hello @admin@dradis.test and @foo@dradis.test')
 
       expect(comment.mentions).to match_array [user1, user2]

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -75,9 +75,9 @@ describe Issue do
     let!(:evidence) { create(:evidence) }
 
     it 'creates an issue with a name containing "Auto-generated Issue"' do
-      expect {
+      expect do
         described_class.autogenerate_from(evidence)
-      }.to change(Issue, :count).by(1)
+      end.to change(Issue, :count).by(1)
 
       expect(Issue.last.title).to include('Auto-generated Issue')
     end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -130,7 +130,7 @@ describe Issue do
     it "returns the issue's activities" do
       # this requires some hackery, because by default it won't work because
       # Issue and Note don't use proper single-table inheritance :(
-      node  = create(:node)
+      node = create(:node)
       issue = create(:issue, node: node)
       activities = create_list(:activity, 2, trackable: issue)
 

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -7,10 +7,10 @@ describe 'subscriptions' do
 
   describe 'POST /subscriptions' do
     it 'subscribes the current user to the subscribable' do
-      expect {
+      expect do
         post '/subscriptions',
           params: { subscription: { subscribable_type: 'Issue', subscribable_id: issue.id } }
-      }.to change(Subscription, :count).by(1)
+      end.to change(Subscription, :count).by(1)
     end
   end
 

--- a/spec/services/activity_service_spec.rb
+++ b/spec/services/activity_service_spec.rb
@@ -6,7 +6,7 @@ describe ActivityService do
   let(:user) { create(:user) }
   let(:project) { create(:project) }
 
-  let(:payload) {
+  let(:payload) do
     {
       action: 'test',
       project: {
@@ -20,7 +20,7 @@ describe ActivityService do
         name: user.name
       }
     }
-  }
+  end
 
   it 'enqueues ActivityTrackingJob for subscribed events' do
     expect do

--- a/spec/support/activity_shared_examples.rb
+++ b/spec/support/activity_shared_examples.rb
@@ -28,14 +28,14 @@ shared_examples 'creates an Activity' do |action, klass = nil|
         ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h| h[:job] }
       ).to include ActivityTrackingJob
       expect(
-        ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+        ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h1|
           h1[:args].map { |h2| h2['action'] }
-        }.flatten
+        end.flatten
       ).to include 'create'
       expect(
-        ActiveJob::Base.queue_adapter.enqueued_jobs.map { |h1|
+        ActiveJob::Base.queue_adapter.enqueued_jobs.map do |h1|
           h1[:args].map { |h2| h2['trackable_type'] }
-        }.flatten
+        end.flatten
       ).to include klass.to_s
     else
       expect { submit_form }.to have_enqueued_job(ActivityTrackingJob).with(

--- a/spec/support/inline_thread_shared_examples.rb
+++ b/spec/support/inline_thread_shared_examples.rb
@@ -65,7 +65,7 @@ shared_examples 'inline threads' do
 
   describe 'POST /inline_threads' do
     it 'creates a new thread with initial comment' do
-      expect {
+      expect do
         post inline_threads_path,
           params: {
             inline_thread: {
@@ -76,7 +76,7 @@ shared_examples 'inline threads' do
             }
           },
           headers: turbo_stream_headers
-      }.to change { InlineThread.count }.by(1)
+      end.to change { InlineThread.count }.by(1)
         .and change { Comment.count }.by(1)
 
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
@@ -97,10 +97,10 @@ shared_examples 'inline threads' do
     it 'destroys a thread owned by the current user' do
       thread = create(:inline_thread, commentable: commentable, user: @logged_in_as)
 
-      expect {
+      expect do
         delete inline_thread_path(thread),
           headers: turbo_stream_headers
-      }.to change { InlineThread.count }.by(-1)
+      end.to change { InlineThread.count }.by(-1)
 
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
     end
@@ -143,11 +143,11 @@ shared_examples 'inline threads' do
     it 'creates a reply comment on the thread' do
       thread = create(:inline_thread, commentable: commentable)
 
-      expect {
+      expect do
         post inline_thread_comments_path(thread),
           params: { comment: { content: 'Good point, will fix' } },
           headers: turbo_stream_headers
-      }.to change { thread.comments.count }.by(1)
+      end.to change { thread.comments.count }.by(1)
 
       expect(response.media_type).to eq('text/vnd.turbo-stream.html')
 

--- a/spec/support/textile_editor_shared_examples.rb
+++ b/spec/support/textile_editor_shared_examples.rb
@@ -63,12 +63,12 @@ shared_examples 'a textile form view' do |klass|
   end
 
   it 'remove fields in the form', js: true do
-    expect {
+    expect do
       find('[data-behavior=textile-form-field]', match: :first).hover
       within '[data-behavior~=textile-form-field]', match: :first do
         click_link 'Delete'
       end
-    }.to change { all('.textile-form-field').count }.by(-1)
+    end.to change { all('.textile-form-field').count }.by(-1)
   end
 
   it 'saves the item when submitted', js: true do


### PR DESCRIPTION
### Summary

A recent review comment flagged a multi-line block using `{ }` braces
that should have used `do...end`. Our RuboCop config runs with
`DisabledByDefault: true`, and `Style/BlockDelimiters` was never
enabled — so the linter couldn't catch these; they had to be spotted
by hand in review.

This enables `Style/BlockDelimiters` (default `line_count_based`:
braces for single-line blocks, `do...end` for multi-line) and
autocorrects the 54 existing offenses across the codebase.

Because `bin/rubocop-ci` lints whole changed files, the touched files
also had a handful of unrelated safe-autocorrectable offenses
(`Layout/ExtraSpacing`, hash alignment, etc.); those are cleaned up in
a separate commit so CI stays green. All changes are mechanical
RuboCop safe-autocorrects — no behavioural changes.

Commits:
- `enforce do...end for multi-line blocks via Style/BlockDelimiters`
- `clean up incidental rubocop offenses in files touched by block-delimiter change`

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

No CHANGELOG entry — this is an internal lint-config change, not user-facing.