### PR TITLE
consolidate tag and list-field grouping into a shared interface

### DIFF
--- a/app/controllers/projects/dashboard/issues_controller.rb
+++ b/app/controllers/projects/dashboard/issues_controller.rb
@@ -5,6 +5,7 @@ class Projects::Dashboard::IssuesController < AuthenticatedController
   def index
     @issues = current_project.issues.includes(:tags).sort
     @tags = current_project.tags
+    @list_fields = list_fields
 
     build_grouping(params[:grouping])
   end

--- a/app/controllers/projects/issues_summary_grouping.rb
+++ b/app/controllers/projects/issues_summary_grouping.rb
@@ -2,42 +2,57 @@ module Projects
   module IssuesSummaryGrouping
     private
 
-    def build_grouping(_grouping)
-      @grouping = 'tags'
-      build_tags_grouping
+    def build_grouping(grouping)
+      valid_groupings = ['tags'] + @list_fields.map { |field| "list:#{field.name}" }
+      @grouping = valid_groupings.include?(grouping) ? grouping : 'tags'
+
+      items =
+        if @grouping.start_with?('list:')
+          field_name = @grouping.delete_prefix('list:')
+          @list_field = @list_fields.find { |f| f.name == field_name }
+          (@list_field&.values || []).map { |v| ListFieldValue.new(v, field_name: field_name, project: current_project) }
+        else
+          @grouping = 'tags'
+          @tags
+        end
+
+      @entries = items.to_h { |item| [item.name, [item.display_name, item.color]] }
+      @count_by_value, @issues_by_value = build_value_grouping(items)
+
+      @chart_data = {
+        grouping: @grouping,
+        tags: @entries.to_json,
+        issues_count: @count_by_value.to_json
+      }
     end
 
-    def build_tags_grouping
-      @count_by_tag = Hash.new(0)
-      @issues_by_tag = Hash.new { |h, k| h[k] = [] }
-
-      @tag_names = @tags.map do |tag|
-        @count_by_tag[tag.name] = 0
-        [tag.name, [tag.display_name, tag.color]]
-      end.to_h
-      @count_by_tag[:unassigned] = 0
+    def build_value_grouping(items)
+      count_by_value = Hash.new(0)
+      items.each { |item| count_by_value[item.name] = 0 }
+      count_by_value[:unassigned] = 0
+      issues_by_value = Hash.new { |h, k| h[k] = [] }
 
       @issues.each do |issue|
-        if issue.tags.empty?
-          @issues_by_tag[:unassigned] << issue
-          @count_by_tag[:unassigned] += 1
+        matched = items.select { |item| item.matches?(issue) }
+
+        if matched.empty?
+          issues_by_value[:unassigned] << issue
+          count_by_value[:unassigned] += 1
         else
-          issue.tags.each do |tag|
-            @issues_by_tag[tag.name] << issue
-            @count_by_tag[tag.name] += 1
+          matched.each do |item|
+            issues_by_value[item.name] << issue
+            count_by_value[item.name] += 1
           end
         end
       end
 
-      @chart_data = {
-        grouping: 'tags',
-        tags: @tag_names.to_json,
-        issues_count: @count_by_tag.to_json
-      }
+      [count_by_value, issues_by_value]
     end
 
     def list_fields
-      []
+      current_project.report_template_properties
+        &.issue_fields
+        &.select { |f| f.type == :list } || []
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -68,6 +68,10 @@ class Tag < ApplicationRecord
     name[/\A(!\h{6})_[[:word:]]+?\z/, 1].try(:gsub, '!', '#') || '#555'
   end
 
+  def matches?(issue)
+    issue.tags.include?(self)
+  end
+
   private
   def normalize_name
     self[:name] = self.name.downcase

--- a/app/views/projects/dashboard/issues/index.html.erb
+++ b/app/views/projects/dashboard/issues/index.html.erb
@@ -3,19 +3,19 @@
     <div class="issue-chart" data-behavior="issue-chart"></div>
 
     <div id="issues-accordion" role="tablist">
