### PR TITLE
fix footer link contrast

### DIFF
--- a/app/assets/stylesheets/hera/layout.scss
+++ b/app/assets/stylesheets/hera/layout.scss
@@ -123,6 +123,14 @@ footer {
   font-size: 0.9rem;
   padding: 0.5rem;
   text-align: center;
+
+  a {
+    color: $brand-500;
+
+    &:hover {
+      color: $brand-900;
+    }
+  }
 }
 
 header {


### PR DESCRIPTION
### Summary

The footer's background (`$brand-100`) doesn't change with the theme, but the footer link inherited the global `a { color: var(--text-link) }` rule, which does switch per theme. In dark mode `--text-link` resolves to `$brand-200`, a light green with insufficient contrast against the footer's (always light) `$brand-100` background.

Fixes this by giving the footer link explicit, theme-invariant colors (`$brand-500` / `$brand-900` on hover) instead of inheriting the theme-driven link color.

### Testing steps

1. Login as any user.
2. Navigate to the navbar theme toggle and switch the theme to **Dark**.
3. Navigate to any page that renders the app footer (e.g. the project dashboard).
4. Assert the "dradis.com" link in the footer is clearly legible (dark green text) against the footer's light green background.
5. Hover over the "dradis.com" footer link.
6. Assert the link color changes to the hover color and remains clearly legible.
7. Switch the theme to **Light**.
8. Assert the footer link still renders with its original color and is legible (no regression).
9. Switch the theme to **Auto** with the OS set to dark mode.
10. Assert the footer link is legible, matching the behavior seen in step 4.

### Other Information

No CHANGELOG entry included per author's request.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.