### PR TITLE
Unscope base NodeDrop#evidence and expose state in IssueDrop and EvidenceDrop

### DIFF
--- a/app/drops/evidence_drop.rb
+++ b/app/drops/evidence_drop.rb
@@ -1,7 +1,7 @@
 class EvidenceDrop < BaseDrop
   include EscapedFields
 
-  delegate :content, :title, to: :@record
+  delegate :content, :state, :title, to: :@record
 
   def issue
     IssueDrop.new(@record.issue)

--- a/app/drops/issue_drop.rb
+++ b/app/drops/issue_drop.rb
@@ -3,17 +3,30 @@ class IssueDrop < BaseDrop
 
   delegate :author, :state, :text, :title, to: :@record
 
+  def initialize(record, scope = :all)
+    super(record)
+    @scope = scope
+  end
+
   def affected
-    @affected ||= @record.affected.map { |node| NodeDrop.new(node) }
+    @affected ||= scoped_evidence.includes(:node).map { |evidence| NodeDrop.new(evidence.node, @scope) }
   end
 
   def evidence
-    @record.evidence.map { |evidence| EvidenceDrop.new(evidence) }
+    scoped_evidence.map { |evidence| EvidenceDrop.new(evidence) }
   end
 
   def tags
-    @tags ||= @record.tags.map { |tag| TagDrop.new(tag) }
+    @tags ||= @record.tags.map { |tag| TagDrop.new(tag, @scope) }
   end
 
   ActiveSupport.run_load_hooks(:issue_drop, self)
+
+  private
+
+  # The Issue itself is expected to already match :scope (the caller is
+  # responsible for that), so only its Evidence needs to be checked here.
+  def scoped_evidence
+    @record.evidence.public_send(@scope)
+  end
 end

--- a/app/drops/issue_drop.rb
+++ b/app/drops/issue_drop.rb
@@ -1,7 +1,7 @@
 class IssueDrop < BaseDrop
   include EscapedFields
 
-  delegate :author, :text, :title, to: :@record
+  delegate :author, :state, :text, :title, to: :@record
 
   def affected
     @affected ||= @record.affected.map { |node| NodeDrop.new(node) }

--- a/app/drops/node_drop.rb
+++ b/app/drops/node_drop.rb
@@ -1,11 +1,24 @@
 class NodeDrop < BaseDrop
   delegate :label, to: :@record
 
+  def initialize(record, scope = :all)
+    super(record)
+    @scope = scope
+  end
+
   def evidence
-    @evidence ||= @record.evidence.map { |evidence| EvidenceDrop.new(evidence) }
+    @evidence ||= scoped_evidence.map { |evidence| EvidenceDrop.new(evidence) }
   end
 
   def notes
     @notes ||= @record.notes.map { |note| NoteDrop.new(note) }
+  end
+
+  private
+
+  # A Node doesn't know whether the Issue its Evidence belongs to matches
+  # :scope, so both the Evidence and its Issue need to be checked.
+  def scoped_evidence
+    @record.evidence.public_send(@scope).joins(:issue).merge(Issue.public_send(@scope))
   end
 end

--- a/app/drops/node_drop.rb
+++ b/app/drops/node_drop.rb
@@ -2,9 +2,7 @@ class NodeDrop < BaseDrop
   delegate :label, to: :@record
 
   def evidence
-    @evidence ||= @record.evidence.filter_map do |evidence|
-      EvidenceDrop.new(evidence) if evidence.issue.published?
-    end
+    @evidence ||= @record.evidence.map { |evidence| EvidenceDrop.new(evidence) }
   end
 
   def notes

--- a/app/drops/tag_drop.rb
+++ b/app/drops/tag_drop.rb
@@ -1,9 +1,20 @@
 class TagDrop < BaseDrop
   delegate :color, :display_name, :name, to: :@record
 
+  def initialize(record, scope = :all)
+    super(record)
+    @scope = scope
+  end
+
   def tag_issues
-    Issue.published.includes(:taggings).where(taggings: { tag: @record }).map do |issue|
-      IssueDrop.new(issue)
+    scoped_issues.includes(:taggings).where(taggings: { tag: @record }).map do |issue|
+      IssueDrop.new(issue, @scope)
     end
+  end
+
+  private
+
+  def scoped_issues
+    Issue.public_send(@scope)
   end
 end


### PR DESCRIPTION
### Summary

Split out of #1677 (the base branch). Two related changes to the Liquid drops that Gateway (Pro's client-facing portal) and other Liquid consumers build from:

1. **Un-scope base `NodeDrop#evidence`** — removes the `evidence.issue.published?` filter that had been added there as an early stopgap to close a Gateway-only scope leak. That filter incorrectly applied to every consumer of `NodeDrop` (including internal ones — Echo, in-app Issue preview, `html_export` custom Liquid templates), not just Gateway. `NodeDrop#evidence` now returns every piece of Evidence for a Node, matching `IssueDrop#evidence`/`TagDrop#tag_issues`, which were never scoped at this level either.
2. **Add an optional `scope` param to `IssueDrop`/`NodeDrop`/`TagDrop`** — `IssueDrop.new(record, scope)`, `NodeDrop.new(record, scope)`, and `TagDrop.new(record, scope)` now accept an optional positional `scope` (default `:all`), an AR scope name (e.g. `:published`) applied to the record's Evidence/Issues before wrapping them in nested drops. This lets a caller like Gateway filter what's nested under an issue/node/tag (`#evidence`, `#affected`, `#tag_issues`) without subclassing these drops — see [dradispro-gateway#217](https://github.com/secroots/dradispro-gateway/pull/217), which deletes its `Gateway::IssueDrop`/`NodeDrop`/`TagDrop` subclasses entirely in favor of this.

**Behavior note:** `TagDrop#tag_issues` previously hardcoded `Issue.published` unconditionally (pre-dating this branch). With the new default `scope = :all`, any existing unscoped caller (main app UI, `html_export`) will now see draft issues' tags where it previously wouldn't have — `TagDrop` is only ever built via `IssueDrop#tags` in this codebase, so the blast radius is narrow, but it's worth a second look before merging since nothing currently passes `scope: :published` outside the Gateway controller.

### Testing steps

1. In a Rails console (or a spec), create a Node with an Issue in Draft state and Evidence attached to that Node.
2. Build a NodeDrop for the Node and call .evidence.
3. Assert the Evidence is present in the result (previously it would have been filtered out because the parent Issue wasn't Published).
4. Build a NodeDrop/IssueDrop/TagDrop with an explicit scope (e.g. NodeDrop.new(node, :published)) and confirm .evidence/.affected/.tag_issues only return Published records.
5. Build the same drops with no scope argument and confirm they return everything, unfiltered.

### Check List

- [ ] Added a CHANGELOG entry (not needed — internal Liquid-drop refactor with no independently released, user-facing behavior; consumed entirely by the still-unmerged Gateway change)
- [x] Commit message has a detailed description of what changed and why.
