### PR TITLE
fix combobox stale label when option value contains a double quote

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   - Upgraded gems:
     - mail, sqlite3
   - Bugs fixes:
+    - Combobox: show the correct selected option when its value contains a double quote
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/app/assets/javascripts/hera/modules/combobox.js
+++ b/app/assets/javascripts/hera/modules/combobox.js
@@ -463,9 +463,7 @@ class ComboBox {
   // ==========================================================================
 
   setInitialSelection() {
-    let $initialOption = this.$comboboxOptions.filter(
-      `[data-value="${this.$target.val()}"]`,
-    );
+    let $initialOption = this.filterByDataValue(this.$comboboxOptions, 'value', this.$target.val());
 
     if (!$initialOption.length) {
       if (this.isMultiSelect) {
@@ -506,10 +504,8 @@ class ComboBox {
 
   updateMultiSelectUI($options) {
     $options.forEach(($option) => {
-      if (
-        this.$combobox.find(`[data-option-value="${$option.data('value')}"]`)
-          .length
-      ) {
+      const $existingTags = this.$combobox.find('[data-behavior~=combobox-multi-option]');
+      if (this.filterByDataValue($existingTags, 'option-value', $option.data('value')).length) {
         return;
       }
 
@@ -543,7 +539,7 @@ class ComboBox {
     if (this.isMultiSelect) {
       const currentValues = this.$target.val() || [];
       currentValues.forEach((value) => {
-        const $option = this.$comboboxOptions.filter(`[data-value="${value}"]`);
+        const $option = this.filterByDataValue(this.$comboboxOptions, 'value', value);
         if ($option.length) {
           $options.push($option);
         }
@@ -551,9 +547,7 @@ class ComboBox {
       this.$comboboxOptions.removeClass('selected');
       this.$combobox.find('[data-behavior~=combobox-multi-option]').remove();
     } else {
-      $options = this.$comboboxOptions.filter(
-        `[data-value="${this.$target.val()}"]`,
-      );
+      $options = this.filterByDataValue(this.$comboboxOptions, 'value', this.$target.val());
     }
 
     this.updateComboboxUI($options);
@@ -562,6 +556,12 @@ class ComboBox {
   // ==========================================================================
   // Utilities
   // ==========================================================================
+
+  // Matches by exact attribute value, so quotes in the value can't break a selector.
+  filterByDataValue($elements, dataKey, value) {
+    const attr = `data-${dataKey}`;
+    return $elements.filter((_, el) => el.getAttribute(attr) === String(value));
+  }
 
   showMenu() {
     this.$comboboxMenu.css('display', 'block');


### PR DESCRIPTION
### Summary

`filter()` and `find()` in the shared `ComboBox` module built CSS attribute selectors by interpolating option values directly into a template string. A value containing a double quote breaks the selector with a Sizzle syntax error, leaving the combobox showing a stale label even though the underlying select's value updated correctly. Matches by exact attribute value instead, which can't be broken by selector metacharacters.

Split out of https://github.com/dradis/dradis-ce/pull/1638 so it can be reviewed and merged on its own.

### Testing steps

1. Visit `/styles`, open the "Multi-select & User-defined Option Example" combobox.
2. Type a value containing a double quote (e.g. `Weird"Value`) and add it as a custom option.
3. Select it and confirm no console error, and the combobox label and selected tag both display correctly.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
