### PR TITLE
Whitelist gemspec files instead of shelling out to git

### DIFF
--- a/engines/dradis-api/dradis-api.gemspec
+++ b/engines/dradis-api/dradis-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Dradis HTTP API'
   gem.homepage      = 'https://dradis.com/ce/'
 
-  gem.files         = system('git', 'rev-parse', '--is-inside-work-tree', out: File::NULL, err: File::NULL) ? `git ls-files`.split($\) : []
+  gem.files         = Dir['{app,config,lib}/**/*', 'CHANGELOG', 'Rakefile', 'README.md']
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']

--- a/engines/dradis-api/dradis-api.gemspec
+++ b/engines/dradis-api/dradis-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Dradis HTTP API'
   gem.homepage      = 'https://dradis.com/ce/'
 
-  gem.files         = Dir['**/*'].select { |f| File.file?(f) }
+  gem.files         = system('git', 'rev-parse', '--is-inside-work-tree', out: File::NULL, err: File::NULL) ? `git ls-files`.split($\) : []
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']

--- a/engines/dradis-api/dradis-api.gemspec
+++ b/engines/dradis-api/dradis-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Dradis HTTP API'
   gem.homepage      = 'https://dradis.com/ce/'
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = Dir['**/*'].select { |f| File.file?(f) }
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']

--- a/engines/dradis-echo/dradis-echo.gemspec
+++ b/engines/dradis-echo/dradis-echo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.authors = ['Daniel Martin']
   spec.homepage = 'https://dradis.com/support/'
 
-  spec.files = Dir['**/*'].select { |f| File.file?(f) }
+  spec.files = system('git', 'rev-parse', '--is-inside-work-tree', out: File::NULL, err: File::NULL) ? `git ls-files`.split($\) : []
   spec.executables = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 

--- a/engines/dradis-echo/dradis-echo.gemspec
+++ b/engines/dradis-echo/dradis-echo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.authors = ['Daniel Martin']
   spec.homepage = 'https://dradis.com/support/'
 
-  spec.files = system('git', 'rev-parse', '--is-inside-work-tree', out: File::NULL, err: File::NULL) ? `git ls-files`.split($\) : []
+  spec.files = Dir['{app,config,db,lib}/**/*', 'CHANGELOG.md', 'Rakefile', 'README.md']
   spec.executables = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 

--- a/engines/dradis-echo/dradis-echo.gemspec
+++ b/engines/dradis-echo/dradis-echo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.authors = ['Daniel Martin']
   spec.homepage = 'https://dradis.com/support/'
 
-  spec.files = `git ls-files`.split($\)
+  spec.files = Dir['**/*'].select { |f| File.file?(f) }
   spec.executables = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 

--- a/engines/dradis-sandbox/dradis-sandbox.gemspec
+++ b/engines/dradis-sandbox/dradis-sandbox.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Dradis CE Sandbox'
   gem.homepage      = 'https://dradis.com/ce/'
 
-  gem.files         = Dir['**/*'].select { |f| File.file?(f) }
+  gem.files         = system('git', 'rev-parse', '--is-inside-work-tree', out: File::NULL, err: File::NULL) ? `git ls-files`.split($\) : []
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']

--- a/engines/dradis-sandbox/dradis-sandbox.gemspec
+++ b/engines/dradis-sandbox/dradis-sandbox.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Dradis CE Sandbox'
   gem.homepage      = 'https://dradis.com/ce/'
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = Dir['**/*'].select { |f| File.file?(f) }
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']

--- a/engines/dradis-sandbox/dradis-sandbox.gemspec
+++ b/engines/dradis-sandbox/dradis-sandbox.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Dradis CE Sandbox'
   gem.homepage      = 'https://dradis.com/ce/'
 
-  gem.files         = system('git', 'rev-parse', '--is-inside-work-tree', out: File::NULL, err: File::NULL) ? `git ls-files`.split($\) : []
+  gem.files         = Dir['{app,config,db,lib}/**/*', 'README.md']
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']


### PR DESCRIPTION
### Summary

The `dradis-api`, `dradis-echo`, and `dradis-sandbox` engine gemspecs built their `files` list with `` `git ls-files`.split($\) ``. Gemspecs are evaluated on every `Bundler.setup` call, so on any deployment that doesn't ship a `.git` directory (Docker images, VM appliances, release tarballs), this fired `fatal: not a git repository` once per engine on every Rails console / server boot, which is what users have been seeing and asking about.

Fixed by listing the files each gem needs directly, following the whitelist pattern RubyGems recommends and that Pro's `dradispro-scheduler` and `dradispro-remediationtracker` engines already use:

```ruby
gem.files = Dir['{app,config,lib}/**/*', 'CHANGELOG', 'Rakefile', 'README.md']
```

This removes the git dependency from gemspec evaluation entirely (no shelling out, no fallback check). Each engine's whitelist was checked against `git ls-files` to confirm it captures the same runtime files, excluding only dev-only paths (specs, `Gemfile`, `.gitignore`) that the reference gemspecs exclude too.

`gem.files` is only read when actually building the gem (`gem build`), a dev-only operation. These engines are `path:`-sourced in the Gemfile, so Bundler uses `require_paths`, not `files`, to load them at runtime. Verified nothing else in the app or in `dradis-plugins` reads `spec.files` on these engines.

### Other Information

Pure refactor, no user-facing behavior change.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [ ] ~~Added a CHANGELOG entry~~
- [x] Commit message has a detailed description of what changed and why.
