### PR TITLE
Update kit_import_job with better dir handling, parity, logging, and …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ v5.3.0 (August 2026)
       - Send only completed conversation turns to the AI provider, so a failed or in-progress reply can no longer break the next one
       - Show a generic message when a reply fails instead of surfacing the provider's raw error
       - Return a graceful error instead of a server error when a chat session is started with a blank prompt
+    - Kit import: correctly associate the imported project with its Word report template when multiple export integrations are enabled
   - REST/JSON API enhancements:
     - Return a 404 instead of a server error for project-scoped endpoints requested without a valid project
     - Set the author field to the authenticated user when creating notes and evidence

--- a/app/jobs/kit_import_job.rb
+++ b/app/jobs/kit_import_job.rb
@@ -9,8 +9,11 @@ class KitImportJob < ApplicationJob
   queue_as :dradis_upload
 
   rescue_from(StandardError) do |e|
-    logger.info "An error ocurred: #{e.message}"
+    logger.info "An error occurred: #{e.message}"
     logger.debug e.backtrace.join("\n")
+    # The import Log only streams to the in-browser console; also surface the
+    # failure on the Rails log (stdout / log files) so it's visible on the server.
+    Rails.logger.error("KitImportJob failed: #{e.full_message}")
   end
 
   def perform(file_or_folder, logger:, user_id: nil)
@@ -39,7 +42,7 @@ class KitImportJob < ApplicationJob
       import_rules
       import_mappings
 
-      assign_project_rtp
+      assign_project_rtp if @project
     end
 
   ensure
@@ -53,7 +56,15 @@ class KitImportJob < ApplicationJob
   def assign_project_rtp
     logger.info { 'Assigning RTP to project...' }
 
-    @project.update_attribute :report_template_properties_id, @word_rtp.id if @word_rtp
+    unless @word_rtp
+      logger.info { '  - No report template properties found; skipping.' }
+      Rails.logger.warn("KitImportJob: no word RTP found for project #{@project.id}; skipping RTP assignment")
+      return
+    end
+
+    # update! (not update_attribute) so a failed write raises and is logged by
+    # rescue_from rather than silently returning false.
+    @project.update!(report_template_properties_id: @word_rtp.id)
   end
 
   def copy_file(file, destination)
@@ -76,6 +87,15 @@ class KitImportJob < ApplicationJob
       # and not the container folder.
       folder = File.join(source, '.')
       FileUtils.cp_r folder, working_dir
+    end
+  end
+
+  def get_report_template_files(integration)
+    temp_integration_path = File.join(working_dir, 'kit', 'templates', 'reports', integration, '*')
+
+    # Only allow certain file extensions
+    Dir[temp_integration_path].select do |f|
+      f.end_with?(*REPORT_TEMPLATE_FILE_EXTENSIONS[integration])
     end
   end
 
@@ -144,12 +164,7 @@ class KitImportJob < ApplicationJob
       word
     }.each do |plugin|
       dest = "#{templates_dirs['reports']}/#{plugin}/"
-      temp_plugin_path = "#{working_dir}/kit/templates/reports/#{plugin}/*"
-
-      # Only allow certain file extensions
-      files = Dir[temp_plugin_path].select do |f|
-        f.end_with?(*REPORT_TEMPLATE_FILE_EXTENSIONS[plugin])
-      end
+      files = get_report_template_files(plugin)
 
       FileUtils.mkdir_p(dest)
       FileUtils.cp(files, dest)
@@ -160,25 +175,35 @@ class KitImportJob < ApplicationJob
     logger.info { 'Adding properties to report template files...' }
 
     Dradis::Plugins.with_feature(:rtp).each do |plugin|
-      Dir.glob(File.join(templates_dirs['reports'], plugin.plugin_name.to_s, '*')) do |template|
+      plugin_name = plugin.plugin_name.to_s
+
+      # Iterate the kit's own template files (not the whole instance reports
+      # directory) so we only attach properties to templates from this kit.
+      get_report_template_files(plugin_name).each do |template|
+        template_file = File.basename(template)
         basename = File.basename(template, '.*')
-        reports_dir = "#{working_dir}/kit/templates/reports"
-        default_properties = "#{reports_dir}/#{plugin.plugin_name}/#{basename}.rb"
+        default_properties = File.join(File.dirname(template), "#{basename}.rb")
 
-        if File.exist?(default_properties)
-          load default_properties
+        rtp =
+          if File.exist?(default_properties)
+            load default_properties
+            ReportTemplateProperties.find_by(
+              plugin_name: plugin_name,
+              template_file: template_file
+            )
+          else
+            ReportTemplateProperties.find_or_initialize_by(
+              template_file: template_file
+            ).tap { |report| report.update!(plugin_name: plugin_name) }
+          end
 
