### PR TITLE
Move `Node` and `Evidence` event tracking from `ActivityTracking` to `EventPublisher`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 [v#.#.#] ([month] [YYYY])
-  - Activities: Remove ActivityTracking for Evidence, Nodes and Notes and use EventPublisher
+  - Webhooks: Add Evidence, Node and Note CRUD webhook events
   - Upgraded gems:
     - mail, sqlite3
   - Bugs fixes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,5 @@
 [v#.#.#] ([month] [YYYY])
-  - [entity]:
-    - [future tense verb] [feature]
+  - Activities: Remove ActivityTracking for Evidence, Nodes and Notes and use EventPublisher
   - Upgraded gems:
     - mail, sqlite3
   - Bugs fixes:

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -29,7 +29,7 @@ class EvidenceController < NestedNodeResourceController
 
     respond_to do |format|
       if @evidence.save
-        track_created(@evidence)
+        publish_event('evidence.created', @evidence.to_event_payload)
         format.html do
           redirect_to [current_project, @evidence.node, @evidence],
             notice: "Evidence added for node #{@evidence.node.label}."
@@ -58,7 +58,7 @@ class EvidenceController < NestedNodeResourceController
       copy_attachments(@evidence) if @evidence.node_changed?
 
       if @evidence.save
-        track_updated(@evidence)
+        publish_event('evidence.updated', @evidence.to_event_payload)
         check_for_edit_conflicts(@evidence, updated_at_before_save)
         format.html do
           redirect_to evidence_redirect_path(params[:return_to]), notice: 'Evidence updated.'
@@ -77,7 +77,7 @@ class EvidenceController < NestedNodeResourceController
   def destroy
     respond_to do |format|
       if @evidence.destroy
-        track_destroyed(@evidence)
+        publish_event('evidence.destroyed', @evidence.to_event_payload)
         format.html do
           notice = "Successfully deleted evidence for '#{@evidence.issue.title}.'"
           # Evidence can be deleted from 3 places:
@@ -106,8 +106,9 @@ class EvidenceController < NestedNodeResourceController
   private
 
   def autogenerate_issue
+    byebug
     @evidence.issue = Issue.autogenerate_from(@evidence)
-    track_created(@evidence.issue)
+    publish_event('issue.created', @evidence.issue.to_event_payload)
   end
 
   def liquid_resource_assigns

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -106,7 +106,6 @@ class EvidenceController < NestedNodeResourceController
   private
 
   def autogenerate_issue
-    byebug
     @evidence.issue = Issue.autogenerate_from(@evidence)
     publish_event('issue.created', @evidence.issue.to_event_payload)
   end

--- a/app/controllers/issues/evidence_controller.rb
+++ b/app/controllers/issues/evidence_controller.rb
@@ -74,6 +74,10 @@ class Issues::EvidenceController < AuthenticatedController
 
   private
 
+  def event_action_payload
+    super.merge(action: 'create')
+  end
+
   def evidence_params
     params.require(:evidence).permit(:author, :content, :issue_id, :node_id)
   end

--- a/app/controllers/issues/evidence_controller.rb
+++ b/app/controllers/issues/evidence_controller.rb
@@ -74,6 +74,9 @@ class Issues::EvidenceController < AuthenticatedController
 
   private
 
+  # Override EventPublisher#event_action_payload to use the correct action
+  # name instead of the RESTful controller action ('create_multiple') so the
+  # activity feed shows the correct verb.
   def event_action_payload
     super.merge(action: 'create')
   end

--- a/app/controllers/issues/evidence_controller.rb
+++ b/app/controllers/issues/evidence_controller.rb
@@ -1,7 +1,7 @@
 class Issues::EvidenceController < AuthenticatedController
-  include ActivityTracking
   include ContentFromTemplate
   include DynamicFieldNamesCacher
+  include EventPublisher
   include MultipleDestroy
   include ProjectScoped
 
@@ -41,7 +41,7 @@ class Issues::EvidenceController < AuthenticatedController
           issue_id: @issue.id,
           node_id: node.id
         )
-        track_created(evidence)
+        publish_event('evidence.created', evidence.to_event_payload)
       end
     end
 
@@ -56,7 +56,7 @@ class Issues::EvidenceController < AuthenticatedController
             label: label,
             parent: parent,
           )
