### PR TITLE
replace chart x-axis labels with a wrapping legend

### DIFF
--- a/app/assets/javascripts/hera/pages/projects/issues_chart.js
+++ b/app/assets/javascripts/hera/pages/projects/issues_chart.js
@@ -5,14 +5,13 @@
 
     if (!$dataElement.length || $chartElement.find('svg').length) return;
 
-    const margin = { top: 20, bottom: 30 };
+    const margin = { top: 20, bottom: 0 };
     const width = 354;
     const height = 180 - margin.top - margin.bottom;
     const x = d3.scaleBand().rangeRound([0, width]);
     const y = d3.scaleLinear().range([height, 0]);
-    const xAxis = d3.axisBottom(x).tickSize(0);
-    const svg = d3
-      .select($chartElement[0])
+    const container = d3.select($chartElement[0]);
+    const svg = container
       .append('svg')
       .attr('width', width)
       .attr('height', height + margin.top + margin.bottom)
@@ -24,12 +23,14 @@
     let highest = 0;
     const data = [];
     const xDomain = [];
+    const colors = [];
 
     for (const key in tags) {
       const issuesCount = issuesByTag[key];
       highest = issuesCount > highest ? issuesCount : highest;
       data.push({ letter: tags[key][0], frequency: issuesCount });
       xDomain.push(tags[key][0]);
+      colors.push(tags[key][1]);
     }
 
     data.push({ letter: 'N/A', frequency: issuesByTag.unassigned });
@@ -37,19 +38,6 @@
 
     x.domain(xDomain);
     y.domain([0, Math.max(highest, issuesByTag.unassigned)]);
-
-    const xAxisGroup = svg
-      .append('g')
-      .attr('class', 'x axis')
-      .attr('transform', `translate(0,${height})`)
-      .call(xAxis);
-
-    xAxisGroup.selectAll('text').style('fill', 'inherit');
-    xAxisGroup.selectAll('path').style('stroke', 'none');
-    xAxisGroup
-      .selectAll('text')
-      .filter((d, index, nodes) => index === nodes.length - 1)
-      .classed('untagged', true);
 
     const bars = svg.append('g');
 
@@ -76,16 +64,37 @@
       .attr('class', 'counter')
       .text(d => d.frequency);
 
-    Object.keys(tags).forEach((key, index) => {
-      $chartElement.find('.tick').eq(index).attr('fill', tags[key][1]);
-      $chartElement.find('.bar').eq(index).attr('fill', tags[key][1]);
-      $chartElement.find('.counter').eq(index).attr('fill', tags[key][1]);
+    colors.forEach((color, index) => {
+      $chartElement.find('.bar').eq(index).attr('fill', color);
+      $chartElement.find('.counter').eq(index).attr('fill', color);
     });
 
-    const untaggedIndex = Object.keys(tags).length;
-    $chartElement.find('.tick').eq(untaggedIndex).addClass('untagged');
-    $chartElement.find('.bar').eq(untaggedIndex).addClass('untagged');
-    $chartElement.find('.counter').eq(untaggedIndex).addClass('untagged');
+    $chartElement.find('.bar').eq(colors.length).addClass('untagged');
+    $chartElement.find('.counter').eq(colors.length).addClass('untagged');
+
+    buildLegend(container, data, colors);
+  };
+
+  const buildLegend = (container, data, colors) => {
+    const legendItems = container
+      .append('ul')
+      .attr('class', 'issue-chart-legend')
+      .selectAll('li')
+      .data(data)
+      .enter()
+      .append('li')
+      .attr('class', (_, index) => (index === colors.length ? 'legend-item untagged' : 'legend-item'))
+      .attr('title', d => d.letter);
+
+    legendItems
+      .append('span')
+      .attr('class', 'legend-swatch')
+      .style('background-color', (_, index) => colors[index] || null);
+
+    legendItems
+      .append('span')
+      .attr('class', 'legend-label')
+      .text(d => d.letter);
   };
 
   document.addEventListener('turbo:load', initIssuesChart);

--- a/app/assets/stylesheets/hera/views/projects.scss
+++ b/app/assets/stylesheets/hera/views/projects.scss
@@ -36,18 +36,58 @@ body.projects {
     }
 
     .issue-chart {
-      display: flex;
-      justify-content: center;
       align-items: center;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      justify-content: center;
 
       .bar.untagged,
-      .counter.untagged,
-      .tick.untagged {
+      .counter.untagged {
         fill: var(--untagged-color);
       }
 
       svg text {
         font-size: 14px;
+      }
+
+      .issue-chart-legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+        justify-content: center;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      .legend-item {
+        align-items: center;
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .legend-item.untagged .legend-swatch {
+        background-color: var(--untagged-color);
+      }
+
+      .legend-item.untagged .legend-label {
+        color: var(--untagged-color);
+      }
+
+      .legend-label {
+        color: var(--text-default);
+        max-width: 12rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .legend-swatch {
+        border-radius: 50%;
+        flex-shrink: 0;
+        height: 0.75rem;
+        width: 0.75rem;
       }
     }
 

--- a/spec/features/projects/issues_summary_widget_spec.rb
+++ b/spec/features/projects/issues_summary_widget_spec.rb
@@ -17,13 +17,6 @@ describe 'Issues Summary widget', js: true do
       expect(page).to have_css('[data-behavior="issue-chart"] svg')
     end
 
-    it 'renders a legend item for each tag and one for unassigned' do
-      visit project_path(current_project)
-
-      expect(page).to have_css('.issue-chart-legend .legend-item', count: 2)
-      expect(page).to have_css('.issue-chart-legend .legend-item.untagged', text: 'N/A')
-    end
-
     it 'initializes the chart once when called repeatedly' do
       visit project_path(current_project)
 

--- a/spec/features/projects/issues_summary_widget_spec.rb
+++ b/spec/features/projects/issues_summary_widget_spec.rb
@@ -17,6 +17,13 @@ describe 'Issues Summary widget', js: true do
       expect(page).to have_css('[data-behavior="issue-chart"] svg')
     end
 
+    it 'renders a legend item for each tag and one for unassigned' do
+      visit project_path(current_project)
+
+      expect(page).to have_css('.issue-chart-legend .legend-item', count: 2)
+      expect(page).to have_css('.issue-chart-legend .legend-item.untagged', text: 'N/A')
+    end
+
     it 'initializes the chart once when called repeatedly' do
       visit project_path(current_project)
 


### PR DESCRIPTION
### Summary

The dashboard \"Issues so far\" chart labeled each bar with its tag name
directly on the x-axis. Several tags or long names made these labels
cramped or unreadable. This change replaces the x-axis with a legend
below the chart.

The legend shows one swatch and label per tag. It also shows \"N/A\" for
unassigned issues. Items wrap onto more rows as needed. Long labels use
an ellipsis, and the full name appears on hover.

This change builds on https://github.com/dradis/dradis-ce/pull/1696.
It does not depend on https://github.com/dradis/dradis-ce/pull/1697.

No CHANGELOG entry was added. This small presentation fix belongs to an
unmerged dashboard feature.

### Testing steps

1. Visit a project dashboard with several tagged issues.
2. Include at least one tag with a long name.
3. Confirm the legend appears below the chart.
4. Confirm legend items wrap when horizontal space runs out.
5. Confirm long labels use an ellipsis.
6. Hover over a long label and confirm the full name appears.
7. Confirm \"N/A\" appears for unassigned issues.

### Check List

- [ ] Added a CHANGELOG entry
- [x] Commit message has a detailed description of what changed and why.