### PR TITLE
Deduplicate system notification check across presenters

### DIFF
--- a/app/presenters/digest_presenter.rb
+++ b/app/presenters/digest_presenter.rb
@@ -7,7 +7,7 @@ class DigestPresenter < NotificationPresenter
   end
 
   def avatar_with_link(opts)
-    actor = notification.actor unless SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)
+    actor = notification.actor unless system_notification?
     h.link_to(avatar_image(actor, opts), 'javascript:void(0)')
   end
 
@@ -26,7 +26,7 @@ class DigestPresenter < NotificationPresenter
 
   def text_title
     email =
-      if SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)
+      if system_notification?
         nil
       elsif notification.actor
         notification.actor.email
@@ -40,7 +40,7 @@ class DigestPresenter < NotificationPresenter
   private
 
   def linked_email
-    return if SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)
+    return if system_notification?
 
     # Get the count of the unique list of actors from the list of notifications
     actor_count = notifications.pluck(:actor_id).uniq.compact.count

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -6,7 +6,7 @@ class NotificationPresenter < BasePresenter
   presents :notification
 
   def avatar_with_link(size)
-    actor = notification.actor unless SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)
+    actor = notification.actor unless system_notification?
     h.link_to(avatar_image(actor, size: size), 'javascript:void(0)')
   end
 
@@ -35,7 +35,7 @@ class NotificationPresenter < BasePresenter
   end
 
   def render_title
-    if SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)
+    if system_notification?
       render_partial.html_safe
     else
       [
@@ -99,5 +99,13 @@ class NotificationPresenter < BasePresenter
     else
       [commentable.project, commentable]
     end
+  end
+
+  def system_notification?
+    # Can't use ||= here: the result is often false, and false is falsy in
+    # Ruby, so ||= would recompute it on every call instead of memoizing it.
+    return @system_notification if defined?(@system_notification)
+
+    @system_notification = SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)
   end
 end


### PR DESCRIPTION
### Summary

Extracts the repeated `SYSTEM_NOTIFICATION_TYPES.include?(notification.notifiable_type)` check into a single memoized `system_notification?` helper on `NotificationPresenter`, used by both `NotificationPresenter` and `DigestPresenter` (which inherits it). No behavior change.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.