### PR TITLE
api: set author on note and evidence creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
       - Send only completed conversation turns to the AI provider, so a failed or in-progress reply can no longer break the next one
       - Show a generic message when a reply fails instead of surfacing the provider's raw error
       - Return a graceful error instead of a server error when a chat session is started with a blank prompt
+    - REST API:
+      - Set the author field to the authenticated user when creating notes and evidence
     - Bug tracker items:
       - [item]
   - New integrations:

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v3/evidence_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v3/evidence_controller.rb
@@ -17,6 +17,7 @@ module Dradis::CE::API
 
       def create
         @evidence = @node.evidence.build(evidence_params)
+        @evidence.author = current_user.email
         if @evidence.save
           track_created(@evidence)
           render status: 201, location: node_evidence_path(@node, @evidence)

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v3/notes_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v3/notes_controller.rb
@@ -17,6 +17,7 @@ module Dradis::CE::API
 
       def create
         @note = @node.notes.build(note_params)
+        @note.author = current_user.email
         @note.category ||= Category.default
         if @note.save
           track_created(@note)

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/evidence_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/evidence_spec.rb
@@ -5,7 +5,7 @@ describe 'Evidence API' do
   include_context 'project scoped API'
   include_context 'https'
 
-  let(:node)  { create(:node, project: current_project) }
+  let(:node) { create(:node, project: current_project) }
   let(:issue) { create(:issue, node: current_project.issue_library) }
 
   context 'as unauthenticated user' do
@@ -95,10 +95,10 @@ describe 'Evidence API' do
 
     describe 'GET /api/nodes/:node_id/evidence/:id' do
       before do
-        @issue    = create(:issue, node: current_project.issue_library)
+        @issue = create(:issue, node: current_project.issue_library)
         @evidence = node.evidence.create!(
           content: "#[foo]#\nbar\n#[fizz]#\nbuzz",
-          issue:   @issue,
+          issue: @issue,
         )
         get "/api/nodes/#{node.id}/evidence/#{@evidence.id}", env: @env
       end

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/evidence_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/evidence_spec.rb
@@ -147,6 +147,17 @@ describe 'Evidence API' do
           let(:submit_form) { post_evidence }
           include_examples 'creates an Activity', :create, Evidence
           include_examples 'sets the whodunnit', :create, Evidence
+
+          it 'sets the author to the authenticated user' do
+            post_evidence
+            expect(node.evidence.last.author).to eq @logged_in_as.email
+          end
+
+          it 'ignores a client-supplied author param' do
+            params[:evidence][:author] = 'attacker@evil.com'
+            post_evidence
+            expect(node.evidence.last.author).to eq @logged_in_as.email
+          end
         end
 
         context 'with params for an invalid evidence' do
@@ -227,6 +238,17 @@ describe 'Evidence API' do
           let(:model) { evidence }
           include_examples 'creates an Activity', :update
           include_examples 'sets the whodunnit', :update
+
+          it 'preserves the original author' do
+            put_evidence
+            expect(evidence.reload.author).to eq 'factory_bot'
+          end
+
+          it 'ignores a client-supplied author param' do
+            params[:evidence][:author] = 'attacker@evil.com'
+            put_evidence
+            expect(evidence.reload.author).to eq 'factory_bot'
+          end
         end
 
         context 'with params for an invalid evidence' do

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/notes_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/notes_spec.rb
@@ -89,7 +89,7 @@ describe 'Notes API' do
     describe 'GET /api/nodes/:node_id/notes/:id' do
       before do
         @note = node.notes.create!(
-          text:     "#[Title]#\nMy note\n#[foo]#\nbar\n#[fizz]#\nbuzz",
+          text: "#[Title]#\nMy note\n#[foo]#\nbar\n#[fizz]#\nbuzz",
           category: category,
         )
         get "/api/nodes/#{node.id}/notes/#{@note.id}", env: @env

--- a/engines/dradis-api/spec/requests/dradis/ce/api/v3/notes_spec.rb
+++ b/engines/dradis-api/spec/requests/dradis/ce/api/v3/notes_spec.rb
@@ -132,6 +132,17 @@ describe 'Notes API' do
           include_examples 'creates an Activity', :create, Note
           include_examples 'sets the whodunnit', :create, Note
 
+          it 'sets the author to the authenticated user' do
+            post_note
+            expect(node.notes.last.author).to eq @logged_in_as.email
+          end
+
+          it 'ignores a client-supplied author param' do
+            params[:note][:author] = 'attacker@evil.com'
+            post_note
+            expect(node.notes.last.author).to eq @logged_in_as.email
+          end
+
           context 'specifying a category' do
             before { params[:note][:category_id] = category.id }
 
@@ -233,6 +244,17 @@ describe 'Notes API' do
           let(:model) { note }
           include_examples 'creates an Activity', :update
           include_examples 'sets the whodunnit', :update
+
+          it 'preserves the original author' do
+            put_note
+            expect(note.reload.author).to eq 'factory-girl'
+          end
+
+          it 'ignores a client-supplied author param' do
+            params[:note][:author] = 'attacker@evil.com'
+            put_note
+            expect(note.reload.author).to eq 'factory-girl'
+          end
 
           it 'returns the attributes of the updated note as JSON' do
             put_note


### PR DESCRIPTION
### Summary

`POST`/`PUT` to the Evidence and Notes REST API v3 endpoints always
returned `"author": null`, even though the web UI correctly attributes the
creating user. `author` is a plain database column, not a content-parsed
field, and the API controllers never set it. (`v1` has the same bug but is
frozen, so it's left as-is.)

This mirrors the existing web UI pattern (`EvidenceController#create`,
`NotesController#create`): `author` is set server-side from
`current_user.email` on create, and left untouched on update so the
original creator is preserved across edits. `author` is not and was not
accepted as a client-supplied param.

### Testing steps

- `POST /api/nodes/:node_id/notes` and `POST /api/nodes/:node_id/evidence` (v3) as an authenticated user, the response now includes `"author"` set to that user's email instead of `null`.
- `PUT` to the same endpoints, `author` stays whatever it was originally (the creator), even if the client tries to send an `author` param in the request body.
- Added request specs covering both cases (`engines/dradis-api/spec/requests/dradis/ce/api/v3/notes_spec.rb`, `.../v3/evidence_spec.rb`).
- Full `engines/dradis-api` spec suite passes: 440 examples, 0 failures.

### Other Information

Found while acceptance-testing the Dradis Pro REST API against a live instance.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.