-          # Save this for later to assign to a project
-          @word_rtp = ReportTemplateProperties.where(
-            plugin_name: 'word',
-            template_file: File.basename(template)
-          ).first
-        else
-          ReportTemplateProperties.find_or_initialize_by(
-            template_file: File.basename(template)
-          ).update!(
-            plugin_name: plugin.plugin_name
-          )
+        # Save the word RTP so the imported project can be linked to it later,
+        # whether or not the template shipped a properties seed. Only the word
+        # plugin may set this, so excel/html_export templates can't clobber it.
+        @word_rtp = rtp if plugin_name == 'word' && rtp
+
+        if plugin_name == 'word' && rtp.nil?
+          Rails.logger.warn("KitImportJob: word template #{template_file} produced no RTP")
         end
       end
     end

--- a/app/jobs/kit_import_job.rb
+++ b/app/jobs/kit_import_job.rb
@@ -11,9 +11,6 @@ class KitImportJob < ApplicationJob
   rescue_from(StandardError) do |e|
     logger.info "An error occurred: #{e.message}"
     logger.debug e.backtrace.join("\n")
-    # The import Log only streams to the in-browser console; also surface the
-    # failure on the Rails log (stdout / log files) so it's visible on the server.
-    Rails.logger.error("KitImportJob failed: #{e.full_message}")
   end
 
   def perform(file_or_folder, logger:, user_id: nil, mapping_options: {})
@@ -59,7 +56,6 @@ class KitImportJob < ApplicationJob
 
     unless @word_rtp
       logger.info { '  - No report template properties found; skipping.' }
-      Rails.logger.warn("KitImportJob: no word RTP found for project #{@project.id}; skipping RTP assignment")
       return
     end
 
@@ -232,10 +228,6 @@ class KitImportJob < ApplicationJob
         # whether or not the template shipped a properties seed. Only the word
         # plugin may set this, so excel/html_export templates can't clobber it.
         @word_rtp = rtp if plugin_name == 'word' && rtp
-
-        if plugin_name == 'word' && rtp.nil?
-          Rails.logger.warn("KitImportJob: word template #{template_file} produced no RTP")
-        end
       end
     end
   end

--- a/app/jobs/kit_import_job.rb
+++ b/app/jobs/kit_import_job.rb
@@ -16,8 +16,9 @@ class KitImportJob < ApplicationJob
     Rails.logger.error("KitImportJob failed: #{e.full_message}")
   end
 
-  def perform(file_or_folder, logger:, user_id: nil)
+  def perform(file_or_folder, logger:, user_id: nil, mapping_options: {})
     @current_user = user_id ? User.find(user_id) : User.first
+    @mapping_options = mapping_options
     @logger = logger
     @project = nil
     @templates_dirs = TEMPLATE_TYPES.map do |template_type|
@@ -40,7 +41,7 @@ class KitImportJob < ApplicationJob
     if defined?(Dradis::Pro)
       import_report_template_properties
       import_rules
-      import_mappings
+      import_mappings_from_kit
 
       assign_project_rtp if @project
     end
@@ -51,7 +52,7 @@ class KitImportJob < ApplicationJob
   end
 
   private
-  attr_reader :current_user, :logger, :templates_dirs, :working_dir
+  attr_reader :current_user, :logger, :mapping_options, :templates_dirs, :working_dir
 
   def assign_project_rtp
     logger.info { 'Assigning RTP to project...' }
@@ -90,6 +91,28 @@ class KitImportJob < ApplicationJob
     end
   end
 
+  def copy_mappings
+    Dradis::Plugins.with_feature(:rtp).each do |integration|
+      integration_name = integration.plugin_name.to_s
+      old_rtp_id = mapping_options[integration_name]
+      next unless old_rtp_id
+
+      files = get_report_template_files(integration_name)
+
+      files.each do |template|
+        new_rtp = ReportTemplateProperties.find_by(
+          plugin_name: integration_name,
+          template_file: File.basename(template)
+        )
+
+        next unless new_rtp
+
+        # copy mappings from existing rtp to new rtp
+        new_rtp.copy_mappings_from!(old_rtp_id)
+      end
+    end
+  end
+
   def get_report_template_files(integration)
     temp_integration_path = File.join(working_dir, 'kit', 'templates', 'reports', integration, '*')
 
@@ -99,10 +122,18 @@ class KitImportJob < ApplicationJob
     end
   end
 