-          track_created(node)
+          publish_event('node.created', node.to_event_payload)
         end
 
         evidence = Evidence.create!(
@@ -65,7 +65,7 @@ class Issues::EvidenceController < AuthenticatedController
           issue_id: @issue.id,
           node_id: node.id
         )
-        track_created(evidence)
+        publish_event('evidence.created', evidence.to_event_payload)
       end
     end
 
@@ -105,7 +105,7 @@ class Issues::EvidenceController < AuthenticatedController
   end
 
   def set_auto_save_key
-    @auto_save_key =  if params[:template]
+    @auto_save_key = if params[:template]
       "issue-#{params[:issue_id]}-evidence-#{params[:template]}"
     elsif params[:from_rtp]
       "issue-#{params[:issue_id]}-rtp-evidence"

--- a/app/controllers/nested_node_resource_controller.rb
+++ b/app/controllers/nested_node_resource_controller.rb
@@ -27,4 +27,14 @@ class NestedNodeResourceController < AuthenticatedController
       ).find(params[:node_id])
     end
   end
+
+  private
+
+  # Override EventPublisher#event_action_payload to use the semantic action
+  # name ('create') instead of the RESTful controller action
+  # ('create_multiple') so the activity feed shows the correct verb.
+  def event_action_payload
+    action_map = { 'create_multiple' => 'create' }
+    super.merge(action: action_map.fetch(action_name, action_name))
+  end
 end

--- a/app/controllers/nested_node_resource_controller.rb
+++ b/app/controllers/nested_node_resource_controller.rb
@@ -1,7 +1,7 @@
 # A controller for pages related to a Node and its notes and evidence.
 class NestedNodeResourceController < AuthenticatedController
-  include ActivityTracking
   include ContentFromTemplate
+  include EventPublisher
   include ProjectScoped
 
   before_action :find_or_initialize_node

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -10,7 +10,7 @@ class NodesController < NestedNodeResourceController
 
   # GET /nodes/<id>
   def show
-    @activities       = @node.nested_activities.latest
+    @activities = @node.nested_activities.latest
   end
 
   # GET /nodes/<id>/edit
@@ -21,7 +21,7 @@ class NodesController < NestedNodeResourceController
   def create
     @node.label = 'unnamed' unless @node.label.present?
     if @node.save
-      track_created(@node)
+      publish_event('node.created', @node.to_event_payload)
       flash[:notice] = 'Successfully created node.'
       redirect_to [current_project, @node]
     else
@@ -49,7 +49,7 @@ class NodesController < NestedNodeResourceController
             parent: @parent,
             type_id: params[:nodes][:type_id]
           )
-          track_created(node)
+          publish_event('node.created', node.to_event_payload)
         end
       end
     end
@@ -65,7 +65,7 @@ class NodesController < NestedNodeResourceController
   # POST /nodes/sort
   def sort
     params[:nodes].each_with_index do |id, index|
-      current_project.nodes.update_all({position: index+1}, {id: id})
+      current_project.nodes.update_all({ position: index + 1 }, { id: id })
     end
     head :ok
   end
@@ -74,7 +74,7 @@ class NodesController < NestedNodeResourceController
   def update
     respond_to do |format|
       if @node.update(node_params)
-        track_updated(@node)
+        publish_event('node.updated', @node.to_event_payload)
         format.html { redirect_to project_node_path(current_project, @node), notice: 'Node updated.' }
         format.json { render json: { success: true }.to_json }
         format.js
@@ -92,7 +92,7 @@ class NodesController < NestedNodeResourceController
   # DELETE /nodes/<id>
   def destroy
     @node.destroy
-    track_destroyed(@node)
+    publish_event('node.destroyed', @node.to_event_payload)
 
     parent = @node.parent
     if parent
@@ -123,7 +123,7 @@ class NodesController < NestedNodeResourceController
     rtp = current_project.report_template_properties
     rtp_default_evidence_fields = rtp ? rtp.evidence_fields.default.field_names : []
 
-    @note_columns     = note_dynamic_fields | extra_field_names
+    @note_columns = note_dynamic_fields | extra_field_names
     @evidence_columns = rtp_default_evidence_fields | evidence_dynamic_fields | extra_field_names
 
     @default_note_columns = default_field_names

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -24,7 +24,7 @@ class NotesController < NestedNodeResourceController
     @note.category ||= Category.default
 
     if @note.save
