### PR TITLE
define report template properties for kit HTML templates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
     - mail, sqlite3
   - Bugs fixes:
     - Combobox: show the correct selected option when its value contains a double quote
+    - Setup kits: render the Red Team report's Recommendation content block
     - [entity]:
       - [future tense verb] [bug fix]
     - Bug tracker items:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
       - [integration bug fixes]:
         - [future tense verb] [integration bug fix]
   - Reporting enhancements:
+    - Setup kits: add report template properties to the OWASP and Red Team HTML report templates
     - [report type]:
       - [future tense verb] [reporting enhancement]
   - REST/JSON API enhancements:

--- a/lib/tasks/templates/owasp/kit/templates/reports/html_export/dradis_template-owasp-colonial_audit.v1.0.html.rb
+++ b/lib/tasks/templates/owasp/kit/templates/reports/html_export/dradis_template-owasp-colonial_audit.v1.0.html.rb
@@ -1,0 +1,62 @@
+ReportTemplateProperties.create_from_hash!(
+  definition_file: File.basename(__FILE__, '.html.rb'),
+  plugin_name: 'html_export',
+  content_block_fields: {
+    'Document Control' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Document Control'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Engagement Overview' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Engagement Overview'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Key Findings' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Key Findings'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Risk Posture' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Risk Posture'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Recommendations' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Recommendations'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Appendix' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Appendix'},
+      {name: 'Description', type: 'string', values: nil}
+    ]
+  },
+  document_properties: [
+    'dradis.project',
+    'dradis.client',
+    'dradis.author',
+    'dradis.version',
+    'dradis.start_date',
+    'dradis.end_date',
+    'dradis.overall_risk_level'
+  ],
+  evidence_fields: [
+    {name: 'Output', type: 'string', values: nil},
+    {name: 'Show', type: 'string', values: "Yes\nNo"}
+  ],
+  issue_fields: [
+    {name: 'Title', type: 'string', values: nil},
+    {name: 'Impact', type: 'string', values: "Very High\nHigh\nModerate\nLow\nVery Low"},
+    {name: 'Likelihood', type: 'string', values: "Very High\nHigh\nModerate\nLow\nVery Low"},
+    {name: 'OWASP Domain', type: 'string', values: "Web\nAPI\nMobile"},
+    {name: 'OWASP Top 10', type: 'string', values: nil},
+    {name: 'Description Long', type: 'string', values: nil},
+    {name: 'Description Short', type: 'string', values: nil},
+    {name: 'Remediation Status', type: 'string', values: "Open\nIn Progress\nRemediated\nPartially Remediated\nAccepted Risk"},
+    {name: 'References', type: 'string', values: nil},
+    {name: 'Risk Score', type: 'number', values: nil}
+  ],
+  sort_fields: ['Risk Score']
+)

--- a/lib/tasks/templates/owasp/kit/templates/reports/html_export/dradis_template-owasp-galactica_cic.v1.0.html.rb
+++ b/lib/tasks/templates/owasp/kit/templates/reports/html_export/dradis_template-owasp-galactica_cic.v1.0.html.rb
@@ -1,0 +1,62 @@
+ReportTemplateProperties.create_from_hash!(
+  definition_file: File.basename(__FILE__, '.html.rb'),
+  plugin_name: 'html_export',
+  content_block_fields: {
+    'Document Control' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Document Control'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Engagement Overview' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Engagement Overview'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Key Findings' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Key Findings'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Risk Posture' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Risk Posture'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Recommendations' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Recommendations'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Appendix' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Appendix'},
+      {name: 'Description', type: 'string', values: nil}
+    ]
+  },
+  document_properties: [
+    'dradis.project',
+    'dradis.client',
+    'dradis.author',
+    'dradis.version',
+    'dradis.start_date',
+    'dradis.end_date',
+    'dradis.overall_risk_level'
+  ],
+  evidence_fields: [
+    {name: 'Output', type: 'string', values: nil},
+    {name: 'Show', type: 'string', values: "Yes\nNo"}
+  ],
+  issue_fields: [
+    {name: 'Title', type: 'string', values: nil},
+    {name: 'Impact', type: 'string', values: "Very High\nHigh\nModerate\nLow\nVery Low"},
+    {name: 'Likelihood', type: 'string', values: "Very High\nHigh\nModerate\nLow\nVery Low"},
+    {name: 'OWASP Domain', type: 'string', values: "Web\nAPI\nMobile"},
+    {name: 'OWASP Top 10', type: 'string', values: nil},
+    {name: 'Description Long', type: 'string', values: nil},
+    {name: 'Description Short', type: 'string', values: nil},
+    {name: 'Remediation Status', type: 'string', values: "Open\nIn Progress\nRemediated\nPartially Remediated\nAccepted Risk"},
+    {name: 'References', type: 'string', values: nil},
+    {name: 'Risk Score', type: 'number', values: nil}
+  ],
+  sort_fields: ['Risk Score']
+)

