### PR TITLE
bump `mail` Rails depenedency to 2.9.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
   - [entity]:
     - [future tense verb] [feature]
   - Upgraded gems:
-    - sqlite3
+    - mail, sqlite3
   - Bugs fixes:
     - [entity]:
       - [future tense verb] [bug fix]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.2.4)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap


### PR DESCRIPTION
### Summary

bundler-audit flagged [GHSA-mvxr-6m87-mv2q](https://github.com/mikel/mail/security/advisories/GHSA-mvxr-6m87-mv2q) (email address spoofing via malformed RFC 2047 encoded-words) against mail 2.9.0. There's no direct Gemfile entry for mail (it's a transitive dependency of Rails components, constrained >= 2.8.0), so only Gemfile.lock needed refreshing via bundle update mail.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
