### PR TITLE
Scope Issue#evidence_by_node by Evidence review state

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -117,8 +117,7 @@ class Issue < Note
   # This is useful in a number of views to present or hide information about
   # all the instances for a given issue and node/host.
   def evidence_by_node(scope = :all)
-    evidence_collection = scope.to_sym == :published ? evidence.published : evidence
-    evidence_collection = evidence_collection.includes(:node)
+    evidence_collection = evidence.send(scope).includes(:node)
 
     results = Hash.new { |h, k| h[k] = [] }
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -107,8 +107,9 @@ class Issue < Note
     self.title <=> other.title
   end
 
-  # This method groups all the available evidence associated with this Issue
-  # into a Hash where the keys are the nodes. E.g.:
+  # This method groups the evidence associated with this Issue (optionally scoped by state)
+  # into a Hash where the keys are
+  # the nodes. E.g.:
   # {
   #   <node 1> => [<evidence 1.1>, <evidence 1.2>],
   #   <node 2> => [<evidence 2.1>]
@@ -116,10 +117,13 @@ class Issue < Note
   #
   # This is useful in a number of views to present or hide information about
   # all the instances for a given issue and node/host.
-  def evidence_by_node()
+  def evidence_by_node(scope = :all)
+    evidence_collection = scope.to_sym == :published ? evidence.published : evidence
+    evidence_collection = evidence_collection.includes(:node)
+
     results = Hash.new { |h, k| h[k] = [] }
 
-    self.evidence.includes(:node).each do |evidence|
+    evidence_collection.each do |evidence|
       results[evidence.node] << evidence
     end
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -126,6 +126,23 @@ describe Issue do
     end
   end
 
+  describe '#evidence_by_node' do
+    let(:issue) { create(:issue, node: project.issue_library) }
+    let(:node_a) { create(:node, label: '10.0.0.1') }
+    let(:node_b) { create(:node, label: '10.0.0.2') }
+
+    let!(:evidence_a) { create(:evidence, issue: issue, node: node_a, state: :published) }
+    let!(:evidence_b) { create(:evidence, issue: issue, node: node_b, state: :draft) }
+
+    it 'defaults to grouping all of the issue\'s evidence by node, regardless of state' do
+      expect(issue.evidence_by_node).to eq([[node_a, [evidence_a]], [node_b, [evidence_b]]])
+    end
+
+    it 'groups only published evidence by node when scope is :published' do
+      expect(issue.evidence_by_node(:published)).to eq([[node_a, [evidence_a]]])
+    end
+  end
+
   describe '#activities' do
     it "returns the issue's activities" do
       # this requires some hackery, because by default it won't work because

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -128,8 +128,8 @@ describe Issue do
 
   describe '#evidence_by_node' do
     let(:issue) { create(:issue, node: project.issue_library) }
-    let(:node_a) { create(:node, label: '10.0.0.1') }
-    let(:node_b) { create(:node, label: '10.0.0.2') }
+    let(:node_a) { create(:node, label: '10.0.0.1', project: project) }
+    let(:node_b) { create(:node, label: '10.0.0.2', project: project) }
 
     let!(:evidence_a) { create(:evidence, issue: issue, node: node_a, state: :published) }
     let!(:evidence_b) { create(:evidence, issue: issue, node: node_b, state: :draft) }


### PR DESCRIPTION
### Summary

Split out of #1677 (the base branch): `Issue#evidence_by_node` now accepts an optional `scope` symbol (`:all`, the default, or `:published`) instead of always returning every piece of Evidence regardless of state.

This exists to support `dradis-html_export`'s Evidence review-state scoping (see its companion PRs, based on this branch): the default HTML export template groups an Issue's Evidence by node, and needs to respect the export's Published/All scope the same way every other exporter now does. Rather than have each caller build and pass in a pre-scoped Evidence collection, the scoping logic lives in the one place that already owns evidence grouping.

- `evidence_by_node` defaults to `:all` (today's unscoped behavior), so no existing caller changes behavior.
- `evidence_by_node(:published)` returns only Published Evidence, grouped by node.

### Testing steps

1. In a Rails console (or a spec), create an Issue with two Evidence records at different Nodes: one Published, one Draft.
2. Call `issue.evidence_by_node` with no arguments.
3. Assert both Nodes appear in the result, each with their Evidence.
4. Call `issue.evidence_by_node(:published)`.
5. Assert only the Node with the Published Evidence appears in the result.

### Check List

- [ ] Added a CHANGELOG entry (not needed — internal API change with no user-visible behavior on its own; the default `:all` scope is unchanged)
- [x] Commit message has a detailed description of what changed and why.