-      <% for tag in @tags do %>
-        <% if @issues_by_tag[tag.name].any? %>
-          <div class="card" style="border-color: <%= tag.color %>">
-            <a data-bs-toggle="collapse" href="#collapse<%= tag.display_name %>" class="card-header" style="background: <%= tag.color %>" data-behavior="card-header">
-              <h5><%= tag.display_name %><span class="float-end"><i class="fa-solid fa-caret-up" data-behavior="caret-icon"></i></span></h5>
+      <% @entries.each do |name, (display_name, color)| %>
+        <% if @issues_by_value[name].any? %>
+          <div class="card" style="border-color: <%= color %>">
+            <a data-bs-toggle="collapse" href="#collapse<%= display_name %>" class="card-header" style="background: <%= color %>" data-behavior="card-header">
+              <h5><%= display_name %><span class="float-end"><i class="fa-solid fa-caret-up" data-behavior="caret-icon"></i></span></h5>
             </a>
 
-            <div id="collapse<%= tag.display_name %>" class="collapse show">
+            <div id="collapse<%= display_name %>" class="collapse show">
               <div class="card-body p-0">
                 <ul class="list-group">
-                  <% @issues_by_tag[tag.name].each do |issue| %>
+                  <% @issues_by_value[name].each do |issue| %>
                     <%= link_to [current_project, issue], class: 'list-group-item', data: { turbo_frame: '_top' }  do %>
-                      <li><i class="fa-solid fa-bug me-2" style="color: <%= tag.color %>"></i><%= issue.title %></li>
+                      <li><i class="fa-solid fa-bug me-2" style="color: <%= color %>"></i><%= issue.title %></li>
                     <% end %>
                   <% end %>
                 </ul>
@@ -25,7 +25,7 @@
         <% end %>
       <% end %>
 
-      <% if @issues_by_tag[:unassigned].any? %>
+      <% if @issues_by_value[:unassigned].any? %>
         <div class="card untagged">
           <a data-bs-toggle="collapse" href="#collapseUnassigned" class="card-header" data-behavior="card-header">
             <h5>Unassigned<span class="float-end"><i class="fa-solid fa-caret-up" data-behavior="caret-icon"></i></span></h5>
@@ -34,7 +34,7 @@
           <div id="collapseUnassigned" class="collapse show">
             <div class="card-body p-0">
               <ul class="list-group">
-                <% @issues_by_tag[:unassigned].each do |issue| %>
+                <% @issues_by_value[:unassigned].each do |issue| %>
                   <%= link_to [current_project, issue], class: 'list-group-item', data: { turbo_frame: '_top' }  do %>
                     <li><i class="fa-solid fa-bug me-2"></i><%= issue.title %></li>
                   <% end %>
@@ -56,6 +56,6 @@
   <% end %>
 
   <% if @issues.any? %>
-    <div data-behavior="issues-summary-data" data-tags='<%= @tag_names.to_json %>' data-issues-count='<%= @count_by_tag.to_json %>'></div>
+    <div data-behavior="issues-summary-data" data-tags='<%= @entries.to_json %>' data-issues-count='<%= @count_by_value.to_json %>'></div>
   <% end %>
 <% end %>

--- a/spec/controllers/projects/issues_summary_grouping_spec.rb
+++ b/spec/controllers/projects/issues_summary_grouping_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 describe Projects::IssuesSummaryGrouping do
   describe '#build_grouping' do
-    it 'uses tags grouping regardless of the requested grouping' do
+    it 'uses tags grouping when the requested grouping is invalid' do
       host = Class.new { include Projects::IssuesSummaryGrouping }.new
+      host.instance_variable_set(:@list_fields, [])
       host.instance_variable_set(:@tags, [])
       host.instance_variable_set(:@issues, [])
 
@@ -14,9 +15,7 @@ describe Projects::IssuesSummaryGrouping do
         grouping: 'tags', tags: {}.to_json, issues_count: { unassigned: 0 }.to_json
       )
     end
-  end
 