--- a/lib/tasks/templates/owasp/kit/templates/reports/html_export/dradis_template-owasp-viper_recon.v1.0.html.rb
+++ b/lib/tasks/templates/owasp/kit/templates/reports/html_export/dradis_template-owasp-viper_recon.v1.0.html.rb
@@ -1,0 +1,62 @@
+ReportTemplateProperties.create_from_hash!(
+  definition_file: File.basename(__FILE__, '.html.rb'),
+  plugin_name: 'html_export',
+  content_block_fields: {
+    'Document Control' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Document Control'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Engagement Overview' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Engagement Overview'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Key Findings' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Key Findings'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Risk Posture' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Risk Posture'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Recommendations' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Recommendations'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Appendix' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Appendix'},
+      {name: 'Description', type: 'string', values: nil}
+    ]
+  },
+  document_properties: [
+    'dradis.project',
+    'dradis.client',
+    'dradis.author',
+    'dradis.version',
+    'dradis.start_date',
+    'dradis.end_date',
+    'dradis.overall_risk_level'
+  ],
+  evidence_fields: [
+    {name: 'Output', type: 'string', values: nil},
+    {name: 'Show', type: 'string', values: "Yes\nNo"}
+  ],
+  issue_fields: [
+    {name: 'Title', type: 'string', values: nil},
+    {name: 'Impact', type: 'string', values: "Very High\nHigh\nModerate\nLow\nVery Low"},
+    {name: 'Likelihood', type: 'string', values: "Very High\nHigh\nModerate\nLow\nVery Low"},
+    {name: 'OWASP Domain', type: 'string', values: "Web\nAPI\nMobile"},
+    {name: 'OWASP Top 10', type: 'string', values: nil},
+    {name: 'Description Long', type: 'string', values: nil},
+    {name: 'Description Short', type: 'string', values: nil},
+    {name: 'Remediation Status', type: 'string', values: "Open\nIn Progress\nRemediated\nPartially Remediated\nAccepted Risk"},
+    {name: 'References', type: 'string', values: nil},
+    {name: 'Risk Score', type: 'number', values: nil}
+  ],
+  sort_fields: ['Risk Score']
+)

--- a/lib/tasks/templates/redteam/kit/templates/reports/html_export/dradis_template-redteam-killchain_ops.v1.0.html.erb
+++ b/lib/tasks/templates/redteam/kit/templates/reports/html_export/dradis_template-redteam-killchain_ops.v1.0.html.erb
@@ -579,7 +579,7 @@
   <!-- ===== PRO CONTENT BLOCKS (before sitrep) ===== -->
   <% if defined?(Dradis::Pro) %>
     <%
-      pro_section_types = ['Rules of Engagement', 'Executive Summary', 'Attack Narrative', 'Key Findings', 'Detection Analysis', 'Recommendations', 'Appendix']
+      pro_section_types = ['Rules of Engagement', 'Executive Summary', 'Attack Narrative', 'Key Findings', 'Detection Analysis', 'Recommendation', 'Appendix']
     %>
     <% pro_section_types.each do |section_type| %>
       <% section_blocks = content_service.all_content_blocks.select { |b| b.fields['Type'] == section_type } %>

--- a/lib/tasks/templates/redteam/kit/templates/reports/html_export/dradis_template-redteam-killchain_ops.v1.0.html.rb
+++ b/lib/tasks/templates/redteam/kit/templates/reports/html_export/dradis_template-redteam-killchain_ops.v1.0.html.rb
@@ -1,0 +1,65 @@
+ReportTemplateProperties.create_from_hash!(
+  definition_file: File.basename(__FILE__, '.html.rb'),
+  plugin_name: 'html_export',
+  content_block_fields: {
+    'Rules of Engagement' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Rules of Engagement'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Executive Summary' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Executive Summary'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Attack Narrative' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Attack Narrative'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Key Findings' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Key Findings'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Detection Analysis' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Detection Analysis'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Recommendation' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Recommendation'},
+      {name: 'Description', type: 'string', values: nil}
+    ],
+    'Appendix' => [
+      {name: 'Title', type: 'string', values: nil},
+      {name: 'Type', type: 'string', values: 'Appendix'},
+      {name: 'Description', type: 'string', values: nil}
+    ]
+  },
+  document_properties: [
+    'dradis.client',
+    'dradis.start_date',
+    'dradis.end_date',
+    'dradis.prepared_by',
+    'dradis.version'
+  ],
+  evidence_fields: [
+    {name: 'Output', type: 'string', values: nil},
+    {name: 'Timestamp', type: 'string', values: nil}
+  ],
+  issue_fields: [
+    {name: 'Title', type: 'string', values: nil},
+    {name: 'Severity', type: 'string', values: "Critical\nHigh\nMedium\nLow\nInfo"},
+    {name: 'Tactic', type: 'string', values: "Collection\nCommand and Control\nCredential Access\nDefense Evasion\nDiscovery\nExecution\nExfiltration\nImpact\nInitial Access\nLateral Movement\nPersistence\nPrivilege Escalation\nReconnaissance\nResource Development\nRemove Service Effects\nNetwork Effects\nEvasion\nImpair Process Control\nInhibit Response Function"},
+    {name: 'Technique', type: 'string', values: nil},
+    {name: 'Technique ID', type: 'string', values: nil},
+    {name: 'Detection', type: 'string', values: "Undetected\nDetected\nPartially Detected"},
+    {name: 'Description', type: 'string', values: nil},
+    {name: 'Attack Narrative', type: 'string', values: nil},
+    {name: 'Business Impact', type: 'string', values: nil},
+    {name: 'Recommendations', type: 'string', values: nil},
+    {name: 'References', type: 'string', values: nil}
+  ]
+)