-      track_created(@note)
+      publish_event('note.created', @note.to_event_payload)
       redirect_to project_node_note_path(current_project, @node, @note), notice: 'Note created'
     else
       initialize_nodes_sidebar
@@ -50,7 +50,7 @@ class NotesController < NestedNodeResourceController
     copy_attachments(@note) if @note.node_changed?
 
     if @note.save
-      track_updated(@note)
+      publish_event('note.updated', @note.to_event_payload)
       check_for_edit_conflicts(@note, updated_at_before_save)
       # if the note has just been moved to another node, we must reload
       # here so that @note.node is correct and we redirect to the right URL
@@ -65,7 +65,7 @@ class NotesController < NestedNodeResourceController
   # Remove a Note from the back-end database.
   def destroy
     if @note.destroy
-      track_destroyed(@note)
+      publish_event('note.destroyed', @note.to_event_payload)
       redirect_to project_node_path(current_project, @node), notice: 'Note deleted'
     else
       redirect_to project_node_note_path(current_project, @node, @note), alert: 'Could not delete note'

--- a/app/controllers/qa/issues_controller.rb
+++ b/app/controllers/qa/issues_controller.rb
@@ -1,5 +1,5 @@
 class QA::IssuesController < AuthenticatedController
-  include ActivityTracking
+  include EventPublisher
   include LiquidEnabledResource
   include Mentioned
   include ProjectScoped
@@ -23,7 +23,7 @@ class QA::IssuesController < AuthenticatedController
 
   def update
     if @issue.update(state: @state, updated_at: Time.now)
-      track_state_change(@issue)
+      publish_event('issue.state_change', @issue.to_event_payload)
 
       redirect_to *next_issue_or_index_path
     else
@@ -38,7 +38,7 @@ class QA::IssuesController < AuthenticatedController
       if @issues.update(state: @state)
 
         @issues.each do |issue|
-          track_state_change(issue)
+          publish_event('issue.state_change', issue.to_event_payload)
         end
 
         format.html do
@@ -55,6 +55,14 @@ class QA::IssuesController < AuthenticatedController
   end
 
   private
+
+  # Override EventPublisher#event_action_payload to use the semantic action
+  # name ('state_change') instead of the RESTful controller actions
+  # ('update'/'multiple_update') so the activity feed shows the correct verb.
+  def event_action_payload
+    action_map = { 'multiple_update' => 'state_change', 'update' => 'state_change' }
+    super.merge(action: action_map.fetch(action_name, action_name))
+  end
 
   def issue_params
     params.permit(:state)

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -36,7 +36,6 @@ class Evidence < ApplicationRecord
         id: project.id,
         name: project.name
       },
