### PR TITLE
api: guard against blank current_project before authorizing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
       - Send only completed conversation turns to the AI provider, so a failed or in-progress reply can no longer break the next one
       - Show a generic message when a reply fails instead of surfacing the provider's raw error
       - Return a graceful error instead of a server error when a chat session is started with a blank prompt
+    - REST API:
+      - Return a 404 instead of a server error for project-scoped endpoints requested without a valid project
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/engines/dradis-api/app/controllers/concerns/dradis/ce/api/project_scoped.rb
+++ b/engines/dradis-api/app/controllers/concerns/dradis/ce/api/project_scoped.rb
@@ -11,7 +11,7 @@ module Dradis::CE::API
     protected
 
     def set_project
-      current_project
+      raise ActiveRecord::RecordNotFound if current_project.nil?
     end
 
     def current_project

--- a/engines/dradis-api/spec/requests/dradis/ce/api/project_scoped_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/project_scoped_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'API' do
+  describe 'ProjectScoped' do
+    include_context 'project scoped API'
+    include_context 'https'
+    include_context 'authorized API user'
+
+    context 'when current_project cannot be resolved' do
+      before do
+        allow_any_instance_of(Dradis::CE::API::V3::NodesController)
+          .to receive(:current_project).and_return(nil)
+      end
+
+      it 'renders a 404 instead of raising' do
+        get '/api/nodes', env: @env
+
+        expect(response.status).to eq(404)
+
+        body = JSON.parse(response.body)
+        expect(body['message']).to eq('ActiveRecord::RecordNotFound')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Every project-scoped API endpoint (Nodes, Issues, Boards, Evidence, Notes, etc.) returns a raw HTTP 500 instead of a 404 when the requesting client omits or sends an invalid project identifier, for any user whose CanCanCan ability includes `can :manage, :all` (e.g. an admin).

`Dradis::CE::API::ProjectScoped#set_project` calls `authorize! :use, current_project` without first checking whether `current_project` resolved to anything. A `can :manage, :all` ability matches a nil subject too, so `authorize!` passes silently, and the controller action then calls a method (`.nodes`, `.boards`, etc.) on `nil`, raising `NoMethodError` and surfacing as a 500.

This fixes it by raising `ActiveRecord::RecordNotFound` (already the convention for 404s in this API, see `rescue_from` in `APIController`) as soon as `current_project` is blank, before `authorize!` runs.

In CE, `current_project` always resolves to a `Project.new` placeholder, so this is a no-op safety net today. Dradis Pro overrides `current_project` to resolve a real project from the `Dradis-Project-Id` header, which can be nil, and that is where this actually reproduces as a 500. This PR is scoped to the shared guard; the Pro-specific reconciliation happens separately.

### Testing steps

- `GET /api/nodes` (or any project-scoped endpoint) as an admin, with `current_project` stubbed to return `nil`, now returns 404 instead of raising.
- Added `engines/dradis-api/spec/requests/dradis/ce/api/project_scoped_spec.rb` to cover this.
- Full `engines/dradis-api` spec suite passes: 433 examples, 0 failures.

### Other Information

Found while acceptance testing the REST API on a Dradis Pro 5.3.0 instance, where it reproduced as `GET /pro/api/boards` (and other project-scoped endpoints) 500ing when the `Dradis-Project-Id` header was omitted.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.