### PR TITLE
Update `HasFields` title fallback to use "Class name #id" and update call sites

### DIFF
--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -12,7 +12,7 @@ module HasFields
   def title
     fields.fetch(
       'Title',
-      '(No #[Title]# field)'
+      "#{self.class.name} ##{self.id}"
     )
   end
 

--- a/app/models/concerns/has_fields.rb
+++ b/app/models/concerns/has_fields.rb
@@ -12,7 +12,7 @@ module HasFields
   def title
     fields.fetch(
       'Title',
-      "#{self.class.name} ##{self.id}"
+      "#{self.class.name.demodulize.titleize} ##{self.id}"
     )
   end
 

--- a/app/views/issues/_breadcrumbs.html.erb
+++ b/app/views/issues/_breadcrumbs.html.erb
@@ -7,7 +7,7 @@
       <%= link_to 'All issues', project_issues_path(current_project) %>
     </li>
     <li class="breadcrumb-item active">
-      <%= (@issue.title? ? @issue.title : "Issue ##{@issue.id}")%>
+      <%= @issue.title %>
     </li>
   </ol>
 </nav>

--- a/app/views/qa/issues/_breadcrumbs.html.erb
+++ b/app/views/qa/issues/_breadcrumbs.html.erb
@@ -7,7 +7,7 @@
       <%= link_to 'QA', project_qa_issues_path(current_project) %>
     </li>
     <li class="breadcrumb-item active">
-      <%= (@issue.title? ? @issue.title : "Issue ##{@issue.id}")%>
+      <%= @issue.title %>
     </li>
   </ol>
 </nav>

--- a/app/views/search/results/_evidence.html.erb
+++ b/app/views/search/results/_evidence.html.erb
@@ -1,7 +1,6 @@
 <span class="fa-regular fa-flag"></span>
 
-<% title = row.title? ? row.title : "Evidence ##{row.id}" %>
-<%= link_to title, project_node_evidence_path(row.node.project, row.node_id, row), class: "search-match-title" %>
+<%= link_to row.title, project_node_evidence_path(row.node.project, row.node_id, row), class: "search-match-title" %>
 
 <div class="result-details">
   <p><span>Issue:</span> <%= link_to row.issue.title, project_issue_path(current_project, row.issue) %></p>

--- a/app/views/search/results/_issue.html.erb
+++ b/app/views/search/results/_issue.html.erb
@@ -1,7 +1,6 @@
 <span class="fa-solid fa-bug"></span>
 
-<% title = row.title? ? row.title : "Issue ##{row.id}" %>
-<%= link_to title, project_issue_path(current_project, row), class: "search-match-title" %>
+<%= link_to row.title, project_issue_path(current_project, row), class: "search-match-title" %>
 
 <p class="result-details">Last updated: <%= local_time_ago(row.updated_at) %></p>
 

--- a/app/views/search/results/_note.html.erb
+++ b/app/views/search/results/_note.html.erb
@@ -1,7 +1,6 @@
 <span class="fa-regular fa-file-text"></span>
 
-<% title = row.title? ? row.title : "Note ##{row.id}" %>
-<%= link_to title, project_node_note_path(row.node.project, row.node_id, row), class: "search-match-title" %>
+<%= link_to row.title, project_node_note_path(row.node.project, row.node_id, row), class: "search-match-title" %>
 
 <div class="result-details">
   <p><span>Node:</span> <%= link_to row.node.label, project_node_path(row.node.project, row.node) %></p>

--- a/spec/support/has_fields_shared_examples.rb
+++ b/spec/support/has_fields_shared_examples.rb
@@ -15,7 +15,7 @@ shared_examples 'a model that has fields' do |model|
 
     context 'when there is no #[Title]# field' do
       let(:content) { "#[Not The Title]#\nMy Title" }
-      it { should eq "#{record.class.name} ##{record.id}" }
+      it { should eq "#{record.class.name.demodulize.titleize} ##{record.id}" }
 
       specify '#title? returns false' do
         expect(record.title?).to be false

--- a/spec/support/has_fields_shared_examples.rb
+++ b/spec/support/has_fields_shared_examples.rb
@@ -1,23 +1,23 @@
-shared_examples "a model that has fields" do |model|
-  describe "#title" do
+shared_examples 'a model that has fields' do |model|
+  describe '#title' do
     let(:record) { model.new(fields_column => content) }
     subject { record.title }
 
-    context "when there is a #[Title]# field" do
+    context 'when there is a #[Title]# field' do
       let(:content) { "#[Title]#\nMy Title" }
 
-      it { should eq "My Title" }
+      it { should eq 'My Title' }
 
-      specify "#title? returns true" do
+      specify '#title? returns true' do
         expect(record.title?).to be true
       end
     end
 
-    context "when there is no #[Title]# field" do
+    context 'when there is no #[Title]# field' do
       let(:content) { "#[Not The Title]#\nMy Title" }
-      it { should eq "(No #[Title]# field)" }
+      it { should eq "#{record.class.name} ##{record.id}" }
 
-      specify "#title? returns false" do
+      specify '#title? returns false' do
         expect(record.title?).to be false
       end
     end


### PR DESCRIPTION
### Summary

The `HasFields` title method already has a fallback for when there is no title field so we don't need to add conditional title checks in the views.

### Testing steps

1. Open a project and create an issue, evidence, note, and card without a title field
2. Save and confirm that the title reads "<Class name> #<id>" for each of the record types
3. Verify the sidebar and dashboard are also correct
4. In the project search bar, search for each of the records you created in step 1 and confirm the title shows up as expected

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [] Added a CHANGELOG entry~
- [x] Commit message has a detailed description of what changed and why.
