### PR TITLE
Fix stuck export/upload progress caused by unindexed logs table

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
   - Upgraded gems:
     - rails-html-sanitizer, sqlite3, websocket-driver
   - Bugs fixes:
+    - Logs: index the logs table so progress lookups and cleanup stay fast as it grows
+    - Uploads/Exports: retry progress polling automatically after a failed request, and show an error if it keeps failing
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/app/assets/javascripts/hera/modules/console_updater.js.coffee
+++ b/app/assets/javascripts/hera/modules/console_updater.js.coffee
@@ -1,6 +1,8 @@
 @ConsoleUpdater =
   jobId: ''
   parsing: false
+  failureCount: 0
+  maxFailures: 5
 
   updateConsole: ->
     unless ConsoleUpdater.parsing
@@ -21,4 +23,12 @@
       {item_id: ConsoleUpdater.jobId, after: after},
       null,
       'script'
-    )
+    ).done(->
+      ConsoleUpdater.failureCount = 0
+    ).fail ->
+      ConsoleUpdater.failureCount += 1
+
+      if ConsoleUpdater.failureCount < ConsoleUpdater.maxFailures
+        setTimeout(ConsoleUpdater.updateConsole, 2000)
+      else
+        $('#console').append('<p class="log text-error">Lost connection while checking progress. Please refresh the page to check the current status.</p>')

--- a/app/assets/javascripts/hera/modules/console_updater.js.coffee
+++ b/app/assets/javascripts/hera/modules/console_updater.js.coffee
@@ -24,6 +24,8 @@
       null,
       'script'
     ).done(->
+      # Reset on every success so the cap only trips on consecutive failures,
+      # not ones accumulated over the whole polling session.
       ConsoleUpdater.failureCount = 0
     ).fail ->
       ConsoleUpdater.failureCount += 1

--- a/db/migrate/20260722163331_add_index_to_logs_on_uid.rb
+++ b/db/migrate/20260722163331_add_index_to_logs_on_uid.rb
@@ -1,0 +1,5 @@
+class AddIndexToLogsOnUid < ActiveRecord::Migration[8.0]
+  def change
+    add_index :logs, :uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_21_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_22_163331) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -184,6 +184,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_21_000001) do
     t.text "text"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["uid"], name: "index_logs_on_uid"
   end
 
   create_table "mapping_fields", force: :cascade do |t|


### PR DESCRIPTION
## Summary

While diagnosing a hosted Pro instance with 47.2 million rows in its `logs` table, we found the root cause is present in CE too: the `logs` table has no index beyond its primary key, and the client-side progress-polling JS has no error handling. Together these mean that once a `logs` table grows large enough for lookups to slow down, progress polling can silently and permanently stop updating, with no indication to the user that anything went wrong.

- **`db/migrate/..._add_index_to_logs_on_uid.rb`**: adds an index on `logs.uid`, the column `ConsoleController#status` filters on for every progress-polling request. Without it, each poll is a full table scan. Note: the equivalent Pro migration uses `algorithm: :inplace` to force an online, non-locking index build on MySQL, but that option isn't supported by the SQLite3 adapter, which CE defaults to — passing it here breaks migrations outright for most CE installs, so it's omitted for this version.
- **`app/assets/javascripts/hera/modules/console_updater.js.coffee`**: the polling loop only rescheduled its next check from inside the AJAX *success* callback, with no `.fail()` handler — a single dropped/timed-out request permanently stopped progress updates with no error shown. Now retries on failure (resetting the retry count on any success, so intermittent blips don't accumulate), and after 5 consecutive failures stops retrying and shows a "lost connection, please refresh" message instead of hanging silently forever.
- **`CHANGELOG`**: entries for the above.

This will be synced into Pro (which has its own equivalent fixes plus two Pro-only changes: batching `LogCleanupJob`'s deletion, and the same polling fix in the Word-export validator).

## Testing steps

Confirm the logs table index exists after migrating
Trigger an export or upload and confirm progress updates appear live in the console without needing a manual refresh
Simulate a failed progress-polling request (e.g. block the endpoint temporarily) and confirm polling retries automatically, then shows the "lost connection" message after repeated failures instead of hanging indefinitely

## Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.