-      state: state,
       issue: {
         id: issue.id,
         title: issue.title

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,5 +1,6 @@
 class Evidence < ApplicationRecord
   include Commentable
+  include Eventable
   include HasFields
   include RevisionTracking
   include Subscribable
@@ -24,11 +25,29 @@ class Evidence < ApplicationRecord
 
   # -- Scopes ---------------------------------------------------------------
 
-
   # -- Class Methods --------------------------------------------------------
 
-
   # -- Instance Methods -----------------------------------------------------
+
+  def local_event_payload
+    {
+      author: author,
+      project: {
+        id: project.id,
+        name: project.name
+      },
+      state: state,
+      issue: {
+        id: issue.id,
+        title: issue.title
+      },
+      node: {
+        id: node.id,
+        label: node.label
+      },
+      fields: fields
+    }
+  end
 
   def local_fields
     {

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,6 +1,5 @@
 class Issue < Note
   include Commentable
-  include Eventable
   include InlineCommentable
   # FIXME - ISSUE/NOTE INHERITANCE
   # Commentable.allowed_types << base.name doesn't work for Issue because it's

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -5,6 +5,7 @@
 # Each Node has a :parent node and a :label. Nodes can also have many
 # Attachment objects associated with them.
 class Node < ApplicationRecord
+  include Eventable
   include Properties
   include Types
 
@@ -73,6 +74,18 @@ class Node < ApplicationRecord
   # Return all the Attachment objects associated with this Node.
   def attachments
     Attachment.find(:all, conditions: { node_id: self.id })
+  end
+
+  def local_event_payload
+    {
+      author: author,
+      project: {
+        id: project.id,
+        name: project.name
+      },
+      label: label,
+      properties: properties
+    }
   end
 
   # SEE: https://github.com/amerine/acts_as_tree/issues/63

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -78,7 +78,6 @@ class Node < ApplicationRecord
 
   def local_event_payload
     {
-      author: author,
       project: {
         id: project.id,
         name: project.name

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -26,6 +26,7 @@
 # This behaviour is extensively used by import/export plugins such as WordExport.
 class Note < ApplicationRecord
   include Commentable
+  include Eventable
   include HasFields
   include RevisionTracking
   include Subscribable
@@ -80,6 +81,22 @@ class Note < ApplicationRecord
 
   def field_or_text(field_name)
     fields.fetch(field_name, text.truncate(20))
+  end
+
+  def local_event_payload
+    {
+      author: author,
+      project: {
+        id: project.id,
+        name: project.name
+      },
+      node: {
+        id: node.id,
+        label: node.label
+      },
+      fields: fields,
+      title: title
+    }
   end
 
   ActiveSupport.run_load_hooks(:note_model, self)

--- a/config/initializers/activity_service.rb
+++ b/config/initializers/activity_service.rb
@@ -1,7 +1,9 @@
 Rails.application.reloader.to_prepare do
   ActivityService.configure do |activity_service|
     activity_service.subscribe_namespace 'card'
+    activity_service.subscribe_namespace 'evidence'
     activity_service.subscribe_namespace 'inline_thread'
     activity_service.subscribe_namespace 'issue'
+    activity_service.subscribe_namespace 'node'
   end
 end

--- a/config/initializers/activity_service.rb
+++ b/config/initializers/activity_service.rb
@@ -5,5 +5,6 @@ Rails.application.reloader.to_prepare do
     activity_service.subscribe_namespace 'inline_thread'
     activity_service.subscribe_namespace 'issue'
     activity_service.subscribe_namespace 'node'
+    activity_service.subscribe_namespace 'note'
   end
 end

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v3/evidence_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v3/evidence_controller.rb
@@ -1,7 +1,7 @@
 module Dradis::CE::API
   module V3
     class EvidenceController < Dradis::CE::API::APIController
-      include ActivityTracking
+      include EventPublisher
       include Dradis::CE::API::ProjectScoped
 
       before_action :set_node
@@ -19,7 +19,7 @@ module Dradis::CE::API
         @evidence = @node.evidence.build(evidence_params)
         @evidence.author = current_user.email
         if @evidence.save
-          track_created(@evidence)
+          publish_event('evidence.created', @evidence.to_event_payload)
           render status: 201, location: node_evidence_path(@node, @evidence)
         else
           render_validation_errors(@evidence)
@@ -29,7 +29,7 @@ module Dradis::CE::API
       def update
         @evidence = @node.evidence.find(params[:id])
         if @evidence.update(evidence_params)
-          track_updated(@evidence)
+          publish_event('evidence.updated', @evidence.to_event_payload)
           render evidence: @evidence
         else
           render_validation_errors(@evidence)
@@ -39,7 +39,7 @@ module Dradis::CE::API
       def destroy
         @evidence = @node.evidence.find(params[:id])
         @evidence.destroy
-        track_destroyed(@evidence)
+        publish_event('evidence.destroyed', @evidence.to_event_payload)
         render_successful_destroy_message
       end
 

--- a/engines/dradis-api/app/controllers/dradis/ce/api/v3/nodes_controller.rb
+++ b/engines/dradis-api/app/controllers/dradis/ce/api/v3/nodes_controller.rb
@@ -1,7 +1,7 @@
 module Dradis::CE::API
   module V3
     class NodesController < Dradis::CE::API::APIController
-      include ActivityTracking
+      include EventPublisher
       include Dradis::CE::API::ProjectScoped
 
       def index
@@ -17,7 +17,7 @@ module Dradis::CE::API
         @node = current_project.nodes.new(node_params)
 
         if @node.save
-          track_created(@node)
+          publish_event('node.created', @node.to_event_payload)
           render status: 201, location: dradis_api.node_url(@node)
         else
           render_validation_errors(@node)
@@ -27,7 +27,7 @@ module Dradis::CE::API
       def update
         @node = current_project.nodes.find(params[:id])
         if @node.update(node_params)
-          track_updated(@node)
+          publish_event('node.updated', @node.to_event_payload)
           render node: @node
         else
           render_validation_errors(@node)
@@ -37,7 +37,7 @@ module Dradis::CE::API
       def destroy
         node = current_project.nodes.find(params[:id])
         node.destroy
-        track_destroyed(node)
+        publish_event('node.destroyed', node.to_event_payload)
         render_successful_destroy_message
       end
 


### PR DESCRIPTION
### Summary

- Create activities using `EventPublisher`'s published events rather than `ActivityTracking` in `issues/evidence_controller`
- Wire up `Node` and `Evidence` for `Eventable`
- Use `EventPublisher` for all nested node resource controllers

### Testing steps

1. Open an existing issue.
2. Click "Add evidence".
3. Select an existing node from the node dropdown and enter some content.
4. Click "Create Evidence".
5. Navigate to the project dashboard and open the activity feed.
6. Assert a "created" activity for the new evidence entry appears in the feed.
7. Go back to the issue and click "Add evidence" again.
8. In the node list field, enter two node labels that do not exist yet, one per line.
9. Click "Create Evidence".
10. Navigate to the project dashboard and open the activity feed.
11. Assert a "created" activity appears for each of the two new nodes.
12. Assert a "created" activity appears for each of the two new evidence entries.
13. Click into one of the newly created nodes.
14. In the sidebar, click the "+" button next to Nodes and add a new top-level node.
15. Assert the activity feed shows a "created" activity for the new node.
16. On the node's show page, click "Edit", change the node's label, and save.
17. Assert the node's label updated and the activity feed shows an "updated" activity for the node.
18. On the node's show page, add a new note with some content and save.
19. Assert the note is created and the activity feed shows a "created" activity for the note.
20. Edit the note's content and save.
21. Assert the activity feed shows an "updated" activity for the note.
22. Delete the note.
23. Assert the note no longer appears on the node and the activity feed shows a "destroyed" activity for the note.
24. On the node's show page, add a new piece of evidence directly (not through an issue) by filling in content and selecting or creating an issue for it, then save.
25. Assert the evidence is created and the activity feed shows a "created" activity for the evidence, and if a new issue was auto-generated, a "created" activity for that issue.
26. Edit that evidence's content and save.
27. Assert the activity feed shows an "updated" activity for the evidence.
28. Delete that evidence.
29. Assert the activity feed shows a "destroyed" activity for the evidence.
30. Delete the node created earlier.
31. Assert the activity feed shows a "destroyed" activity for the node.
32. Navigate to the project's QA section from the sidebar.
33. Select the checkbox next to a "Ready for review" issue, click the "State" button, and choose "Approved".
34. Assert the flash message reads "State successfully updated" and the issue's state changes to Approved.
35. Assert the activity feed shows a "state_change" activity for that issue, not an "update" activity.
36. Open a different "Ready for review" issue's QA show page directly and click a state button (e.g. "Rejected") to change its state.
37. Assert the state updates and the activity feed shows a "state_change" activity for that issue.
38. Run the following curl command:
39. curl -X POST "[http://localhost:3000/api/nodes](https://domain/api/nodes)" -u "USER_EMAIL:SHARED_PASSWORD" -H "Content-Type: application/json" -d '{"node": {"label": "api-test-node"}}'
40. Assert the response is a 201 Created with a JSON body containing the new node's id and label "api-test-node".
41. Assert the activity feed shows a "created" activity for the API-created node.
42. Run the following curl command to create evidence on that node via the API, replacing NODE_ID with the id returned above:
43. curl -X POST "[http://localhost:3000/api/nodes/NODE_ID/evidence](https://domain/api/nodes/NODE_ID/evidence)" -u "USER_EMAIL:SHARED_PASSWORD" -H "Content-Type: application/json" -d '{"evidence": {"content": "#[Title]#\napi test evidence"}}'
44. Assert the response is a 201 Created with a JSON body containing the new evidence's id.
45. Assert the activity feed shows a "created" activity for the API-created evidence.

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.
