### PR TITLE
Ticketing: use both `:ticketing` and `:issue_sync` in send_to menu to account for renaming ticketing integrations `provides`

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -19,8 +19,8 @@ class IssuesController < AuthenticatedController
   before_action :set_auto_save_key, only: [:new, :create, :edit, :update]
   before_action :set_affected_nodes, only: [:show]
   before_action :set_form_cancel_path, only: [:new, :edit]
-  before_action :set_tags, except: [:destroy]
   before_action :set_send_to_integrations, only: [:new, :edit, :show]
+  before_action :set_tags, except: [:destroy]
 
   def index
   end
@@ -190,12 +190,6 @@ class IssuesController < AuthenticatedController
     @issuelib = current_project.issue_library
   end
 
-  def set_send_to_integrations
-    ticketing_integrations = Dradis::Plugins::with_feature(:ticketing)
-    sync_integrations = Dradis::Plugins::with_feature(:issue_sync)
-    @send_to_integrations = sync_integrations + ticketing_integrations
-  end
-
   # Once a valid @issuelib is set by the previous filter we look for the Issue we
   # are going to be working with based on the :id passed by the user.
   def set_or_initialize_issue
@@ -208,6 +202,12 @@ class IssuesController < AuthenticatedController
     else
       @issue = Issue.new(node: @issuelib)
     end
+  end
+
+  def set_send_to_integrations
+    ticketing_integrations = Dradis::Plugins::with_feature(:ticketing)
+    sync_integrations = Dradis::Plugins::with_feature(:issue_sync)
+    @send_to_integrations = sync_integrations + ticketing_integrations
   end
 
   def set_tags

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -20,6 +20,7 @@ class IssuesController < AuthenticatedController
   before_action :set_affected_nodes, only: [:show]
   before_action :set_form_cancel_path, only: [:new, :edit]
   before_action :set_tags, except: [:destroy]
+  before_action :set_send_to_integrations, only: [:new, :edit, :show]
 
   def index
   end
@@ -31,8 +32,8 @@ class IssuesController < AuthenticatedController
                         .group('nodes.id')
                         .sort_by { |node, _| node.label }
 
-    @first_node      = @affected_nodes.first
-    @first_evidence  = Evidence.where(node: @first_node, issue: @issue)
+    @first_node = @affected_nodes.first
+    @first_evidence = Evidence.where(node: @first_node, issue: @issue)
 
     load_conflicting_revisions(@issue)
   end
@@ -187,6 +188,12 @@ class IssuesController < AuthenticatedController
 
   def set_issuelib
     @issuelib = current_project.issue_library
+  end
+
+  def set_send_to_integrations
+    ticketing_integrations = Dradis::Plugins::with_feature(:ticketing)
+    sync_integrations = Dradis::Plugins::with_feature(:issue_sync)
+    @send_to_integrations = sync_integrations + ticketing_integrations
   end
 
   # Once a valid @issuelib is set by the previous filter we look for the Issue we

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -207,7 +207,7 @@ class IssuesController < AuthenticatedController
   def set_send_to_integrations
     ticketing_integrations = Dradis::Plugins::with_feature(:ticketing)
     sync_integrations = Dradis::Plugins::with_feature(:issue_sync)
-    @send_to_integrations = sync_integrations + ticketing_integrations
+    @send_to_integrations = sync_integrations | ticketing_integrations
   end
 
   def set_tags

--- a/app/views/issues/_send_to_menu.html.erb
+++ b/app/views/issues/_send_to_menu.html.erb
@@ -1,5 +1,5 @@
 <span class="dropdown-item dots-dropdown-header" tabindex="-1">Send to...</span>
-<% sync_plugins = Dradis::Plugins::with_feature(:issue_sync) %>
+<% sync_plugins = Dradis::Plugins::with_feature(:ticketing) %>
 
 <% if sync_plugins.any? %>
   <% sync_plugins.each do |plugin| %>

--- a/app/views/issues/_send_to_menu.html.erb
+++ b/app/views/issues/_send_to_menu.html.erb
@@ -1,17 +1,16 @@
 <span class="dropdown-item dots-dropdown-header" tabindex="-1">Send to...</span>
-<% sync_plugins = Dradis::Plugins::with_feature(:ticketing) %>
 
-<% if sync_plugins.any? %>
-  <% sync_plugins.each do |plugin| %>
+<% if @send_to_integrations.any? %>
+  <% @send_to_integrations.each do |integration| %>
     <%=
-      plugin_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(plugin.name))
-      render partial: "#{plugin_path}/issues/send_to_menu"
+      integration_path = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.deconstantize(integration.name))
+      render partial: "#{integration_path}/issues/send_to_menu"
     %>
   <% end %>
 <% end %>
 
 <% unless defined?(Dradis::Pro) %>
-  <% if sync_plugins.any? %>
+  <% if @send_to_integrations.any? %>
     <div class="divider"></div>
   <% end %>
 


### PR DESCRIPTION
### Summary

Integrations that can send/sync an issue to a ticketing system currently declare this capability under two different, inconsistent names (`:issue_sync` and a deprecated `:sync`). Standardizing on `:ticketing` matches the `Dradis::Plugins::Mappings::Ticketing` namespace already used for related mapping code.

### Solution

- In ticketing integrations, rename the `:issue_sync` feature flag to `:ticketing`. 
- Update main app `_send_to_menu.html.erb` to reference `ticketing` instead of `issue_sync`


Companion changes in the Jira, ServiceNow, RT, and Azure DevOps integrations update their `provides :addon, ...` declarations to match. 

Note: This is a breaking change for any third-party ticketing addon still declaring `:issue_sync` — it will silently drop out of the Send To menu until updated to declare `:ticketing` instead. Accepted risk.

### Testing steps

Confirm an addon that provides ticketing (e.g. Jira) still appears in the issue's "Send to..." dropdown menu after its companion PR updating `provides :addon, :ticketing` is applied locally.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] No CHANGELOG entry needed (internal refactor, no user-facing change)
- [x] Commit message has a detailed description of what changed and why.