### PR DESCRIPTION
### Summary

Two related fixes to the setup kits' HTML report templates.

**1. Report template properties for the OWASP and Red Team HTML templates**

Only the `welcome` kit shipped a `.html.rb` properties sidecar next to its HTML template. `KitImportJob#import_report_template_properties` looks for `<template basename>.rb` beside each template file and, when it doesn't find one, falls back to `find_or_initialize_by(template_file:)` — producing a bare RTP whose title defaults to the filename and which carries no document properties and no issue/evidence fields. Such an RTP is excluded by the `with_fields_defined` scope, and the HTML exporter's `sort_issues` no-ops without it, so findings came out unsorted.

This adds the four missing sidecars:

- `owasp/…/dradis_template-owasp-colonial_audit.v1.0.html.rb`
- `owasp/…/dradis_template-owasp-galactica_cic.v1.0.html.rb`
- `owasp/…/dradis_template-owasp-viper_recon.v1.0.html.rb`
- `redteam/…/dradis_template-redteam-killchain_ops.v1.0.html.rb`

Each declares what its ERB actually reads, rather than being copied wholesale from the kit's Word properties. All three OWASP templates reference an identical field set, so they share one definition. `values` lists for fields that also appear in a kit's Word sidecar are copied from it so the dropdowns stay consistent across a kit. OWASP sorts on `Risk Score` (present in the kit's issue data; the templates compute a displayed risk score from Impact × Likelihood); Red Team declares no sort field, matching its Word sidecar.

**2. Red Team template selected a content block type the kit doesn't define**

`dradis_template-redteam-killchain_ops.v1.0.html.erb` selected a `'Recommendations'` content block, but the kit's repository XML and its Word properties both define `'Recommendation'` (singular). `pro_section_types` therefore matched nothing and the block was silently dropped from every Red Team HTML export. The template now selects `'Recommendation'`.

Note the issue field `Recommendations` (plural) further down the same template is correct — the kit really does define `#[Recommendations]#` on issues — so only the content block type changed.

### Testing steps

In Pro, with the `html_export` addon enabled **before** importing (see Other Information):

1. Admin → Setup kits → import the **Red Team** kit.
2. Admin → Templates → Report templates → **HTML** tab. Confirm `dradis_template-redteam-killchain_ops.v1.0.html` is listed and, when opened, shows 11 issue fields, 2 evidence fields and 7 content blocks — not an empty definition.
3. Open the imported project → Export → **HTML** → choose the Red Team template → export. Confirm the report renders a **Recommendation** section from the kit's content block (this section was missing before).
4. Repeat 1–3 with the **OWASP** kit and any of its three templates. Confirm findings are ordered by `Risk Score` descending, and that the Document Control / Engagement Overview / Key Findings / Risk Posture / Recommendations / Appendix sections render.

### Other Information

These sidecars only take effect when the `html_export` addon is enabled at kit-import time. Under Pro the addon ships `default_enabled = false`, and `import_report_template_properties` iterates `Dradis::Plugins.with_feature(:rtp)`, which is filtered through `enabled_list` — so on a fresh Pro instance the `.erb` files are still copied to disk while the RTP rows are skipped entirely, and enabling the addon later does not backfill them. That gap is not addressed here and wants a separate fix in `KitImportJob` (or a backfill on addon enable).

Also unchanged: the Red Team template selects a `'Detection Analysis'` block that the kit never defines, and never renders the kit's `'Asset'` and `'Automation'` blocks. Both degrade gracefully (`next if section_blocks.empty?`), so they're left for a follow-up rather than folded into a pluralization fix.

I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA2Bx2fA5MCS53fzYjoVkz
