### PR TITLE
Scope divider gap to labeled dividers only

### DIFF
--- a/app/assets/stylesheets/hera/modules/_divider.scss
+++ b/app/assets/stylesheets/hera/modules/_divider.scss
@@ -1,7 +1,6 @@
 .divider {
   align-items: center;
   display: flex;
-  gap: 0.5rem;
   margin: 0.25rem 0;
 
   &::before,
@@ -9,6 +8,10 @@
     border-top: 1px solid var(--border-color);
     content: '';
     flex: 1;
+  }
+
+  &:has(.divider-label) {
+    gap: 0.5rem;
   }
 
   .divider-label {


### PR DESCRIPTION
### Summary

Plain `.divider` elements (no label) only render the `::before`/`::after` pseudo-elements as flex children. The flexbox `gap` added to `.divider` split that single line into two segments with a visible break in the middle. This restricts the gap to only apply when a `.divider-label` is present, using `&:has(.divider-label)`.

### Testing steps

1. Visit `/styles#dividers` and confirm the plain divider renders as a single unbroken line, and the labeled (`divider-lg`/`divider-xl`) dividers still show correct spacing around their label.
2. Open any dropdown with a plain divider (e.g. the tag input dropdown or the "send to" menu on an Issue) and confirm the line has no gap.
3. Visit the setup wizard's kit selection page and confirm the "or" divider still has proper spacing around its label.
4. Visit a project dashboard (`/pm/projects/:id`) and confirm the "Methodology Progress" and "Quality Assurance" section dividers still show correct spacing around their labels.

### Other Information

N/A

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- ~[ ] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.