### PR TITLE
Scrub invalid UTF-8 byte sequences from every string/text column

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   - Upgraded gems:
     - rails-html-sanitizer, sqlite3, websocket-driver
   - Bugs fixes:
+    - Models: scrub invalid UTF-8 byte sequences from every :string and :text column before saving
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/config/initializers/scrub_invalid_encoding.rb
+++ b/config/initializers/scrub_invalid_encoding.rb
@@ -1,0 +1,19 @@
+# Content can contain invalid UTF-8 byte sequences. MySQL can be configured
+# to reject these at the DB layer, but CE runs on SQLite, which has no
+# charset enforcement at all, so DB-level rejection can't be the shared fix
+# across editions. Scrub instead, so an unscrubbed value never reaches the
+# DB and never raises an unhandled ArgumentError later, wherever it happens
+# to be read first rather than where it was written.
+#
+# ActiveModel::Type::String is the shared base type behind every :string and
+# :text column (ActiveRecord::Type::String and ActiveRecord::Type::Text both
+# inherit from it), so scrubbing here covers every column of both types, on
+# every model and every adapter, without registering per model or column.
+module ScrubsInvalidEncoding
+  def cast(value)
+    value = value.scrub if value.is_a?(String)
+    super
+  end
+end
+
+ActiveModel::Type::String.prepend(ScrubsInvalidEncoding)

--- a/spec/initializers/scrub_invalid_encoding_spec.rb
+++ b/spec/initializers/scrub_invalid_encoding_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'scrubbing invalid encoding' do
+  let(:bad_bytes) { "before \xC3\x28 after" }
+
+  it 'scrubs invalid byte sequences on cast' do
+    type = ActiveModel::Type::String.new
+
+    expect(type.cast(bad_bytes).valid_encoding?).to eq(true)
+  end
+
+  it 'leaves valid strings untouched' do
+    type = ActiveModel::Type::String.new
+
+    expect(type.cast('valid string')).to eq('valid string')
+  end
+
+  it 'passes non-string values through to the wrapped type' do
+    type = ActiveModel::Type::String.new
+
+    expect(type.cast(42)).to eq('42')
+  end
+
+  it 'covers :string columns' do
+    node = build(:node, label: bad_bytes)
+
+    node.save!
+
+    expect(node.reload.label.valid_encoding?).to eq(true)
+  end
+
+  it 'covers :text columns' do
+    note = build(:note, text: bad_bytes)
+
+    note.save!
+
+    expect(note.reload.text.valid_encoding?).to eq(true)
+  end
+
+  it 'covers :string columns without per-model opt-in' do
+    card = create(:card, name: bad_bytes)
+
+    expect(card.reload.name.valid_encoding?).to eq(true)
+  end
+end


### PR DESCRIPTION
### Summary

Notes, Cards, Nodes, and Evidence can pick up invalid UTF-8 byte sequences from pasted or imported content. Until now this only failed as an unhandled `ArgumentError` in whichever request happened to trip over it first, since validations end up calling `String#length` on invalid bytes.

This scrubs at the type-casting layer. `ActiveRecord::Type::String` and `ActiveRecord::Type::Text` both inherit from `ActiveModel::Type::String`, so prepending the scrub onto that shared base type covers every `:string` and `:text` column, on every model, without per-model registration.

This also has to work identically on CE (SQLite) and Pro (MySQL). MySQL can be configured to reject invalid UTF-8 at the DB layer, but SQLite has no charset enforcement at all, so DB-level rejection can't be the shared fix across editions. Scrubbing before the value ever reaches the DB is.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.