-  def import_mappings
+  def import_mappings_from_kit
+    action = mapping_options[:action]
+    return if action == :manual
+
     logger.info { 'Adding Mappings...' }
-    mappings_seed = "#{working_dir}/kit/mappings_seed.rb"
-    load mappings_seed if File.exist?(mappings_seed)
+
+    if action == :seed
+      mappings_seed = "#{working_dir}/kit/mappings_seed.rb"
+      load mappings_seed if File.exist?(mappings_seed)
+    elsif action == :copy
+      copy_mappings
+    end
   end
 
   def import_methodology_templates

--- a/app/jobs/kit_import_job.rb
+++ b/app/jobs/kit_import_job.rb
@@ -226,7 +226,7 @@ class KitImportJob < ApplicationJob
           else
             ReportTemplateProperties.find_or_initialize_by(
               template_file: template_file
-            ).tap { |report| report.update!(plugin_name: plugin_name) }
+            ).tap { |rtp| rtp.update!(plugin_name: plugin_name) }
           end
 
         # Save the word RTP so the imported project can be linked to it later,

--- a/app/jobs/kit_import_job.rb
+++ b/app/jobs/kit_import_job.rb
@@ -194,6 +194,11 @@ class KitImportJob < ApplicationJob
       files = get_report_template_files(plugin)
 
       FileUtils.mkdir_p(dest)
+      # Deliberately not using NamingService/copy_file here: report template
+      # files are copied under their own name (overwriting any existing file
+      # of the same name) so the filename stays a stable identity that
+      # import_report_template_properties can look up the RTP by. Renaming on
+      # collision would break that lookup.
       FileUtils.cp(files, dest)
     end
   end

--- a/spec/jobs/kit_import_job_spec.rb
+++ b/spec/jobs/kit_import_job_spec.rb
@@ -75,6 +75,20 @@ RSpec.describe KitImportJob do
       expect(Methodology.find('OWASPv4_Testing_Methodology_copy-01')).to_not be_nil
     end
 
+    it 'overwrites report template files in place if one with the same name already exists' do
+      word_dir = Rails.root.join('tmp', 'rspec', 'reports', 'word')
+      FileUtils.mkdir_p word_dir
+      FileUtils.touch word_dir.join('dradis_welcome_template.v0.5.docm')
+
+      described_class.new.perform(@tmp_file, logger: Log.new.write('Testing...'))
+
+      # Unlike project/note/methodology templates, report templates are not
+      # renamed on collision - the existing file is overwritten in place so
+      # its filename stays a stable identity for the associated RTP.
+      expect(File.exist?(word_dir.join('dradis_welcome_template.v0.5_copy-01.docm'))).to eq false
+      expect(File.exist?(word_dir.join('dradis_welcome_template.v0.5.docm'))).to eq true
+    end
+
     if defined?(Dradis::Pro)
       it 'imports Pro-only content too' do
         described_class.new.perform(@tmp_file, logger: Log.new.write('Testing...'))
@@ -114,6 +128,30 @@ RSpec.describe KitImportJob do
         described_class.new.perform(@tmp_file, logger: Log.new.write('Testing...'))
 
         expect(Project.last.name).to eq('dradis-export-welcome_copy-01')
+      end
+
+      it 'updates the existing report template properties in place on re-import' do
+        word_dir = Rails.root.join('tmp', 'rspec', 'reports', 'word')
+        FileUtils.mkdir_p word_dir
+        FileUtils.touch word_dir.join('dradis_welcome_template.v0.5.docm')
+
+        existing_rtp = create(
+          :report_template_properties,
+          plugin_name: 'word',
+          template_file: 'dradis_welcome_template.v0.5.docm',
+          title: 'Stale title',
+          content_blocks: {}
+        )
+
+        described_class.new.perform(@tmp_file, logger: Log.new.write('Testing...'))
+
+        # Re-importing a kit with a report template that already exists should
+        # update the matching RTP in place (same identity, by filename)
+        # rather than creating a duplicate record.
+        expect(ReportTemplateProperties.where(template_file: 'dradis_welcome_template.v0.5.docm').count).to eq(1)
+
+        existing_rtp.reload
+        expect(existing_rtp.content_blocks.keys).to match_array(['Conclusion', 'Scope'])
       end
     end
   end


### PR DESCRIPTION
This PR implements the following

- Only assign the `@word_rtp` if the `plugins == word`. Also assign for cases where .rb is missing
- Use `get_report_template_files` when iterating through the template files.
- CE/Pro parity
- Better logging


### Check List

- [ ] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