-  describe '#build_tags_grouping' do
     it 'groups tagged and unassigned issues and builds the chart attributes' do
       host = Class.new { include Projects::IssuesSummaryGrouping }.new
       tag = create(:tag, name: '!dc3545_critical')
@@ -24,18 +23,19 @@ describe Projects::IssuesSummaryGrouping do
       tagged_issue.tags << tag
       unassigned_issue = create(:issue)
 
+      host.instance_variable_set(:@list_fields, [])
       host.instance_variable_set(:@tags, [tag])
       host.instance_variable_set(:@issues, [tagged_issue, unassigned_issue])
 
-      host.send(:build_tags_grouping)
+      host.send(:build_grouping, 'tags')
 
-      expect(host.instance_variable_get(:@issues_by_tag)).to eq(
+      expect(host.instance_variable_get(:@issues_by_value)).to eq(
         tag.name => [tagged_issue], unassigned: [unassigned_issue]
       )
-      expect(host.instance_variable_get(:@count_by_tag)).to eq(
+      expect(host.instance_variable_get(:@count_by_value)).to eq(
         tag.name => 1, unassigned: 1
       )
-      expect(host.instance_variable_get(:@tag_names)).to eq(
+      expect(host.instance_variable_get(:@entries)).to eq(
         tag.name => [tag.display_name, tag.color]
       )
       expect(host.instance_variable_get(:@chart_data)).to eq(
@@ -48,7 +48,14 @@ describe Projects::IssuesSummaryGrouping do
 
   describe '#list_fields' do
     it 'returns no list fields' do
-      host = Class.new { include Projects::IssuesSummaryGrouping }.new
+      host_class = Class.new do
+        include Projects::IssuesSummaryGrouping
+
+        def current_project
+          Project.new
+        end
+      end
+      host = host_class.new
 
       expect(host.send(:list_fields)).to eq([])
     end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -13,6 +13,23 @@ describe Tag do
     end
   end
 
+  describe '#matches?' do
+    it 'returns true when the issue is tagged with it' do
+      tag = create(:tag, name: '!0000ff_blue')
+      issue = create(:issue)
+      issue.tags << tag
+
+      expect(tag.matches?(issue)).to be true
+    end
+
+    it 'returns false when the issue is not tagged with it' do
+      tag = create(:tag, name: '!0000ff_blue')
+      issue = create(:issue)
+
+      expect(tag.matches?(issue)).to be false
+    end
+  end
+
   describe '#save' do
     it 'normalizes the name before persisting' do
       tag = Tag.create!(name: '!0000ff_BlUe')


### PR DESCRIPTION
## Summary
- Add `Tag#matches?(issue)`, giving `Tag` the interface (`name`, `display_name`, `color`, `matches?`) that a Pro-only list-field value object will also implement.
- Replace `build_tags_grouping`'s bucketing loop with a shared `build_value_grouping(items)` used by both the tags path and (in Pro) a list-field path, dropping the per-grouping-type duplication.
- Implement `list_fields` for real (`current_project.report_template_properties&.issue_fields&.select { |f| f.type == :list } || []`) instead of the `[]` stub — safely resolves to `[]` on CE since `Project#report_template_properties` always returns `nil` here, but lets the same concern file work unmodified in Pro.
- `Dashboard::IssuesController#index` now sets `@list_fields`, matching the concern's expectations.
- Rename the grouping ivars (`@tag_names`/`@issues_by_tag`/`@count_by_tag` → `@entries`/`@issues_by_value`/`@count_by_value`) and update the dashboard view accordingly.

This is purely an internal refactor — behavior for tags-only grouping (the only grouping CE exercises) is unchanged. Done in CE first, ahead of a matching Pro branch that adds a list-field grouping on top of this shared interface, per our CE→Pro sync convention.

## Test plan
- [x] `bundle exec rspec spec/controllers/projects/issues_summary_grouping_spec.rb spec/models/tag_spec.rb spec/requests/projects/dashboard/issues_spec.rb`
- [x] `bin/rubocop-ci develop false`
- [ ] Manually verify the dashboard issues summary chart/accordion still renders tags correctly